### PR TITLE
fix(openclaw): register hooks via api.on so a throwing registerHook can't abort register() (#26)

### DIFF
--- a/integrations/openclaw/plugin/src/index.ts
+++ b/integrations/openclaw/plugin/src/index.ts
@@ -623,10 +623,25 @@ const plugin: {
       if (!block) return;
       return { prependContext: `Relevant long-term memory from memini:\n${block}` };
     };
-    api.registerHook("before_prompt_build", recallHandler);
-    // api.on is the legacy hook surface; some test/runtime mocks still use it.
-    // Production OpenClaw only has api.registerHook.
-    api.on?.("before_prompt_build", recallHandler);
+    // Register on whichever hook surface this OpenClaw build exposes. api.on is
+    // the surface the prior plugin.mjs used and is present in current
+    // production; a positional api.registerHook(name, handler) is rejected with
+    // "hook registration missing name" and would abort register(), dropping the
+    // memory hooks entirely (eleboucher/memini#26). Prefer api.on; fall back to
+    // registerHook's object form only when api.on is unavailable, and never let
+    // it throw.
+    const addHook = (name: string, handler: any) => {
+      if (typeof api.on === "function") {
+        api.on(name, handler);
+        return;
+      }
+      try {
+        api.registerHook?.({ name, handler });
+      } catch {
+        /* unknown registerHook signature; nothing else to try */
+      }
+    };
+    addHook("before_prompt_build", recallHandler);
 
     const captureHandler = async (event: any, ctx: any) => {
       if (!cfg.enabled || !Array.isArray(event.messages)) return;
@@ -650,8 +665,7 @@ const plugin: {
         metadata,
       }, ns);
     };
-    api.registerHook("agent_end", captureHandler);
-    api.on?.("agent_end", captureHandler);
+    addHook("agent_end", captureHandler);
 
     // Opt-in explicit tools, registered after the memory slot above. Best-effort:
     // a failure (e.g. typebox unavailable) is logged and leaves the slot working.

--- a/integrations/openclaw/plugin/test/regression.test.mjs
+++ b/integrations/openclaw/plugin/test/regression.test.mjs
@@ -237,6 +237,34 @@ test("register wires the three tools when expose_tools is on", async () => {
   assert.deepEqual(names.sort(), ["memory_list", "memory_recall", "memory_remember"]);
 });
 
+// Production OpenClaw's api.registerHook(name, handler) rejects the positional
+// form with "hook registration missing name". That throw must not abort
+// register() and lose the memory hooks (eleboucher/memini#26) — they register
+// via api.on, which production exposes.
+test("register survives a throwing api.registerHook and still wires hooks via api.on", async () => {
+  const hooks = {};
+  let threw = false;
+  try {
+    await plugin.register({
+      pluginConfig: { enabled: true, namespace_per_agent: false },
+      registerMemoryCapability() {},
+      registerHook() {
+        throw new Error("hook registration missing name");
+      },
+      on(name, handler) {
+        hooks[name] = handler;
+      },
+      logger: { warn() {} },
+      registerTool() {},
+    });
+  } catch {
+    threw = true;
+  }
+  assert.equal(threw, false, "register must not throw when registerHook rejects");
+  assert.equal(typeof hooks.before_prompt_build, "function", "recall hook wired via api.on");
+  assert.equal(typeof hooks.agent_end, "function", "capture hook wired via api.on");
+});
+
 // OpenClaw requires every runtime api.registerTool(...) name to be declared in
 // the manifest's contracts.tools, or tool discovery can't route to this plugin.
 // Keep the manifest and the registered tools in lockstep.


### PR DESCRIPTION
## Problem

Fixes #26. The TypeScript OpenClaw plugin (0.4.7/0.4.8) installs cleanly but **fails `register()` at gateway startup**, so memini never loads — no recall, no capture:

```
[plugins] loading memini from .../extensions/memini/dist/index.js
[plugins] memini failed during register: Error: hook registration missing name
[plugins] 1 plugin(s) failed to initialize (register: memini)
```

`register()` calls `api.registerHook("before_prompt_build", recallHandler)` (positional). Production OpenClaw rejects that form with `hook registration missing name`, and the throw aborts `register()` **before** the `api.on?.(...)` fallback on the next line can run — so neither hook is wired and the plugin is dropped. The previous `plugin.mjs` (0.4.6) registered via `api.on(...)` and loads fine, so `api.on` is present in production; only the `registerHook` call is the regression.

## Fix

Register through a small `addHook` helper that:
- prefers `api.on` (the surface that actually loads in production), and
- falls back to `registerHook`'s **object** form (`{ name, handler }`) only when `api.on` is unavailable, wrapped so a signature mismatch can never abort `register()`.

The hook bodies (incl. the runtime-preamble strip and recall gating) are unchanged — only the registration wiring.

## Test

Adds a regression test to `test/regression.test.mjs` with a mock whose `registerHook` **throws** `hook registration missing name` (replicating production) while `on` captures. It asserts `register()` doesn't throw and both hooks are wired. The test **fails against the current code** and passes with this change:

```
# old registration:  ✖ register survives a throwing api.registerHook ...  (1 fail)
# this PR:            ✔ ... 46 pass / 0 fail
```

`npm run build`, `npm run typecheck`, and `npm test` all pass.
