### PR TITLE
helm chart: rerank values and extraEnv passthrough

### DIFF
--- a/charts/memini/README.md
+++ b/charts/memini/README.md
@@ -35,6 +35,7 @@ helm install memini ./charts/memini \
 | embeddings | object | `{"apiKeySecret":{"key":"api-key","name":""},"baseURL":"","dims":1536,"model":"text-embedding-3-small"}` | External OpenAI-compatible embeddings endpoint (required for vector search) |
 | embeddings.apiKeySecret | object | `{"key":"api-key","name":""}` | Optional existing secret holding the embeddings API key |
 | embeddings.dims | int | `1536` | Embedding dimensionality; MUST match the deployed model |
+| extraEnv | list | `[]` | Extra environment variables appended verbatim to the container, for MEMINI_* settings that don't have dedicated chart values |
 | fsck | object | `{"cronjob":{"enabled":false,"image":"curlimages/curl:8.20.0","schedule":"0 * * * *"}}` | Periodic fsck CronJob (the in-process sweeper already handles decay) |
 | fullnameOverride | string | `""` |  |
 | grafanaDashboards | object | `{"enabled":false,"folder":"memini"}` | Bundled Grafana dashboards, rendered as ConfigMaps for the grafana-operator. Point your Grafana CR's `dashboardsConfigMaps` selector at this release's namespace; the operator will pick up any ConfigMap with the `grafana_dashboard: "1"` label. |
@@ -57,6 +58,11 @@ helm install memini ./charts/memini \
 | postgres | object | `{"dsnSecret":{"key":"dsn","name":""}}` | postgres backend connection |
 | postgres.dsnSecret | object | `{"key":"dsn","name":""}` | Existing secret holding the libpq DSN (required when backend=postgres) |
 | replicaCount | int | `1` | Replica count (postgres only; sqlite is pinned to 1) |
+| rerank | object | `{"apiKeySecret":{"key":"api-key","name":""},"mode":"","model":"","topN":20}` | Opt-in recall reranking (MEMINI_RERANK); leave mode empty to disable |
+| rerank.apiKeySecret | object | `{"key":"api-key","name":""}` | Optional existing secret holding the cross-encoder endpoint API key (when mode is a URL) |
+| rerank.mode | string | `""` | "" or "off" (disabled), "llm" (reorder with the chat LLM), or a cross-encoder /rerank base URL (e.g. http://reranker:8080/v1, served by Infinity, vLLM, TEI, or llama-server --rerank) |
+| rerank.model | string | `""` | Cross-encoder model name (when mode is a URL) |
+| rerank.topN | int | `20` | How many composite-ranked candidates the reranker sees |
 | resources | object | `{}` |  |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
@@ -67,6 +73,8 @@ helm install memini ./charts/memini \
 | serviceAccount.name | string | `""` | ServiceAccount name; generated when empty |
 | sqlite | object | `{"persistence":{"accessModes":["ReadWriteOnce"],"enabled":true,"size":"5Gi","storageClass":""}}` | sqlite backend persistence (StatefulSet volumeClaimTemplate) |
 | tolerations | list | `[]` |  |
+| ui | object | `{"enabled":true}` | Embedded admin UI served at / |
+| ui.enabled | bool | `true` | Mount the admin SPA at /; set to false for a headless API/MCP-only service |
 
 ## Observability
 

--- a/charts/memini/templates/_helpers.tpl
+++ b/charts/memini/templates/_helpers.tpl
@@ -98,6 +98,23 @@ app.kubernetes.io/instance: {{ .Release.Name }}
       key: {{ .Values.llm.apiKeySecret.key }}
 {{- end }}
 {{- end }}
+{{- if and .Values.rerank.mode (ne .Values.rerank.mode "off") }}
+- name: MEMINI_RERANK
+  value: {{ .Values.rerank.mode | quote }}
+{{- with .Values.rerank.model }}
+- name: MEMINI_RERANK_MODEL
+  value: {{ . | quote }}
+{{- end }}
+- name: MEMINI_RERANK_TOP_N
+  value: {{ .Values.rerank.topN | quote }}
+{{- if .Values.rerank.apiKeySecret.name }}
+- name: MEMINI_RERANK_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.rerank.apiKeySecret.name }}
+      key: {{ .Values.rerank.apiKeySecret.key }}
+{{- end }}
+{{- end }}
 {{- if include "memini.authEnabled" . }}
 - name: MEMINI_API_KEY
   valueFrom:
@@ -107,6 +124,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 - name: MEMINI_UI_ENABLED
   value: {{ .Values.ui.enabled | quote }}
