### PR TITLE
fix(plugin): stop leaking <memory> blocks into replies, save via memory_remember

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -12,7 +12,7 @@ the agent _when_ to use the memory tools.
 | `SessionStart` | Searches prior context, writes a short block to the agent's input                                                                                                             |
 | `PreToolUse`   | Before Edit/Write/Read/Glob/Grep, surfaces related memories                                                                                                                   |
 | `PostToolUse`  | Buffers state-changing tool calls locally (no network, no per-call memory)                                                                                                    |
-| `Stop`         | Distills the buffer into a working-tier checkpoint, captures the last turn as episodic memory, extracts inline `<memory>` facts, and periodically nudges an auto-save (below) |
+| `Stop`         | Distills the buffer into a working-tier checkpoint, captures the last turn as episodic memory, scrapes legacy inline `<memory>` blocks (back-compat), and periodically nudges an auto-save (below) |
 | `PreCompact`   | Before context compaction, distills the buffer into an episodic emergency checkpoint (Claude Code only)                                                                       |
 | `SessionEnd`   | Distills the buffer into one durable episodic **session digest**                                                                                                              |
 
@@ -49,10 +49,13 @@ real memories out of the box — not just session digests:
   stored as an **episodic** memory (deduped on the assistant message id), the
   same automatic per-turn recall layer the opencode plugin gets from
   `session.idle`. Set to `0` to disable.
-- **Inline extraction** (`MEMINI_INLINE_EXTRACT`): `SessionStart` injects a
-  short directive asking the agent to emit `<memory>` blocks for durable facts
-  it learns; `Stop` scans the transcript and persists each as a **semantic**
-  fact. Model-curated, so it stays low-noise. Set to `0` to disable.
+- **Memory directive** (`MEMINI_INLINE_EXTRACT`): `SessionStart` injects a
+  short directive asking the agent to persist durable facts via the
+  `memory_remember` MCP tool (tier `semantic`) instead of printing them into
+  its reply. `Stop` still scans transcripts for legacy `<memory>` blocks and
+  persists those too, as a back-compat fallback for sessions started under the
+  old directive. Model-curated, so it stays low-noise. Set to `0` to disable
+  both.
 
 Plus 3 skills (`remember`, `recall`, `recap`) the agent invokes directly.
 
@@ -67,6 +70,12 @@ so the agent has memory_remember / memory_recall / memory_get / memory_update / 
 memory_list / memory_briefing (plus memory_answer, when an LLM is configured) without extra
 config. Verify with `curl http://localhost:8080/healthz`.
 ```
+
+The memory directive makes the agent call `memory_remember` on its own, which
+triggers a permission prompt on first use. To pre-approve, add the tools to
+`permissions.allow` in your Claude Code settings, e.g.
+`"mcp__plugin_memini_memini__memory_remember"` (plugin-shipped MCP tools are
+namespaced `mcp__plugin_memini_memini__*`).
 
 ### Codex CLI
 
@@ -152,7 +161,7 @@ server is detached from the agent's cwd.
 | `MEMINI_AUTO_SAVE`          | on                       | `Stop` hook           | set to `0` to disable the periodic auto-save nudge                                              |
 | `MEMINI_AUTO_SAVE_INTERVAL` | `10`                     | `Stop` hook           | user messages between auto-save nudges                                                          |
 | `MEMINI_CAPTURE_TURNS`      | on                       | `Stop` hook           | auto-capture each user→assistant turn as episodic memory; set to `0` to disable                 |
-| `MEMINI_INLINE_EXTRACT`     | on                       | SessionStart + `Stop` | inject a directive to emit `<memory>` blocks and persist them as durable facts; `0` to disable  |
+| `MEMINI_INLINE_EXTRACT`     | on                       | SessionStart + `Stop` | inject the memory-save directive (`memory_remember`) and scrape legacy `<memory>` blocks; `0` to disable |
 | `MEMINI_DEBUG`              | —                        | hooks                 | set to `1` for verbose hook logging                                                             |
 
 ### Tuning injection budgets

--- a/plugin/scripts/_shared.mjs
+++ b/plugin/scripts/_shared.mjs
@@ -786,27 +786,30 @@ export function readToolCall(payload) {
   };
 }
 
-// Inline memory extraction: parse <memory> blocks from agent output.
-// Opt-in via MEMINI_INLINE_EXTRACT=1.
+// Memory directive: at SessionStart the plugin injects a short instruction
+// telling the agent to persist durable facts via the memory_remember MCP
+// tool. On by default; opt out with MEMINI_INLINE_EXTRACT=0. The Stop hook
+// keeps a legacy scraper (parseMemoryBlocks) as a back-compat fallback for
+// sessions still emitting inline <memory> blocks under the old instruction.
 
 export const MEMORY_INSTRUCTION = `
 
