### PR TITLE
openclaw plugin: resolve agent identity from hook ctx and session keys

### DIFF
--- a/integrations/openclaw/plugin/openclaw.plugin.json
+++ b/integrations/openclaw/plugin/openclaw.plugin.json
@@ -13,6 +13,7 @@
       "namespace": { "type": "string" },
       "namespace_per_agent": { "type": "boolean" },
       "namespace_template": { "type": "string" },
+      "skip_without_agent": { "type": "boolean" },
       "fallback_on_error": { "type": "boolean" },
       "timeout_ms": { "type": "number" }
     }
@@ -31,6 +32,10 @@
     "namespace_template": {
       "label": "Namespace Template",
       "help": "Per-agent namespace, e.g. \"{agent}\" or \"openclaw-{agent}\" ({namespace} also substituted)"
+    },
+    "skip_without_agent": {
+      "label": "Skip Without Agent",
+      "help": "In per-agent mode, skip recall/write when no agent identity resolves (e.g. cron/heartbeat) instead of using the fallback namespace"
     },
     "fallback_on_error": { "label": "Fallback On Error" },
     "timeout_ms": { "label": "Timeout (ms)" }

--- a/integrations/openclaw/plugin/plugin.mjs
+++ b/integrations/openclaw/plugin/plugin.mjs
@@ -38,23 +38,48 @@ function sanitizeNsSegment(s) {
   return String(s).trim().replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
-// agentIdentity pulls a stable per-agent id from an OpenClaw hook event,
-// tolerating the field names different OpenClaw versions use. Returns "" when
-// the event doesn't identify an agent.
-function agentIdentity(event) {
-  if (!event || typeof event !== "object") return "";
-  const candidates = [
-    event.agentId,
-    event.agentName,
-    event.agent?.id,
-    event.agent?.name,
-    event.agent?.slug,
-    event.sessionId,
-    event.session?.id,
-    event.session?.agentId,
+// Session keys look like "agent:<id>:..." (e.g. agent:carol:cron:...);
+// extract the agent segment. Raw session UUIDs are NOT identities — treating
+// them as such fragments memory into per-session namespaces.
+const SESSION_KEY_AGENT = /(?:^|[:/])agent[:/]([^:/]+)/;
+
+function parseAgentFromSessionKey(value) {
+  if (typeof value !== "string") return "";
+  const match = value.match(SESSION_KEY_AGENT);
+  return match ? match[1] : "";
+}
+
+// agentIdentity pulls a stable per-agent id from an OpenClaw hook event and
+// the hook context (the gateway invokes handlers as handler(event, ctx); some
+// events carry no identity fields, but ctx.sessionKey is keyed by agent).
+// Returns "" when neither identifies an agent.
+function agentIdentity(event, ctx) {
+  const direct = [
+    ctx?.agentId,
+    ctx?.agent_id,
+    event?.agentId,
+    event?.agent_id,
+    event?.agentName,
+    event?.agent?.id,
+    event?.agent?.name,
+    event?.agent?.slug,
+    event?.session?.agentId,
+    event?.session?.agent_id,
   ];
-  for (const c of candidates) {
+  for (const c of direct) {
     if (typeof c === "string" && c.trim()) return c.trim();
+  }
+  const keys = [
+    ctx?.sessionKey,
+    ctx?.sessionId,
+    ctx?.runId,
+    event?.sessionKey,
+    event?.sessionId,
+    event?.runId,
+  ];
+  for (const k of keys) {
+    const id = parseAgentFromSessionKey(k);
+    if (id) return id;
   }
   return "";
 }
@@ -62,16 +87,16 @@ function agentIdentity(event) {
 // effectiveNamespace returns the configured namespace, or a per-agent namespace
 // when namespace_per_agent is enabled and the event identifies an agent. The
 // per-agent name comes from namespace_template (default "{agent}"), with
-// {agent} and {namespace} substituted — e.g. "{agent}" -> "miso",
-// "openclaw-{agent}" -> "openclaw-miso". Falls back to the base namespace when
+// {agent} and {namespace} substituted — e.g. "{agent}" -> "alice",
+// "openclaw-{agent}" -> "openclaw-alice". Falls back to the base namespace when
 // no agent id is present, preserving the shared-memory behavior — unless
 // skip_without_agent is set, in which case it returns null so the caller skips
 // the operation entirely (no recall, no write, no fallback namespace). Useful
 // for gateways where unattributable sessions (cron, heartbeat) should not
 // pollute memory.
-export function effectiveNamespace(cfg, event) {
+export function effectiveNamespace(cfg, event, ctx) {
   if (!cfg.namespace_per_agent) return cfg.namespace;
-  const id = sanitizeNsSegment(agentIdentity(event));
+  const id = sanitizeNsSegment(agentIdentity(event, ctx));
   if (!id) return cfg.skip_without_agent ? null : cfg.namespace;
   const tmpl = cfg.namespace_template || DEFAULT_NAMESPACE_TEMPLATE;
   return tmpl.replaceAll("{agent}", id).replaceAll("{namespace}", cfg.namespace);
@@ -211,11 +236,11 @@ const plugin = {
       });
     }
 
-    api.on("before_agent_start", async (event) => {
+    api.on("before_agent_start", async (event, ctx) => {
       if (!cfg.enabled) return;
       const prompt = typeof event?.prompt === "string" ? event.prompt.trim() : "";
       if (!prompt) return;
-      const ns = effectiveNamespace(cfg, event);
+      const ns = effectiveNamespace(cfg, event, ctx);
       if (ns == null) return;
       const result = await client.postJson("/v1/search", { query: prompt, limit: 5 }, ns);
       const block = formatResults(result?.results || []);
@@ -223,12 +248,12 @@ const plugin = {
       return { prependContext: `Relevant long-term memory from memini:\n${block}` };
     });
 
-    api.on("agent_end", async (event) => {
+    api.on("agent_end", async (event, ctx) => {
       if (!cfg.enabled || !event?.success || !Array.isArray(event.messages)) return;
       const userText = lastTextByRole(event.messages, "user");
       const assistantText = lastTextByRole(event.messages, "assistant");
       if (!userText || !assistantText) return;
-      const ns = effectiveNamespace(cfg, event);
+      const ns = effectiveNamespace(cfg, event, ctx);
       if (ns == null) return;
       await client.postJson("/v1/memories", {
         content: `User: ${userText.slice(0, 1000)}\nAssistant: ${assistantText.slice(0, 3000)}`,

--- a/integrations/openclaw/plugin/plugin.test.mjs
+++ b/integrations/openclaw/plugin/plugin.test.mjs
@@ -5,23 +5,26 @@ import { effectiveNamespace } from "./plugin.mjs";
 
 test("namespace_per_agent off returns the base namespace", () => {
   const cfg = { namespace: "openclaw", namespace_per_agent: false };
-  assert.equal(effectiveNamespace(cfg, { agentId: "miso" }), "openclaw");
+  assert.equal(effectiveNamespace(cfg, { agentId: "alice" }), "openclaw");
 });
 
 test("default template is the bare agent id", () => {
   const cfg = { namespace: "openclaw", namespace_per_agent: true, namespace_template: "{agent}" };
-  assert.equal(effectiveNamespace(cfg, { agentId: "miso" }), "miso");
+  assert.equal(effectiveNamespace(cfg, { agentId: "alice" }), "alice");
 });
 
 test("template can prefix and substitute {namespace}", () => {
   const cfg = { namespace: "openclaw", namespace_per_agent: true, namespace_template: "{namespace}-{agent}" };
-  assert.equal(effectiveNamespace(cfg, { agent: { name: "saffron" } }), "openclaw-saffron");
+  assert.equal(effectiveNamespace(cfg, { agent: { name: "bob" } }), "openclaw-bob");
 });
 
 test("resolves alternate event shapes", () => {
   const cfg = { namespace: "ns", namespace_per_agent: true, namespace_template: "{agent}" };
-  assert.equal(effectiveNamespace(cfg, { agentName: "matcha" }), "matcha");
-  assert.equal(effectiveNamespace(cfg, { sessionId: "sess1" }), "sess1");
+  assert.equal(effectiveNamespace(cfg, { agentName: "carol" }), "carol");
+  // raw session UUIDs are not identities (they would fragment namespaces);
+  // only agent-keyed session keys resolve
+  assert.equal(effectiveNamespace(cfg, { sessionId: "sess1" }), "ns");
+  assert.equal(effectiveNamespace(cfg, { sessionId: "agent:bob:b7d2-uuid" }), "bob");
 });
 
 test("sanitizes the agent id", () => {
@@ -42,5 +45,19 @@ test("skip_without_agent returns null when no agent id (per-agent mode)", () => 
 
 test("skip_without_agent still resolves a present agent id", () => {
   const cfg = { namespace: "openclaw", namespace_per_agent: true, namespace_template: "{agent}", skip_without_agent: true };
-  assert.equal(effectiveNamespace(cfg, { agentId: "miso" }), "miso");
+  assert.equal(effectiveNamespace(cfg, { agentId: "alice" }), "alice");
+});
+
+test("ctx identity wins and session keys parse from ctx", () => {
+  const cfg = { namespace: "ns", namespace_per_agent: true, namespace_template: "{agent}" };
+  assert.equal(effectiveNamespace(cfg, {}, { agentId: "alice" }), "alice");
+  assert.equal(effectiveNamespace(cfg, {}, { sessionKey: "agent:carol:cron:daily" }), "carol");
+  assert.equal(effectiveNamespace(cfg, {}, { sessionKey: "heartbeat:gateway" }), "ns");
+});
+
+test("skip_without_agent skips gateway-level sessions but keeps agent crons", () => {
+  const cfg = { namespace: "ns", namespace_per_agent: true, namespace_template: "{agent}", skip_without_agent: true };
+  assert.equal(effectiveNamespace(cfg, {}, { sessionKey: "agent:alice:heartbeat:hourly" }), "alice");
+  assert.equal(effectiveNamespace(cfg, {}, { sessionKey: "heartbeat:gateway" }), null);
+  assert.equal(effectiveNamespace(cfg, {}, {}), null);
 });


### PR DESCRIPTION
Fixes per-agent namespacing (#4) actually working against a real OpenClaw gateway.

**Problem:** OpenClaw's `agent_end` event payload is `{type, messages}` — none of the identity fields `agentIdentity()` checks exist on it (verified against the gateway dist: `emit({ type: "agent_end", messages: event.messages })`). So with `namespace_per_agent: true`, identity never resolves and **every** write lands in the static fallback namespace. Multi-agent gateways get one co-mingled namespace — the thing #4 was meant to prevent.

**Fix:** the gateway invokes extension handlers as `handler(event, ctx)`, and ctx carries agent-scoped session keys (`agent:<id>:...`, e.g. `agent:carol:cron:daily`). Accept `ctx` in both hooks; resolve identity from `ctx.agentId`/`agent_id` first, then by parsing the `agent:<id>` segment from ctx/event sessionKey/sessionId/runId. (Same mechanism the agentmemory OpenClaw plugin used, which demonstrably produced per-agent attribution.)

**Behavior change:** raw session ids are no longer treated as identities — a bare session UUID isn't an agent, and using it fragments memory into per-session namespaces. Session ids now contribute only via the `agent:<id>` parse; one existing test updated accordingly.

Composes with `skip_without_agent` (#12/#13) to give exact semantics: agent sessions — including their crons/heartbeats — route to the agent's namespace; gateway-level unattributable sessions are skipped.

`node --test`: 10/10 (3 new cases incl. ctx resolution and the cron/heartbeat split).
