### PR TITLE
feat(openclaw): reserve recall slots for consolidated semantic/procedural memory (#21)

### DIFF
--- a/integrations/openclaw/plugin/openclaw.plugin.json
+++ b/integrations/openclaw/plugin/openclaw.plugin.json
@@ -28,7 +28,8 @@
       "timeout_ms": { "type": "number" },
       "expose_tools": { "type": "boolean" },
       "recall_limit": { "type": "number" },
-      "recall_max_tokens": { "type": "number" }
+      "recall_max_tokens": { "type": "number" },
+      "recall_semantic_reserve": { "type": "number" }
     }
   },
   "activation": {

--- a/integrations/openclaw/plugin/src/index.ts
+++ b/integrations/openclaw/plugin/src/index.ts
@@ -42,6 +42,7 @@ const typeboxConfigSchema = Type.Object(
     expose_tools: Type.Optional(Type.Boolean()),
     recall_limit: Type.Optional(Type.Number()),
     recall_max_tokens: Type.Optional(Type.Number()),
+    recall_semantic_reserve: Type.Optional(Type.Number()),
   },
   { additionalProperties: false },
 );
@@ -105,6 +106,14 @@ export function resolveConfig(pluginConfig: any) {
       Number.isFinite(c.recall_max_tokens) && c.recall_max_tokens > 0
         ? c.recall_max_tokens
         : intEnv("MEMINI_INJECT_RECALL_MAX_TOK", 800),
+    // Reserve up to N of the recall_limit slots for durable (consolidated)
+    // memories — semantic + procedural — so high-volume episodic chatter can't
+    // crowd distilled facts/rules out of recall. 0 (default) reserves nothing,
+    // i.e. identical to prior behavior.
+    recall_semantic_reserve:
+      Number.isFinite(c.recall_semantic_reserve) && c.recall_semantic_reserve > 0
+        ? c.recall_semantic_reserve
+        : 0,
   };
 }
 
@@ -118,6 +127,32 @@ function intEnv(name: string, def: number) {
 }
 
 export type ResolvedConfig = ReturnType<typeof resolveConfig>;
+
+// The consolidated tiers: LLM-distilled facts (semantic) and rules/runbooks
+// (procedural), as opposed to raw per-turn episodic captures.
+const DURABLE_TIERS = new Set(["semantic", "procedural"]);
+
+// reserveDurableTiers caps `results` at `limit`, but first guarantees up to
+// `reserve` of those slots go to durable (consolidated) memories, so episodic
+// chatter — which usually outnumbers consolidated memory by an order of
+// magnitude — can't crowd distilled facts/rules out of recall. Remaining slots
+// fill by relevance (any tier). reserve <= 0 is a plain top-`limit` slice.
+// Output preserves the input's relevance order.
+export function reserveDurableTiers(results: any[], limit: number, reserve: number) {
+  if (!Array.isArray(results)) return [];
+  if (reserve <= 0 || results.length <= limit) return results.slice(0, limit);
+  const want = Math.min(reserve, limit);
+  const keep = new Set<any>();
+  for (const r of results) {
+    if (keep.size >= want) break;
+    if (DURABLE_TIERS.has(r?.memory?.tier)) keep.add(r);
+  }
+  for (const r of results) {
+    if (keep.size >= limit) break;
+    keep.add(r);
+  }
+  return results.filter((r) => keep.has(r)).slice(0, limit);
+}
 
 // sanitizeNsSegment keeps a namespace segment header-safe (the server sanitizes
 // too, but the X-Memini-Namespace value should be clean): alnum, dot, dash,
