### PR TITLE
feat(chart): support existing PVC for sqlite backend

### DIFF
--- a/charts/memini/README.md
+++ b/charts/memini/README.md
@@ -18,6 +18,12 @@ helm install memini ./charts/memini \
   --set postgres.dsnSecret.name=memini-pg \
   --set autoscaling.enabled=true \
   --set embeddings.baseURL=http://text-embeddings:80/v1
+
+# Sqlite with a pre-provisioned PVC (RWO, same namespace, large enough for the db):
+helm install memini ./charts/memini \
+  --set embeddings.baseURL=http://text-embeddings:80/v1 \
+  --set embeddings.model=bge-m3 --set embeddings.dims=1024 \
+  --set sqlite.persistence.existingClaimName=memini-data
 ```
 
 ## Values
@@ -65,7 +71,8 @@ helm install memini ./charts/memini \
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.create | bool | `true` | Create a ServiceAccount |
 | serviceAccount.name | string | `""` | ServiceAccount name; generated when empty |
-| sqlite | object | `{"persistence":{"accessModes":["ReadWriteOnce"],"enabled":true,"size":"5Gi","storageClass":""}}` | sqlite backend persistence (StatefulSet volumeClaimTemplate) |
+| sqlite | object | `{"persistence":{"accessModes":["ReadWriteOnce"],"enabled":true,"existingClaimName":"","size":"5Gi","storageClass":""}}` | sqlite backend persistence (StatefulSet volumeClaimTemplate, or an existing PVC) |
+| sqlite.persistence.existingClaimName | string | `""` | Name of an existing PVC to use instead of creating one via volumeClaimTemplates. Must be in the same namespace, RWO, and large enough for the sqlite database. When set, `size`, `storageClass`, and `accessModes` are ignored. |
 | tolerations | list | `[]` |  |
 
 ## Observability

--- a/charts/memini/templates/statefulset.yaml.tpl
+++ b/charts/memini/templates/statefulset.yaml.tpl
@@ -1,4 +1,5 @@
 {{- if eq .Values.backend "sqlite" }}
+{{- $useExistingClaim := and .Values.sqlite.persistence.enabled .Values.sqlite.persistence.existingClaimName }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -30,7 +31,15 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         {{- include "memini.container" . | nindent 8 }}
-      {{- if not .Values.sqlite.persistence.enabled }}
+      {{- if $useExistingClaim }}
+      # Mount a pre-existing PVC via a pod-level volume. The StatefulSet's
+      # volumeClaimTemplates is omitted below so we don't create an extra PVC
+      # alongside the one the user already provisioned.
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.sqlite.persistence.existingClaimName }}
+      {{- else if not .Values.sqlite.persistence.enabled }}
       volumes:
         - name: data
           emptyDir: {}
@@ -47,7 +56,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- if .Values.sqlite.persistence.enabled }}
+  {{- if and .Values.sqlite.persistence.enabled (not $useExistingClaim) }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/charts/memini/values.schema.json
+++ b/charts/memini/values.schema.json
@@ -530,6 +530,12 @@
               "title": "enabled",
               "type": "boolean"
             },
+            "existingClaimName": {
+              "default": "",
+              "description": "Name of an existing PVC to use instead of creating one via volumeClaimTemplates. Must be in the same namespace, RWO, and large enough for the sqlite database. When set, size, storageClass, and accessModes are ignored.",
+              "title": "existingClaimName",
+              "type": "string"
+            },
             "size": {
               "default": "5Gi",
               "title": "size",

--- a/charts/memini/values.yaml
+++ b/charts/memini/values.yaml
@@ -63,12 +63,16 @@ auth:
     name: ""
     key: api-key
 
-# -- sqlite backend persistence (StatefulSet volumeClaimTemplate)
+# -- sqlite backend persistence (StatefulSet volumeClaimTemplate, or an existing PVC)
 sqlite:
   persistence:
     enabled: true
     size: 5Gi
     storageClass: ""
+    # -- Name of an existing PVC to use instead of creating one via volumeClaimTemplates.
+    # Must be in the same namespace, RWO, and large enough for the sqlite database.
+    # When set, `size`, `storageClass`, and `accessModes` are ignored.
+    existingClaimName: ""
     accessModes:
       - ReadWriteOnce
 


### PR DESCRIPTION
## What

Adds `sqlite.persistence.existingClaimName` to the chart so a pre-provisioned PVC can be mounted instead of having the StatefulSet create one via `volumeClaimTemplates`.

## Why

Useful when storage is managed out-of-band — CSI drivers that provision on first attach, restored-from-snapshot PVCs, shared storage owned by a platform team, or simply reuse of a PVC that was created by a previous deployment.

## How

When `existingClaimName` is set:
- A pod-level `volumes.persistentVolumeClaim.claimName: ...` references the existing claim.
- The StatefulSet's `volumeClaimTemplates` is omitted, so no extra PVC is created alongside it.
- `size`, `storageClass`, and `accessModes` become no-ops (the existing claim's properties win).

The container `volumeMount` is unchanged (`/data` from a volume named `data`), so no env or mount-path changes are needed. The PVC must be in the same namespace, RWO, and large enough for the sqlite database.

## Tested

```
helm template test ./charts/memini --set sqlite.persistence.enabled=false
# → pod-level emptyDir, no volumeClaimTemplates

helm template test ./charts/memini --set embeddings.baseURL=http://x
# → no pod-level volumes, StatefulSet volumeClaimTemplates present (unchanged)

helm template test ./charts/memini \
  --set embeddings.baseURL=http://x \
  --set sqlite.persistence.existingClaimName=memini-data
# → pod-level persistentVolumeClaim.claimName: memini-data, no volumeClaimTemplates
```

`helm lint .` is clean. Schema and YAML are valid.

## Notes

- Migration: if you're switching from a chart-managed PVC, the old `data-memini-0` claim will be orphaned. Move the data over (e.g. `kubectl cp` after a temporary pod) and delete the old claim, or use a different release name.
- `values.schema.json` is updated to validate the new field.
- `README.md` and the values table are updated to match (this chart doesn't have helm-docs in CI, so I edited it by hand).
