### PR TITLE
fix(openclaw): don't re-inject the same memories on every step of a turn (#21)

### DIFF
--- a/integrations/openclaw/plugin/src/index.ts
+++ b/integrations/openclaw/plugin/src/index.ts
@@ -604,6 +604,28 @@ const plugin: {
       });
     }
 
+    // OpenClaw fires before_prompt_build on every step of a turn (each tool
+    // call), and an unchanged query recalls the same top memories — so the same
+    // "long-term memory" block is re-injected on every step, drowning the prompt
+    // (eleboucher/memini#21). Track what each session has already been shown and
+    // drop repeats on later steps; genuinely new matches still surface. Bounded
+    // so the map can't grow without limit across long-lived gateways.
+    const injectedBySession = new Map<string, Set<string>>();
+    const MAX_TRACKED_SESSIONS = 200;
+    const rememberInjected = (session: string, ids: string[]) => {
+      let seen = injectedBySession.get(session);
+      if (!seen) {
+        seen = new Set<string>();
+        injectedBySession.set(session, seen);
+        while (injectedBySession.size > MAX_TRACKED_SESSIONS) {
+          const oldest = injectedBySession.keys().next().value;
+          if (oldest === undefined) break;
+          injectedBySession.delete(oldest);
+        }
+      }
+      for (const id of ids) if (id) seen.add(id);
+    };
+
     const recallHandler = async (event: any, ctx: any) => {
       if (!cfg.enabled) return;
       const prompt = typeof event?.prompt === "string" ? event.prompt.trim() : "";
@@ -619,8 +641,18 @@ const plugin: {
       const session = sessionIdentity(event, ctx);
       if (session) body.exclude_metadata = { session_id: session };
       const result = await client.postJson("/v1/search", body, ns);
-      const block = formatResults(result?.results || [], recallLabels());
+      let results = Array.isArray(result?.results) ? result.results : [];
+      // Suppress memories this session has already been shown so a multi-step
+      // turn doesn't re-inject the same block on every tool call (#21).
+      if (session) {
+        const seen = injectedBySession.get(session);
+        if (seen?.size) results = results.filter((r: any) => !seen.has(r?.memory?.id));
+      }
+      const block = formatResults(results, recallLabels());
       if (!block) return;
+      if (session) {
+        rememberInjected(session, results.map((r: any) => r?.memory?.id).filter(Boolean));
+      }
       return { prependContext: `Relevant long-term memory from memini:\n${block}` };
     };
     // Register on whichever hook surface this OpenClaw build exposes. api.on is

--- a/integrations/openclaw/plugin/test/regression.test.mjs
+++ b/integrations/openclaw/plugin/test/regression.test.mjs
@@ -329,6 +329,48 @@ test("recall sends recall_limit and min_score on /v1/search when configured", as
   }
 });
 
+// before_prompt_build fires on every step of a turn; an unchanged query returns
+// the same memories, so without dedup the same block is re-injected on every
+// tool call (eleboucher/memini#21). The same session must only be shown a given
+// memory once; a different session is unaffected.
+test("recall does not re-inject memories already shown in the same session (#21)", async () => {
+  const hooks = {};
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: true,
+    async json() {
+      return {
+        results: [
+          { memory: { id: "m1", summary: "alpha", tier: "semantic" }, score: 0.9 },
+          { memory: { id: "m2", summary: "beta", tier: "semantic" }, score: 0.8 },
+        ],
+      };
+    },
+    async text() { return ""; },
+  });
+  try {
+    await plugin.register({
+      pluginConfig: { enabled: true, namespace_per_agent: false },
+      registerMemoryCapability() {}, registerHook() {},
+      on(name, handler) { hooks[name] = handler; },
+      logger: { warn() {} },
+      registerTool() {},
+    });
+    const ev = (sessionId) => ({ prompt: "q", session: { id: sessionId } });
+    const first = await hooks.before_prompt_build(ev("s1"), {});
+    assert.match(first.prependContext, /alpha/);
+    assert.match(first.prependContext, /beta/);
+    // Same session, same query (a later tool-call step): both already shown -> no re-injection.
+    const second = await hooks.before_prompt_build(ev("s1"), {});
+    assert.equal(second, undefined, "already-shown memories must not be re-injected");
+    // A different session still sees them.
+    const other = await hooks.before_prompt_build(ev("s2"), {});
+    assert.match(other.prependContext, /alpha/);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
 test("recall uses before_prompt_build, not the deprecated before_agent_start", async () => {
   const hooks = {};
   await plugin.register({


### PR DESCRIPTION
## Problem

Re #21 (closed). `recall_limit`/`recall_min_score` gave a single global cap + optional floor, but the noisiest part of automatic injection is still there: **the same memories get re-injected on every step of a turn.**

`before_prompt_build` fires on every step (each tool call), and an unchanged user query recalls the same top memories each time — so the `Relevant long-term memory from memini:` block is re-prepended on every step. A multi-tool turn ends up with the same memories stacked repeatedly, drowning the prompt — especially painful for smaller/fast models. This is the "spray" half of #21's complaint, independent of the per-hook budget design.

## Fix

Track, per session, which memory ids have already been surfaced, and drop repeats on later steps:

- First injection of a turn is **unchanged** (backward-compatible — same memories, same formatting).
- Later steps only inject memories not already shown this session; genuinely new matches still surface.
- The session→ids map is bounded (200 sessions, oldest evicted) so a long-lived gateway can't leak.

No new config and no default changes — purely removes redundant re-injection. Complements `recall_min_score` (quality floor) and `recall_limit` (per-call cap) rather than replacing them.

## Test

Adds a regression test: two `before_prompt_build` calls in the same session with the same query → the second injects nothing (already shown); a different session still sees them. It **fails without the dedup** and passes with it. `npm run build`, `npm run typecheck`, `npm test` (47 + 25) all green.

## Note / possible follow-up

This doesn't implement #21's full per-hook budget (`session_start` vs `pre_tool_use`, token budgets, tier sections) — just the highest-impact, lowest-risk slice. Happy to take it further if you'd like the budgeted-injection layer too.