+{{- with .Values.extraEnv }}
+{{ toYaml . }}
+{{- end }}
 {{- end -}}
 
 {{/* Shared container spec */}}

--- a/charts/memini/values.schema.json
+++ b/charts/memini/values.schema.json
@@ -148,6 +148,14 @@
       "title": "embeddings",
       "type": "object"
     },
+    "extraEnv": {
+      "description": "Extra environment variables appended verbatim to the container, for\nMEMINI_* settings that don't have dedicated chart values",
+      "items": {
+        "required": []
+      },
+      "title": "extraEnv",
+      "type": "array"
+    },
     "fsck": {
       "description": "Periodic fsck CronJob (the in-process sweeper already handles decay)",
       "properties": {
@@ -430,6 +438,50 @@
       "description": "Replica count (postgres only; sqlite is pinned to 1)",
       "title": "replicaCount",
       "type": "integer"
+    },
+    "rerank": {
+      "description": "Opt-in recall reranking (MEMINI_RERANK); leave mode empty to disable",
+      "properties": {
+        "apiKeySecret": {
+          "description": "Optional existing secret holding the cross-encoder endpoint API key\n(when mode is a URL)",
+          "properties": {
+            "key": {
+              "default": "api-key",
+              "title": "key",
+              "type": "string"
+            },
+            "name": {
+              "default": "",
+              "title": "name",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "apiKeySecret",
+          "type": "object"
+        },
+        "mode": {
+          "default": "",
+          "description": "\"\" or \"off\" (disabled), \"llm\" (reorder with the chat LLM), or a\ncross-encoder /rerank base URL (e.g. http://reranker:8080/v1, served by\nInfinity, vLLM, TEI, or llama-server --rerank)",
+          "title": "mode",
+          "type": "string"
+        },
+        "model": {
+          "default": "",
+          "description": "Cross-encoder model name (when mode is a URL)",
+          "title": "model",
+          "type": "string"
+        },
+        "topN": {
+          "default": 20,
+          "description": "How many composite-ranked candidates the reranker sees",
+          "title": "topN",
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "title": "rerank",
+      "type": "object"
     },
     "resources": {
       "required": [],

--- a/charts/memini/values.yaml
+++ b/charts/memini/values.yaml
@@ -51,6 +51,28 @@ llm:
     name: ""
     key: api-key
 
+# -- Opt-in recall reranking (MEMINI_RERANK); leave mode empty to disable
+rerank:
+  # -- "" or "off" (disabled), "llm" (reorder with the chat LLM), or a
+  # cross-encoder /rerank base URL (e.g. http://reranker:8080/v1, served by
+  # Infinity, vLLM, TEI, or llama-server --rerank)
+  mode: ""
+  # -- Cross-encoder model name (when mode is a URL)
+  model: ""
+  # -- How many composite-ranked candidates the reranker sees
+  topN: 20
+  # -- Optional existing secret holding the cross-encoder endpoint API key
+  # (when mode is a URL)
+  apiKeySecret:
+    name: ""
+    key: api-key
+
+# -- Extra environment variables appended verbatim to the container, for
+# MEMINI_* settings that don't have dedicated chart values
+extraEnv: []
+#  - name: MEMINI_PROMOTE_INTERVAL
+#    value: 12h
+
 # -- Optional bearer-token auth for the API
 # -- Bearer-token auth (protects both /v1 and /mcp). REQUIRED before exposing
 # memini off-cluster (see httpRoute). Either reference an existing secret, or set


### PR DESCRIPTION
Implements #5.

Adds a structured `rerank` block following the existing `embeddings`/`llm` shape, mapped to the 0.0.4 `MEMINI_RERANK*` env vars (rendered only when `rerank.mode` is set and not `off`):

```yaml
rerank:
  mode: ""        # "", "off", "llm", or a cross-encoder /rerank base URL
  model: ""
  topN: 20
  apiKeySecret:
    name: ""
    key: api-key
```

Also adds a generic `extraEnv` passthrough appended after the derived env, so app settings that don't have dedicated values yet (e.g. `MEMINI_PROMOTE_INTERVAL`, `MEMINI_CONSOLIDATE_MODE`) are usable from the chart without a chart release.

README/values.schema.json regenerated with the CI-pinned helm-docs 1.14.2 / helm-schema 0.23.4 (this also picks up the two `ui` rows that were missing from the committed README). Verified with `helm lint` and `helm template` across: defaults (no rerank env rendered), `mode=off` (disabled), `mode=llm`, and a cross-encoder URL with model + apiKeySecret + extraEnv.

Running this against a live llama-server `--rerank` instance (Qwen3-Reranker-0.6B) on my cluster — currently via a Flux postRenderer patch, which this PR removes the need for.
