### PR TITLE
fix(openclaw): strip OpenClaw runtime preambles from captured turns

### DIFF
--- a/integrations/openclaw/plugin/plugin.mjs
+++ b/integrations/openclaw/plugin/plugin.mjs
@@ -262,6 +262,24 @@ function lastTextByRole(messages, role) {
   return "";
 }
 
+// OpenClaw prepends runtime plumbing to the user turn that the model sees:
+// one or more "<Label> (untrusted metadata):" blocks (chat/sender info), each
+// followed by a fenced JSON object. That metadata is explicitly untrusted and
+// is not memory — captured verbatim it dominates a namespace and recalls at
+// high similarity (it's templated), crowding out real memories. Strip the
+// leading metadata blocks and keep the actual message that follows.
+const UNTRUSTED_METADATA_BLOCK =
+  /^\s*[^\n]*\(untrusted metadata\):\s*```(?:json)?\s*[\s\S]*?```\s*/;
+
+export function stripRuntimePreambles(text) {
+  if (typeof text !== "string") return text;
+  let out = text;
+  while (UNTRUSTED_METADATA_BLOCK.test(out)) {
+    out = out.replace(UNTRUSTED_METADATA_BLOCK, "");
+  }
+  return out.trim();
+}
+
 // DEFAULT_RECALL_LABELS mirrors the opencode plugin's labels toggle. Empty by
 // default — when labels are off, formatResults renders the legacy
 // "(tier) text" line so existing callers see identical output.
@@ -482,6 +500,10 @@ const plugin = {
       const assistantText = lastTextByRole(event.messages, "assistant");
       if (!userText || !assistantText) return;
       if (shouldSkipSystemTurn(cfg, event, ctx, userText)) return;
+      // Drop OpenClaw runtime plumbing from the captured turn: untrusted-metadata
+      // preambles, and subagent task delegations (framing, not conversation).
+      const captureUser = stripRuntimePreambles(userText);
+      if (!captureUser || captureUser.startsWith("[Subagent Context]")) return;
       const ns = effectiveNamespace(cfg, event, ctx);
       if (ns == null) return;
       const metadata = { source: "openclaw" };
@@ -489,7 +511,7 @@ const plugin = {
       if (session) metadata.session_id = session;
       if (!event?.success) metadata.failed = true;
       await client.postJson("/v1/memories", {
-        content: `User: ${userText.slice(0, 1000)}\nAssistant: ${assistantText.slice(0, 3000)}`,
+        content: `User: ${captureUser.slice(0, 1000)}\nAssistant: ${assistantText.slice(0, 3000)}`,
         tier: "episodic",
         metadata,
       }, ns);

--- a/integrations/openclaw/plugin/plugin.test.mjs
+++ b/integrations/openclaw/plugin/plugin.test.mjs
@@ -12,6 +12,7 @@ import plugin, {
   resolveConfig,
   sessionIdentity,
   shouldSkipSystemTurn,
+  stripRuntimePreambles,
 } from "./plugin.mjs";
 
 // fakeClient records the last memini call and returns canned responses, so the
@@ -569,4 +570,47 @@ test("memory_remember rejects unknown tier and falls back to semantic", async ()
   await byName.memory_remember.execute("id", { content: "fact", tier: "bogus" });
   const call = client.calls.at(-1);
   assert.equal(call.body.tier, "semantic", "unknown tier must fall back to semantic");
+});
+
+test("stripRuntimePreambles drops a leading untrusted-metadata block, keeps the message", () => {
+  const input = [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    '{ "chat_id": "c1", "sender": "alice" }',
+    "```",
+    "",
+    "What is the deploy status?",
+  ].join("\n");
+  assert.equal(stripRuntimePreambles(input), "What is the deploy status?");
+});
+
+test("stripRuntimePreambles drops multiple stacked metadata blocks", () => {
+  const input = [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    '{ "chat_id": "c1" }',
+    "```",
+    "",
+    "Sender (untrusted metadata):",
+    "```json",
+    '{ "name": "alice" }',
+    "```",
+    "",
+    "Real question here",
+  ].join("\n");
+  assert.equal(stripRuntimePreambles(input), "Real question here");
+});
+
+test("stripRuntimePreambles leaves a normal message untouched", () => {
+  assert.equal(stripRuntimePreambles("Just a normal question"), "Just a normal question");
+});
+
+test("stripRuntimePreambles returns empty when the turn is only metadata", () => {
+  const input = [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    '{ "chat_id": "c1" }',
+    "```",
+  ].join("\n");
+  assert.equal(stripRuntimePreambles(input), "");
 });


### PR DESCRIPTION
Fixes #22.

## Problem

OpenClaw injects runtime plumbing into the user turn the model (and `agent_end`) sees:

- one or more `<Label> (untrusted metadata):` blocks (chat info, sender info), each followed by a fenced JSON object, and
- a `[Subagent Context] You are running as a subagent …` preamble on subagent task delegations.

`agent_end` captured these verbatim as episodic memories. Because they're templated and repeat across turns, they recall at **high** similarity (0.8–0.94 in practice) and crowd out real memories during `before_prompt_build` injection. A `min_score` floor can't filter them (the scores are high), and `skip_system_turns` doesn't catch them — the metadata block rides on a *genuine* user turn, so it isn't a cron/heartbeat kind.

What got stored, e.g.:

```
User: Conversation info (untrusted metadata):
```json
{ "chat_id": "...", "sender_id": "...", "sender": "..." }
```

Sender (untrusted metadata):
```json
{ "name": "..." }
```

<the actual user message>
```

## Change

In the `agent_end` capture path, after the existing system-turn check (so cron/heartbeat detection still runs on the raw text):

- `stripRuntimePreambles()` removes leading `… (untrusted metadata):` + fenced-JSON blocks (handles stacked blocks), keeping the real message.
- Skip capture when the turn is a pure `[Subagent Context]` delegation (framing, not conversation), or when stripping leaves nothing.

No config/schema change — the metadata blocks are unambiguously OpenClaw plumbing, so stripping is unconditional.

## Tests

Added 4 unit tests for `stripRuntimePreambles` (single block, stacked blocks, plain message untouched, metadata-only → empty). Full suite: **45 passing** (`node --test`, deps installed).
