### PR TITLE
fix(plugin): track Codex apply_patch files

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -60,7 +60,9 @@ Codex implements a Claude-Code-compatible plugin model: it auto-discovers
 compatibility), so the same hook wiring drives both. Mount this directory as a
 Codex plugin via `.codex-plugin/plugin.json` — no Codex-specific hooks file is
 needed. (Matchers naming Claude-only tools like `Read`/`Glob`/`Grep` just don't
-fire under Codex, which exposes `Bash`/`apply_patch`/`mcp__*`.)
+fire under Codex, which exposes `Bash`/`apply_patch`/`mcp__*`.) The
+`PostToolUse` hook captures Codex `apply_patch` calls by parsing the patch
+header lines, so session digests still list edited files.
 
 ### opencode
 

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -55,7 +55,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|MultiEdit|Write|Bash|NotebookEdit|Agent|Task",
+        "matcher": "Edit|MultiEdit|Write|Bash|NotebookEdit|Agent|Task|apply_patch",
         "hooks": [
           {
             "type": "command",

--- a/plugin/scripts/_shared.mjs
+++ b/plugin/scripts/_shared.mjs
@@ -627,7 +627,11 @@ export function buildSessionDigest(events, project) {
   const commands = [];
   const seenCmd = new Set();
   for (const ev of events) {
-    if (ev.file) fileCounts.set(ev.file, (fileCounts.get(ev.file) || 0) + 1);
+    const files = Array.isArray(ev.files) && ev.files.length ? ev.files : ev.file ? [ev.file] : [];
+    for (const f of files) {
+      if (typeof f !== "string" || !f) continue;
+      fileCounts.set(f, (fileCounts.get(f) || 0) + 1);
+    }
     if (ev.cmd && !seenCmd.has(ev.cmd)) {
       seenCmd.add(ev.cmd);
       commands.push(ev.cmd);

--- a/plugin/scripts/_test.mjs
+++ b/plugin/scripts/_test.mjs
@@ -333,6 +333,48 @@ test("session-end.mjs: distills buffered events into one digest", async () => {
   }
 });
 
+test("session-end.mjs: counts files edited through Codex apply_patch", async () => {
+  const cache = freshCache();
+  const patch = `*** Begin Patch
+*** Update File: src/auth.js
+@@
+-old
++new
+*** Add File: src/session.js
++export const session = {};
+*** End Patch
+`;
+
+  await runHook(
+    "post-tool-use.mjs",
+    JSON.stringify({ session_id: "codexpatch1", cwd: __dirname, tool_name: "apply_patch", tool_input: patch }),
+    { XDG_CACHE_HOME: cache },
+  );
+
+  const hits = [];
+  const { url, close } = await startMockServer((req, res, body) => {
+    hits.push({ url: req.url, ns: req.headers["x-memini-namespace"], body });
+    res.setHeader("Content-Type", "application/json");
+    res.statusCode = 201;
+    res.end(JSON.stringify({ id: "m1" }));
+  });
+
+  try {
+    await runHook(
+      "session-end.mjs",
+      JSON.stringify({ session_id: "codexpatch1", cwd: __dirname, reason: "user_exit" }),
+      { MEMINI_URL: url, XDG_CACHE_HOME: cache },
+    );
+
+    assert.equal(hits.length, 1, "session-end should write a digest for apply_patch edits");
+    const body = JSON.parse(hits[0].body);
+    assert.match(body.content, /Edited: src\/auth\.js, src\/session\.js\./);
+    assert.deepEqual(body.metadata.files, ["src/auth.js", "src/session.js"]);
+  } finally {
+    await close();
+  }
+});
+
 test("pre-tool-use.mjs: searches by file path, surfaces context to stdout", async () => {
   const hits = [];
   const { url, close } = await startMockServer((req, res, body) => {

--- a/plugin/scripts/post-tool-use.mjs
+++ b/plugin/scripts/post-tool-use.mjs
@@ -11,7 +11,7 @@
 import { readStdin, parseJSON, readToolCall, appendSessionEvent, DEBUG } from "./_shared.mjs";
 
 const FILE_KEYS = ["filePath", "file_path", "path", "file", "pattern"];
-const RECORDED = new Set(["Edit", "MultiEdit", "Write", "Bash", "NotebookEdit", "Agent", "Task"]);
+const RECORDED = new Set(["edit", "multiedit", "write", "bash", "notebookedit", "agent", "task", "apply_patch"]);
 
 function firstFile(args) {
   if (!args || typeof args !== "object") return "";
@@ -22,20 +22,50 @@ function firstFile(args) {
   return "";
 }
 
+function patchText(input) {
+  if (typeof input === "string") return input;
+  if (!input || typeof input !== "object") return "";
+  for (const k of ["patch", "input", "cmd", "command"]) {
+    const v = input[k];
+    if (typeof v === "string" && v.includes("*** Begin Patch")) return v;
+  }
+  return "";
+}
+
+function filesFromApplyPatch(input) {
+  const text = patchText(input);
+  if (!text) return [];
+  const files = [];
+  const seen = new Set();
+  for (const line of text.split("\n")) {
+    const m = line.match(/^\*\*\* (?:Add|Update|Delete) File: (.+)$/) || line.match(/^\*\*\* Move to: (.+)$/);
+    if (!m) continue;
+    const file = m[1].trim();
+    if (!file || seen.has(file)) continue;
+    seen.add(file);
+    files.push(file);
+  }
+  return files;
+}
+
 async function main() {
   const payload = parseJSON(await readStdin()) || {};
   const { toolName, toolInput, sessionId } = readToolCall(payload);
-  if (!toolName || !RECORDED.has(toolName)) return;
+  const toolKey = String(toolName || "").toLowerCase();
+  if (!toolName || !RECORDED.has(toolKey)) return;
 
   const args = toolInput && typeof toolInput === "object" ? toolInput : {};
   const cmd = typeof args.command === "string" ? args.command : args.cmd;
+  const files = toolKey === "apply_patch" ? filesFromApplyPatch(toolInput) : [];
+  const file = files[0] || firstFile(args);
 
   if (DEBUG) console.error(`[memini] PostToolUse buffer tool=${toolName} session=${sessionId}`);
 
   appendSessionEvent(sessionId, {
     ts: Date.now(),
     tool: toolName,
-    file: firstFile(args),
+    file,
+    files: files.length ? files : undefined,
     cmd: typeof cmd === "string" ? cmd : "",
   });
 }


### PR DESCRIPTION
## Summary
- include Codex `apply_patch` in the plugin PostToolUse matcher and recorder
- parse `apply_patch` patch headers into edited file lists for session digests
- count multi-file session events while keeping the existing `event.file` fallback

## Test Plan
- [x] `env -u MEMINI_NAMESPACE -u MEMINI_NAMESPACE_SCOPE node plugin/scripts/_test.mjs`
- [x] `go test ./...`
- [x] `git diff --check`