@@ -680,7 +715,14 @@ const plugin: {
       if (shouldSkipSystemTurn(cfg, event, ctx, prompt)) return;
       const ns = effectiveNamespace(cfg, event, ctx);
       if (ns == null) return;
-      const body: any = { query: prompt, limit: cfg.recall_limit };
+      // Over-fetch a candidate pool when reserving durable slots, so semantic/
+      // procedural memories can surface in the pool despite episodic dominating
+      // by volume; reserveDurableTiers composes it back down to recall_limit.
+      const fetchLimit =
+        cfg.recall_semantic_reserve > 0
+          ? Math.max(cfg.recall_limit * 4, cfg.recall_limit + 12)
+          : cfg.recall_limit;
+      const body: any = { query: prompt, limit: fetchLimit };
       // Exclude this session's own just-captured turns: they're still in the
       // live transcript, so recalling them echoes the conversation back as
       // "long-term memory". agent_end tags each capture with session_id.
@@ -694,6 +736,7 @@ const plugin: {
         const seen = injectedBySession.get(session);
         if (seen?.size) results = results.filter((r: any) => !seen.has(r?.memory?.id));
       }
+      results = reserveDurableTiers(results, cfg.recall_limit, cfg.recall_semantic_reserve);
       const bullets = formatResults(results, recallLabels());
       if (bullets.length === 0) return;
       // Apply the token ceiling to the rendered bullets; recall_max_tokens <= 0

--- a/integrations/openclaw/plugin/test/regression.test.mjs
+++ b/integrations/openclaw/plugin/test/regression.test.mjs
@@ -8,6 +8,7 @@ import plugin, {
   effectiveNamespace,
   meminiListPath,
   registerMeminiTools,
+  reserveDurableTiers,
   resolveConfig,
   sessionIdentity,
   shouldSkipSystemTurn,
@@ -282,6 +283,34 @@ test("resolveConfig defaults recall_limit to 3", () => {
 
 test("resolveConfig honors explicit recall_limit", () => {
   assert.equal(resolveConfig({ recall_limit: 2 }).recall_limit, 2);
+});
+
+test("resolveConfig defaults recall_semantic_reserve to 0 (off) and honors it", () => {
+  assert.equal(resolveConfig(undefined).recall_semantic_reserve, 0);
+  assert.equal(resolveConfig({ recall_semantic_reserve: 2 }).recall_semantic_reserve, 2);
+  assert.equal(resolveConfig({ recall_semantic_reserve: 0 }).recall_semantic_reserve, 0);
+});
+
+// Episodic outnumbers consolidated memory ~20:1, so top-by-relevance recall is
+// nearly all episodic chatter. reserveDurableTiers guarantees up to N slots for
+// semantic/procedural without losing relevance order (eleboucher/memini#21).
+test("reserveDurableTiers reserves slots for semantic/procedural over episodic", () => {
+  const pool = [
+    { memory: { id: "e1", tier: "episodic" } },
+    { memory: { id: "e2", tier: "episodic" } },
+    { memory: { id: "s1", tier: "semantic" } },
+    { memory: { id: "e3", tier: "episodic" } },
+    { memory: { id: "p1", tier: "procedural" } },
+  ];
+  const ids = (rs) => rs.map((r) => r.memory.id);
+  // reserve 0 = plain top-limit, unchanged
+  assert.deepEqual(ids(reserveDurableTiers(pool, 2, 0)), ["e1", "e2"]);
+  // reserve 1 = keep the top episodic + pull in the top durable, relevance order
+  assert.deepEqual(ids(reserveDurableTiers(pool, 2, 1)), ["e1", "s1"]);
+  // reserve 2 = two durable slots
+  assert.deepEqual(ids(reserveDurableTiers(pool, 2, 2)), ["s1", "p1"]);
+  // reserve capped at limit; pool already <= limit returns as-is
+  assert.deepEqual(ids(reserveDurableTiers(pool.slice(0, 2), 3, 2)), ["e1", "e2"]);
 });
 
 test("resolveConfig falls back when recall_limit is zero/negative", () => {


### PR DESCRIPTION
## Problem

Re #21. Recall pulls the top `recall_limit` memories by relevance across **all tiers**. But episodic per-turn captures outnumber the LLM-distilled tiers by ~20:1 in practice (one real namespace: **299 episodic / 16 semantic / 6 procedural**), so the top matches are almost always conversational chatter ("how far did the cron get", "keep going") and the consolidated facts/rules — exactly the durable knowledge worth surfacing — rarely make the cut. `recall_limit` and `recall_max_tokens` bound *volume* but can't bias *what kind* of memory wins a slot.

## Fix

Add `recall_semantic_reserve` (default `0` = unchanged). When `> 0`, recall over-fetches a candidate pool and guarantees up to N of the `recall_limit` slots go to **durable** memories (semantic + procedural), filling the remaining slots by relevance. Output preserves relevance order.

- **Back-compat:** `0` reserves nothing — byte-identical behavior to today.
- **No server change:** results already carry `memory.tier`; composition is client-side. (`/v1/search` has no tier filter, so the pool is over-fetched then composed down.)
- Complements the existing knobs: `recall_limit` (count) + `recall_max_tokens` (token budget) + `recall_semantic_reserve` (tier floor) — the per-tier "sections" idea from #21, scoped to one small, optional knob rather than a full injection-policy DSL.

`reserveDurableTiers()` is exported and unit-tested directly.

## Tests

- `resolveConfig` default (`0`) + honored value.
- `reserveDurableTiers`: reserve 0 = plain top-N; reserve 1/2 promote semantic/procedural over episodic while keeping relevance order; reserve capped at limit; small-pool passthrough.

`npm run build`, `npm run typecheck`, `npm test` (49 + 27) all green.

## Note

This is a deliberately small slice of #21 — a tier floor, not the full per-hook budget/sections config. Happy to extend toward the larger design if you'd prefer it server-side (e.g. a tier weight in fusion, which would also let the reserve work without over-fetching).
