### PR TITLE
openclaw plugin: skip_without_agent to drop unattributed sessions

### DIFF
--- a/integrations/openclaw/plugin/plugin.mjs
+++ b/integrations/openclaw/plugin/plugin.mjs
@@ -23,6 +23,7 @@ const configSchema = {
     namespace: { type: "string" },
     namespace_per_agent: { type: "boolean" },
     namespace_template: { type: "string" },
+    skip_without_agent: { type: "boolean" },
     fallback_on_error: { type: "boolean" },
     timeout_ms: { type: "number" },
   },
@@ -63,11 +64,15 @@ function agentIdentity(event) {
 // per-agent name comes from namespace_template (default "{agent}"), with
 // {agent} and {namespace} substituted — e.g. "{agent}" -> "miso",
 // "openclaw-{agent}" -> "openclaw-miso". Falls back to the base namespace when
-// no agent id is present, preserving the shared-memory behavior.
+// no agent id is present, preserving the shared-memory behavior — unless
+// skip_without_agent is set, in which case it returns null so the caller skips
+// the operation entirely (no recall, no write, no fallback namespace). Useful
+// for gateways where unattributable sessions (cron, heartbeat) should not
+// pollute memory.
 export function effectiveNamespace(cfg, event) {
   if (!cfg.namespace_per_agent) return cfg.namespace;
   const id = sanitizeNsSegment(agentIdentity(event));
-  if (!id) return cfg.namespace;
+  if (!id) return cfg.skip_without_agent ? null : cfg.namespace;
   const tmpl = cfg.namespace_template || DEFAULT_NAMESPACE_TEMPLATE;
   return tmpl.replaceAll("{agent}", id).replaceAll("{namespace}", cfg.namespace);
 }
@@ -189,6 +194,7 @@ const plugin = {
       namespace: api.pluginConfig?.namespace || DEFAULT_NAMESPACE,
       namespace_per_agent: api.pluginConfig?.namespace_per_agent === true,
       namespace_template: api.pluginConfig?.namespace_template || DEFAULT_NAMESPACE_TEMPLATE,
+      skip_without_agent: api.pluginConfig?.skip_without_agent === true,
       fallback_on_error: api.pluginConfig?.fallback_on_error !== false,
       timeout_ms: api.pluginConfig?.timeout_ms || DEFAULT_TIMEOUT_MS,
     };
@@ -209,7 +215,9 @@ const plugin = {
       if (!cfg.enabled) return;
       const prompt = typeof event?.prompt === "string" ? event.prompt.trim() : "";
       if (!prompt) return;
-      const result = await client.postJson("/v1/search", { query: prompt, limit: 5 }, effectiveNamespace(cfg, event));
+      const ns = effectiveNamespace(cfg, event);
+      if (ns == null) return;
+      const result = await client.postJson("/v1/search", { query: prompt, limit: 5 }, ns);
       const block = formatResults(result?.results || []);
       if (!block) return;
       return { prependContext: `Relevant long-term memory from memini:\n${block}` };
@@ -220,11 +228,13 @@ const plugin = {
       const userText = lastTextByRole(event.messages, "user");
       const assistantText = lastTextByRole(event.messages, "assistant");
       if (!userText || !assistantText) return;
+      const ns = effectiveNamespace(cfg, event);
+      if (ns == null) return;
       await client.postJson("/v1/memories", {
         content: `User: ${userText.slice(0, 1000)}\nAssistant: ${assistantText.slice(0, 3000)}`,
         tier: "episodic",
         metadata: { source: "openclaw" },
-      }, effectiveNamespace(cfg, event));
+      }, ns);
     });
   },
 };

--- a/integrations/openclaw/plugin/plugin.test.mjs
+++ b/integrations/openclaw/plugin/plugin.test.mjs
@@ -34,3 +34,13 @@ test("falls back to base namespace when no agent id", () => {
   assert.equal(effectiveNamespace(cfg, {}), "openclaw");
   assert.equal(effectiveNamespace(cfg, { agentId: "   " }), "openclaw");
 });
+
+test("skip_without_agent returns null when no agent id (per-agent mode)", () => {
+  const cfg = { namespace: "openclaw", namespace_per_agent: true, namespace_template: "{agent}", skip_without_agent: true };
+  assert.equal(effectiveNamespace(cfg, {}), null);
+});
+
+test("skip_without_agent still resolves a present agent id", () => {
+  const cfg = { namespace: "openclaw", namespace_per_agent: true, namespace_template: "{agent}", skip_without_agent: true };
+  assert.equal(effectiveNamespace(cfg, { agentId: "miso" }), "miso");
+});


### PR DESCRIPTION
Implements #12.

In `namespace_per_agent` mode, sessions that reach the plugin with no resolvable agent identity (gateway cron/heartbeat runs) fall back to the static base namespace, mixing automation noise into shared memory. Adds an opt-in `skip_without_agent` flag: when set, `effectiveNamespace` returns `null` for unattributable events and both the `before_agent_start` (recall) and `agent_end` (write) hooks skip the operation entirely. Default behavior is unchanged.

`node --test` 8/8 (2 new cases). `node --check` clean.