-<memini-inline-memory>
-After your response, if you learned something durable worth persisting for
-future sessions (a decision, a fact, a convention, a gotcha), emit a block:
-
-<memory>
-{"memories":[{"content":"concise fact, one per item"}]}
-</memory>
+<memini-memory-directive>
+When you learn something durable worth persisting for future sessions (a
+decision, a fact, a convention, a gotcha), save it by calling the memini
+memory_remember MCP tool (tier "semantic", one memory per call).
 
 Rules:
-- One JSON object, one "memories" array of {"content":"..."} objects.
-- Each content should be a self-contained fact (readable without context).
-- Omit the block entirely when nothing is worth keeping — don't emit empty arrays.
-- This is reference memory, not scratch space. Prefer quality over quantity.
-- If a stale or wrong fact turns up (rather than a new one), correct it in place
-  with the memory_update MCP tool instead of emitting a duplicate here.
-</memini-inline-memory>`;
+- Each memory should be a self-contained fact, readable without this
+  conversation's context.
+- Save nothing when nothing is worth keeping. This is reference memory,
+  not scratch space: prefer quality over quantity.
+- If a stale or wrong fact turns up (rather than a new one), correct it in
+  place with the memory_update MCP tool instead of saving a duplicate.
+- Never print memory markup or JSON memory payloads in your reply text.
+  Memories are saved only through the MCP tools. If the tools are
+  unavailable, do nothing.
+</memini-memory-directive>`;
 
 /**
  * Parse all <memory>...</memory> blocks from a text. Returns an array of

--- a/plugin/scripts/_test.mjs
+++ b/plugin/scripts/_test.mjs
@@ -234,6 +234,8 @@ test("session-start.mjs: fetches the briefing with right namespace, writes conte
 
     assert.match(stdout, /<memini-context[^>]*>/, "should emit context block");
     assert.match(stdout, /last session did X/, "should surface prior memory");
+    assert.match(stdout, /memory_remember/, "should inject the memory directive");
+    assert.ok(!stdout.includes("<memory>"), "injected context must not contain memory markup");
     assert.equal(hits.length, 1, `expected 1 briefing call, got ${hits.length}`);
     const [h] = hits;
     assert.equal(h.method, "GET");
@@ -1075,6 +1077,15 @@ test("parseMemoryBlocks: extracts contents, tolerates malformed and empty blocks
   );
   assert.deepEqual(parseMemoryBlocks(""), []);
   assert.deepEqual(parseMemoryBlocks("no blocks here"), []);
+});
+
+test("MEMORY_INSTRUCTION: directs to memory_remember, contains no memory markup", async () => {
+  const { MEMORY_INSTRUCTION } = await import("./_shared.mjs");
+  assert.match(MEMORY_INSTRUCTION, /memory_remember/, "must name the MCP tool");
+  assert.match(MEMORY_INSTRUCTION, /memory_update/, "must keep the stale-fact correction path");
+  assert.match(MEMORY_INSTRUCTION, /semantic/, "must keep tier guidance");
+  assert.ok(!MEMORY_INSTRUCTION.includes("<memory>"), "must not contain a literal <memory> tag the model could echo");
+  assert.ok(!MEMORY_INSTRUCTION.includes("</memory>"), "must not contain a closing memory tag");
 });
 
 test("extractAssistantText: pulls text blocks from a transcript, skips tool-only turns", async () => {

--- a/plugin/scripts/session-start.mjs
+++ b/plugin/scripts/session-start.mjs
@@ -109,8 +109,8 @@ async function main() {
   if (sessionId && briefingUnchanged(sessionId, contentHash)) {
     if (DEBUG) console.error("[memini] SessionStart: briefing unchanged this session, skipping re-injection");
     // A re-fire usually means the context was rebuilt (resume / clear / compact),
-    // which drops the inline-extraction directive. Skip the unchanged briefing
-    // but re-emit the directive so the agent keeps emitting <memory> blocks.
+    // which drops the memory directive. Skip the unchanged briefing but re-emit
+    // the directive so the agent keeps saving durable facts via memory_remember.
     if (inlineExtract) process.stdout.write(MEMORY_INSTRUCTION);
     return;
   }
@@ -174,9 +174,10 @@ async function main() {
   }
   lines.push("</memini-context>");
 
-  // Inline extraction instruction: when MEMINI_INLINE_EXTRACT=1, append a
-  // directive telling the agent to emit <memory> blocks in its responses.
-  // The Stop hook scans the transcript for these blocks and persists them.
+  // Memory directive: when MEMINI_INLINE_EXTRACT=1 (default), append a
+  // directive telling the agent to persist durable facts via the
+  // memory_remember MCP tool. The Stop hook also scrapes legacy inline
+  // <memory> blocks from the transcript as a back-compat fallback.
   if (inlineExtract) {
     lines.push(MEMORY_INSTRUCTION);
   }

--- a/plugin/scripts/stop.mjs
+++ b/plugin/scripts/stop.mjs
@@ -149,9 +149,11 @@ async function main() {
       metadata: { source: "stop_checkpoint", session_id: sessionId },
     });
 
-  // Inline memory extraction (on by default; opt out with MEMINI_INLINE_EXTRACT=0):
-  // scan the session transcript for <memory> blocks the agent emitted during its
-  // responses and persist each as a durable semantic fact.
+  // Legacy inline-block scrape (on by default; opt out with MEMINI_INLINE_EXTRACT=0):
+  // back-compat fallback for sessions started under the old instruction that asked
+  // for <memory> blocks in the reply text. New sessions save via the memory_remember
+  // MCP tool directly; any block that still shows up here is persisted as a durable
+  // semantic fact so nothing is lost.
   if (envEnabled("MEMINI_INLINE_EXTRACT", true) && hasSessionIdentity && payload.transcript_path) {
     const transcript = readTranscript(payload.transcript_path);
     const assistantTexts = extractAssistantText(transcript);


### PR DESCRIPTION
## Problem

The SessionStart directive currently asks the agent to print a raw `<memory>{"memories":[...]}` block at the end of its reply so the Stop hook can scrape it out of the transcript. The capture works, but the XML+JSON shows up in the terminal every time the agent saves something. I kept noticing it in my own sessions and it looks like broken output, not a feature.

## What changed

The directive now points the agent at the `memory_remember` MCP tool instead (tier "semantic", one memory per call) and tells it to never print memory markup in the reply. Tool calls render as a collapsed line in Claude Code, so saves no longer show up in the reply text. The wording follows the auto-save nudge, which already asks for `memory_remember`.

The transcript scraper in the Stop hook stays as-is, as a fallback: sessions that started under the old directive (or a model that emits a block anyway) still get captured with the same `inline_extract` provenance. `MEMINI_INLINE_EXTRACT` keeps gating both the injection and the scrape, so setting it to `0` still turns off model-curated capture entirely.

One detail worth calling out: the new instruction contains no literal `<memory>` tag anywhere, so there is nothing for a model to echo back. A new test pins that, along with the tool names and tier guidance, and the session-start test now checks the injected context carries the directive without markup. I also renamed the wrapper tag from `<memini-inline-memory>` to `<memini-memory-directive>`, which makes it easy to spot old vs new sessions in transcripts.

If the MCP tools are not available the directive says to do nothing. Turn capture, checkpoints, and distill-on-write are untouched and still record the session.

## Docs

Updated the hook table, the automatic-capture bullet, and the env var row in `plugin/README.md` for the tool-based flow, and added a note about pre-approving `mcp__plugin_memini_memini__memory_remember` in `permissions.allow` so the first save does not stall on a permission prompt.

## Tests

`node --test plugin/scripts/_test.mjs`: 51 pass, 0 fail.