### PR TITLE
Teach agents the conventions memini already has: server instructions, schema enums, and correction-by-upsert

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -117,13 +117,15 @@ is the exception: its native plugin is deliberately tool-free (automatic recall 
 capture only), so to give it `memory_forget` (or any tool) wire the memini MCP
 server alongside the plugin.
 
-**`memory_update` (partial update by id) is MCP-only** — there is no REST
-update endpoint. Claude Code, Codex, and any host wired to the memini MCP
-server get it; Hermes, Pi, OpenClaw, Open WebUI, and opencode's native plugins
-talk REST (`/v1/search`, `/v1/memories`) and do **not** expose it, so their
-tool descriptions correctly point to `memory_forget` (delete + re-remember) as
-the only way to correct a stored fact. Wire the MCP server alongside a native
-plugin if a host needs `memory_update`.
+**`memory_update` (partial update by id) is MCP-only** — REST has no PATCH
+endpoint, but `POST /v1/memories` **upserts when given an `id`**, replacing the
+memory in place while preserving its identity and history. The REST-backed
+plugins (Hermes, Pi, OpenClaw, Open WebUI) therefore accept an optional `id` on
+`memory_remember`, and their tool descriptions point to re-remember-with-id as
+the way to correct a stored fact; `memory_forget` is only for memories that
+should not exist at all. Wire the MCP server alongside a native plugin if a
+host needs true partial updates (`memory_update` merges field-by-field; the
+REST upsert replaces the record with what you send).
 
 Two host-specific differences remain by design:
 

--- a/integrations/hermes/plugin/memini/__init__.py
+++ b/integrations/hermes/plugin/memini/__init__.py
@@ -610,10 +610,11 @@ class MeminiMemoryProvider(MemoryProvider):
                 "name": "memory_recall",
                 "description": "Search long-term memory (memini) for relevant past facts and context. Call "
                 "before starting work that may have history: editing an unfamiliar file, "
-                "debugging a recurring issue, or when asked what's known about something. A "
-                'degraded:"keyword_only" field in the result means semantic search was '
-                "unavailable and results came from keyword matching alone — treat as "
-                "incomplete, not exhaustive.",
+                "debugging a recurring issue, or when asked what's known about something. "
+                "Empty results mean nothing is known — proceed from first principles, never "
+                'invent a remembered fact. A degraded:"keyword_only" field in the result '
+                "means semantic search was unavailable and results came from keyword "
+                "matching alone — treat as incomplete, not exhaustive.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -677,13 +678,20 @@ class MeminiMemoryProvider(MemoryProvider):
                 "description": "Store a durable fact, decision, or preference in long-term memory (memini). "
                 "Call proactively when the user says 'remember this', after an architectural "
                 "decision (capture the why), or after discovering a non-obvious bug or "
-                "convention. Keep memories atomic — one self-contained fact per call.",
+                "convention. Keep memories atomic — one self-contained fact per call. Don't "
+                "store what's already in project docs or trivially recoverable from code. To "
+                "correct an existing memory, pass its id — the write updates it in place.",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "content": {
                             "type": "string",
-                            "description": "The fact to remember",
+                            "description": "The fact to remember — atomic and self-contained.",
+                        },
+                        "id": {
+                            "type": "string",
+                            "description": "Existing memory id (from memory_recall / memory_list) "
+                            "to correct in place instead of writing a new memory.",
                         },
                         "tier": {
                             "type": "string",
@@ -695,7 +703,8 @@ class MeminiMemoryProvider(MemoryProvider):
                         "tags": {
                             "type": "array",
                             "items": {"type": "string"},
-                            "description": "Optional keywords for later search/filtering.",
+                            "description": "Topic keywords for later search/filtering; tag a "
+                            "critical always-relevant fact 'pinned'.",
                         },
                         "category": {
                             "type": "string",
@@ -711,9 +720,9 @@ class MeminiMemoryProvider(MemoryProvider):
                 "name": "memory_forget",
                 "description": "Permanently delete a memory from long-term memory (memini) by its id — use when "
                 "a recalled memory is wrong, outdated, or poisoned. Get the id from memory_recall "
-                "or memory_list. To correct a fact, forget the stale one and remember the "
-                "corrected version — this provider talks to memini over REST, which has no "
-                "partial-update endpoint.",
+                "or memory_list. To correct a fact instead, call memory_remember with the "
+                "existing id (it updates in place, preserving history); forget only memories "
+                "that should not exist at all.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -776,6 +785,8 @@ class MeminiMemoryProvider(MemoryProvider):
             # No client-side tier default: send tier only when the caller gave a
             # valid one, else omit it so the server classifies the content.
             body: dict = {"content": args["content"]}
+            if args.get("id"):  # POST /v1/memories upserts by id
+                body["id"] = args["id"]
             tier = args.get("tier")
             if tier in VALID_TIERS:
                 body["tier"] = tier

--- a/integrations/openclaw/plugin/src/index.ts
+++ b/integrations/openclaw/plugin/src/index.ts
@@ -571,9 +571,10 @@ export function registerMeminiTools(api: any, client: MeminiClient, cfg: Resolve
       description:
         "Search long-term memory (memini) for relevant past facts and context. Call before starting work " +
         "that may have history: editing an unfamiliar file, debugging a recurring issue, or when asked " +
-        "what's known about something. A degraded:\"keyword_only\" field in the result means semantic " +
-        "search was unavailable and results came from keyword matching alone — treat as incomplete, not " +
-        "exhaustive.",
+        "what's known about something. Empty results mean nothing is known — proceed from first " +
+        "principles, never invent a remembered fact. A degraded:\"keyword_only\" field in the result means " +
+        "semantic search was unavailable and results came from keyword matching alone — treat as " +
+        "incomplete, not exhaustive.",
       parameters: Type.Object({
         query: Type.String({ description: "What to search for" }),
         limit: Type.Optional(Type.Number({ description: "Max results (default 3)" })),
@@ -629,9 +630,16 @@ export function registerMeminiTools(api: any, client: MeminiClient, cfg: Resolve
       description:
         "Store a durable fact, decision, or preference in long-term memory (memini). Call proactively when " +
         "the user says 'remember this', after an architectural decision (capture the why), or after " +
-        "discovering a non-obvious bug or convention. Keep memories atomic — one self-contained fact per call.",
+        "discovering a non-obvious bug or convention. Keep memories atomic — one self-contained fact per " +
+        "call. Don't store what's already in project docs or trivially recoverable from code. To correct " +
+        "an existing memory, pass its id — the write updates it in place.",
       parameters: Type.Object({
-        content: Type.String({ description: "The fact to remember" }),
+        content: Type.String({ description: "The fact to remember — atomic and self-contained." }),
+        id: Type.Optional(
+          Type.String({
+            description: "Existing memory id (from memory_recall / memory_list) to correct in place instead of writing a new memory.",
+          }),
+        ),
         tier: Type.Optional(
           Type.String({
             description:
@@ -639,7 +647,11 @@ export function registerMeminiTools(api: any, client: MeminiClient, cfg: Resolve
               "(omit to let the server classify from the content)",
           }),
         ),
-        tags: Type.Optional(Type.Array(Type.String(), { description: "Optional keywords for later search/filtering." })),
+        tags: Type.Optional(
+          Type.Array(Type.String(), {
+            description: "Topic keywords for later search/filtering; tag a critical always-relevant fact 'pinned'.",
+          }),
+        ),
         category: Type.Optional(
           Type.String({
             description:
@@ -651,6 +663,7 @@ export function registerMeminiTools(api: any, client: MeminiClient, cfg: Resolve
         // No client-side tier default: an omitted (or invalid) tier lets the
         // server classify the content and apply its own default.
         const body: any = { content: params.content };
+        if (params.id) body.id = params.id; // POST /v1/memories upserts by id
         const VALID_TIERS = ["working", "episodic", "semantic", "procedural"];
         if (params.tier && VALID_TIERS.includes(params.tier)) body.tier = params.tier;
         if (params.tags?.length) body.tags = params.tags;
@@ -664,8 +677,8 @@ export function registerMeminiTools(api: any, client: MeminiClient, cfg: Resolve
       description:
         "Permanently delete a memory from long-term memory (memini) by its id — use when a recalled " +
         "memory is wrong, outdated, or poisoned. Get the id from memory_recall or memory_list. To " +
-        "correct a fact, forget the stale one and remember the corrected version — this plugin talks " +
-        "to memini over REST, which has no partial-update endpoint.",
+        "correct a fact instead, call memory_remember with the existing id (it updates in place, " +
+        "preserving history); forget only memories that should not exist at all.",
       parameters: Type.Object({
         id: Type.String({ description: "The id of the memory to forget (from memory_recall / memory_list)." }),
       }),

--- a/integrations/openclaw/plugin/test/helpers.test.ts
+++ b/integrations/openclaw/plugin/test/helpers.test.ts
@@ -42,6 +42,10 @@ function fakeClient(): MeminiClient & { calls: RecordedCall[] } {
       calls.push({ method: "GET", path, ns });
       return { memories: [{ id: "m1", content: "c", tier: "procedural", tags: ["auth"], metadata: { category: "bug_fixes" } }] };
     },
+    async deleteJson(path: string, ns?: string) {
+      calls.push({ method: "DELETE", path, ns });
+      return {};
+    },
   };
 }
 

--- a/integrations/openwebui/tools/memini_tools.py
+++ b/integrations/openwebui/tools/memini_tools.py
@@ -165,13 +165,15 @@ class Tools:
             header += f" (degraded: {note})"
         return header + "\n" + "\n".join(lines)
 
-    async def remember_memory(self, content: str, __event_emitter__=None) -> str:
+    async def remember_memory(self, content: str, id: str = "", __event_emitter__=None) -> str:
         """
         Store a fact in long-term memory so it can be recalled in future
         conversations. Call this when the user shares a durable preference,
-        decision, or fact worth remembering.
+        decision, or fact worth remembering. To correct an existing memory,
+        pass its id (as shown by recall_memory) — the write updates it in place.
 
         :param content: The fact to remember, written as a self-contained statement.
+        :param id: Optional id of an existing memory to correct in place.
         :return: Confirmation that the memory was stored.
         """
         if __event_emitter__:
@@ -181,14 +183,14 @@ class Tools:
         # No forced tier: this tool is for durable preferences/decisions/facts,
         # so let the server classify the content (a decision or preference lands
         # durable, chatter stays episodic) instead of pinning everything to one tier.
-        await self._post_json(
-            "/v1/memories",
-            {
-                "content": content,
-                "tags": ["openwebui"],
-                "metadata": {"source": "openwebui"},
-            },
-        )
+        body = {
+            "content": content,
+            "tags": ["openwebui"],
+            "metadata": {"source": "openwebui"},
+        }
+        if id:  # POST /v1/memories upserts by id
+            body["id"] = id
+        await self._post_json("/v1/memories", body)
         if __event_emitter__:
             await __event_emitter__(
                 {"type": "status", "data": {"description": "Memory stored", "done": True}}
@@ -199,9 +201,9 @@ class Tools:
         """
         Permanently delete a memory from long-term memory by its id. Call this when
         a recalled memory is wrong, outdated, or poisoned. Get the id from
-        recall_memory (each hit is annotated with its id). To correct a fact,
-        forget the stale one and remember_memory the corrected version — this tool
-        talks to memini over REST, which has no partial-update endpoint.
+        recall_memory (each hit is annotated with its id). To correct a fact
+        instead, call remember_memory with the existing id (it updates in place);
+        forget only memories that should not exist at all.
 
         :param id: The id of the memory to forget, as shown by recall_memory.
         :return: Confirmation that the memory was forgotten.

--- a/integrations/pi/plugin/src/index.ts
+++ b/integrations/pi/plugin/src/index.ts
@@ -536,9 +536,10 @@ export default function meminiExtension(pi: ExtensionAPI): void {
     description:
       "Recall relevant memories from long-term memory (memini) via hybrid (semantic + keyword) search. " +
       "Call before starting work that may have history: editing an unfamiliar file, debugging a recurring " +
-      "issue, or when asked what's known about something. A degraded:\"keyword_only\" field in the result " +
-      "means semantic search was unavailable and results came from keyword matching alone — treat as " +
-      "incomplete, not exhaustive.",
+      "issue, or when asked what's known about something. Empty results mean nothing is known — proceed " +
+      "from first principles, never invent a remembered fact. A degraded:\"keyword_only\" field in the " +
+      "result means semantic search was unavailable and results came from keyword matching alone — treat " +
+      "as incomplete, not exhaustive.",
     parameters: Type.Object({
       query: Type.String({ description: "What to search for" }),
       limit: Type.Optional(Type.Number({ description: "Max results (default 3)" })),
@@ -598,9 +599,16 @@ export default function meminiExtension(pi: ExtensionAPI): void {
     description:
       "Store a durable fact, decision, or preference in long-term memory (memini). Call proactively when " +
       "the user says 'remember this', after an architectural decision (capture the why), or after " +
-      "discovering a non-obvious bug or convention. Keep memories atomic — one self-contained fact per call.",
+      "discovering a non-obvious bug or convention. Keep memories atomic — one self-contained fact per " +
+      "call. Don't store what's already in project docs or trivially recoverable from code. To correct " +
+      "an existing memory, pass its id — the write updates it in place.",
     parameters: Type.Object({
-      content: Type.String({ description: "The fact to remember" }),
+      content: Type.String({ description: "The fact to remember — atomic and self-contained." }),
+      id: Type.Optional(
+        Type.String({
+          description: "Existing memory id (from memory_recall / memory_list) to correct in place instead of writing a new memory.",
+        }),
+      ),
       tier: Type.Optional(
         Type.String({
           description:
@@ -609,7 +617,9 @@ export default function meminiExtension(pi: ExtensionAPI): void {
         }),
       ),
       tags: Type.Optional(
-        Type.Array(Type.String(), { description: "Optional keywords for later search/filtering." }),
+        Type.Array(Type.String(), {
+          description: "Topic keywords for later search/filtering; tag a critical always-relevant fact 'pinned'.",
+        }),
       ),
       category: Type.Optional(
         Type.String({
@@ -622,6 +632,7 @@ export default function meminiExtension(pi: ExtensionAPI): void {
       // No client-side tier default: an omitted (or invalid) tier lets the
       // server classify the content and apply its own default.
       const body: any = { content: params.content };
+      if (params.id) body.id = params.id; // POST /v1/memories upserts by id
       if (params.tier && VALID_TIERS.includes(params.tier)) body.tier = params.tier;
       if (params.tags?.length) body.tags = params.tags;
       if (params.category) body.metadata = { category: params.category };
@@ -635,9 +646,9 @@ export default function meminiExtension(pi: ExtensionAPI): void {
     label: "Forget",
     description:
       "Permanently delete a memory from long-term memory (memini) by its id — use when a recalled memory " +
-      "is wrong, outdated, or poisoned. Get the id from memory_recall or memory_list. To correct a fact, " +
-      "forget the stale one and remember the corrected version — this integration talks to memini over " +
-      "REST, which has no partial-update endpoint.",
+      "is wrong, outdated, or poisoned. Get the id from memory_recall or memory_list. To correct a fact " +
+      "instead, call memory_remember with the existing id (it updates in place, preserving history); " +
+      "forget only memories that should not exist at all.",
     parameters: Type.Object({
       id: Type.String({ description: "The id of the memory to forget (from memory_recall / memory_list)." }),
     }),

--- a/internal/api/mcp/mcp.go
+++ b/internal/api/mcp/mcp.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/eleboucher/memini/internal/httputil"
@@ -42,13 +43,85 @@ var (
 	}
 )
 
+// enumSchema infers the JSON schema for T (keeping the jsonschema struct-tag
+// descriptions) and applies enum constraints, which the tag syntax cannot
+// express. Array-typed properties get the enum on their items. It panics on an
+// unknown property; the vars below run at init, so a typo fails any test run.
+func enumSchema[T any](enums map[string][]any) *jsonschema.Schema {
+	s, err := jsonschema.For[T](&jsonschema.ForOptions{})
+	if err != nil {
+		panic(err)
+	}
+	for name, vals := range enums {
+		p, ok := s.Properties[name]
+		if !ok {
+			panic("enumSchema: no property " + name)
+		}
+		if p.Items != nil { // array property: constrain its items
+			p.Items.Enum = vals
+		} else {
+			p.Enum = vals
+		}
+	}
+	return s
+}
+
+// Property names shared by several enum maps below.
+const (
+	propTiers  = "tiers"
+	propLevels = "levels"
+	propScope  = "scope"
+)
+
+// Input schemas with enum constraints, computed once. get/forget (idArgs) have
+// no enum-valued parameters and keep the SDK's inferred schema.
+var (
+	tierEnum  = []any{"working", "episodic", "semantic", "procedural"}
+	levelEnum = []any{"explicit", "deduced"}
+	scopeEnum = []any{"exact", "subtree"}
+
+	rememberSchema = enumSchema[rememberArgs](map[string][]any{"tier": tierEnum, "level": levelEnum})
+	recallSchema   = enumSchema[recallArgs](map[string][]any{
+		propTiers: tierEnum, propLevels: levelEnum, propScope: scopeEnum,
+		"response_format": {"concise", "detailed"},
+	})
+	briefingSchema = enumSchema[briefingArgs](map[string][]any{propScope: scopeEnum})
+	answerSchema   = enumSchema[answerArgs](map[string][]any{
+		propTiers: tierEnum, propLevels: levelEnum,
+		"reasoning_level": {"minimal", "low", "medium", "high"},
+	})
+	listSchema   = enumSchema[listArgs](map[string][]any{propTiers: tierEnum, propLevels: levelEnum})
+	updateSchema = enumSchema[updateArgs](map[string][]any{"tier": tierEnum})
+)
+
+// serverInstructions is sent to clients in the initialize response. It is the
+// one server-controlled string that can teach cross-tool policy (call order,
+// proactive use, storage conventions) — per-tool descriptions are read in
+// isolation during tool selection and can't express it.
+const serverInstructions = "memini is persistent cross-session memory for this agent. Standing policy:\n" +
+	"- At session start, call memory_briefing once to orient (pinned context, durable facts, " +
+	"how-tos, recent activity). Prefer it over broad recall queries.\n" +
+	"- Before work that may have history — an unfamiliar file, a recurring bug, a non-obvious " +
+	"decision — call memory_recall first.\n" +
+	"- After learning something durable (a decision and its why, a gotcha, a convention, a stated " +
+	"preference), call memory_remember proactively: one atomic, self-contained fact per call. " +
+	"Don't store what's already in project docs/CLAUDE.md or trivially recoverable from code.\n" +
+	"- tier: semantic = durable fact, procedural = how-to/command, episodic = what happened, " +
+	"working = scratch. Omit to auto-classify.\n" +
+	"- Conventions: tag critical always-relevant facts \"pinned\" (they surface in every briefing); " +
+	"set metadata.category to a topic bucket (e.g. bug_fixes, architecture_decisions, coding_conventions).\n" +
+	"- To correct or extend a stored fact, use memory_update on its id rather than writing a " +
+	"near-duplicate; memory_forget only for memories that should not exist.\n" +
+	"- Empty recall means nothing is known — proceed from first principles, never invent a " +
+	"remembered fact. A degraded field means results are keyword-only and incomplete, not a confident negative."
+
 // NewServer builds an MCP server exposing memini's memory tools. defaultNS is
 // used whenever a tool call omits the namespace argument.
 func NewServer(svc *service.Service, defaultNS string) *mcpsdk.Server {
 	s := mcpsdk.NewServer(&mcpsdk.Implementation{
 		Name:    "memini",
 		Version: version.Version,
-	}, nil)
+	}, &mcpsdk.ServerOptions{Instructions: serverInstructions})
 
 	h := &tools{svc: svc, defaultNS: defaultNS}
 
@@ -66,6 +139,7 @@ func NewServer(svc *service.Service, defaultNS string) *mcpsdk.Server {
 			"existing memory — either call memory_update with id=merge_hint.similar_id to fold " +
 			"them together, or ignore it to keep both. Returns {id, tier, stored}; stored=false " +
 			"means a low-signal write was dropped by the value gate (not an error).",
+		InputSchema: rememberSchema,
 		Annotations: additive,
 	}, h.remember)
 	mcpsdk.AddTool(s, &mcpsdk.Tool{
@@ -82,9 +156,8 @@ func NewServer(svc *service.Service, defaultNS string) *mcpsdk.Server {
 			"treat as incomplete. Supports time-travel (as_of), nested namespaces (scope=subtree), " +
 			"an exact per-call read set (namespaces — replaces the default; writes are unaffected), " +
 			"and query_rewrite (LLM expands the query into variants, fused via RRF — better " +
-			"recall, slower). When the current session's turns are being captured as memories, " +
-			"pass exclude_metadata {\"session_id\": \"<current session id>\"} so the session's " +
-			"own captured turns are not echoed back as memory.",
+			"recall, slower).",
+		InputSchema: recallSchema,
 		Annotations: readOnly,
 	}, h.recall)
 	mcpsdk.AddTool(s, &mcpsdk.Tool{
@@ -95,6 +168,7 @@ func NewServer(svc *service.Service, defaultNS string) *mcpsdk.Server {
 			"Call it when a session opens to orient yourself. Prefer this over broad recall " +
 			"queries at session start. scope=subtree also briefs nested namespaces; namespaces " +
 			"briefs an exact read set instead of the default (writes are unaffected).",
+		InputSchema: briefingSchema,
 		Annotations: readOnly,
 	}, h.briefing)
 	// memory_answer requires an LLM; only advertise it when one is configured,
@@ -106,6 +180,7 @@ func NewServer(svc *service.Service, defaultNS string) *mcpsdk.Server {
 			Description: "Recall relevant memories and answer a question grounded on them (requires " +
 				"an LLM). Slower than memory_recall; use when you want a synthesized answer with " +
 				"sources rather than raw memories.",
+			InputSchema: answerSchema,
 			Annotations: readOnly,
 		}, h.answer)
 	}
@@ -116,6 +191,7 @@ func NewServer(svc *service.Service, defaultNS string) *mcpsdk.Server {
 			"(e.g. all procedural memories, or everything tagged/categorized X). Returns at " +
 			"most limit (default 20) newest-first; page with offset. For relevance-ranked " +
 			"search use memory_recall.",
+		InputSchema: listSchema,
 		Annotations: readOnly,
 	}, h.list)
 	mcpsdk.AddTool(s, &mcpsdk.Tool{
@@ -132,6 +208,7 @@ func NewServer(svc *service.Service, defaultNS string) *mcpsdk.Server {
 			"change; metadata merges key-by-key). Use to correct or enrich a fact — e.g. to fold " +
 			"a near-duplicate flagged by memory_remember's merge_hint into the surviving memory. " +
 			"To delete instead, use memory_forget.",
+		InputSchema: updateSchema,
 		Annotations: additive,
 	}, h.update)
 	mcpsdk.AddTool(s, &mcpsdk.Tool{
@@ -245,19 +322,22 @@ func (t *tools) ns(arg string) (string, error) {
 }
 
 type rememberArgs struct {
-	Content    string         `json:"content" jsonschema:"the text to remember"`
-	Tier       string         `json:"tier,omitempty" jsonschema:"working, episodic, semantic, or procedural (omit to auto-classify)"`
-	Level      string         `json:"level,omitempty" jsonschema:"explicit (user-stated) or deduced (LLM-distilled); omit to leave unset"`
-	Summary    string         `json:"summary,omitempty" jsonschema:"optional one-line summary"`
-	Tags       []string       `json:"tags,omitempty" jsonschema:"optional labels"`
-	Metadata   map[string]any `json:"metadata,omitempty" jsonschema:"optional structured metadata"`
-	Importance float64        `json:"importance,omitempty" jsonschema:"0..1 bias toward retention"`
-	TTLSeconds *int           `json:"ttl_seconds,omitempty" jsonschema:"overrides the tier default TTL; negative means never expire"`
-	ID         string         `json:"id,omitempty" jsonschema:"upserts an existing memory when provided"`
-	Confidence *float64       `json:"confidence,omitempty" jsonschema:"0..1 seed corroboration for a durable fact; omit for default"`
-	ValidFrom  string         `json:"valid_from,omitempty" jsonschema:"RFC3339 start of the fact's validity; backdate for as_of recall"`
-	ValidTo    string         `json:"valid_to,omitempty" jsonschema:"RFC3339 end of the fact's validity; omit if still true"`
-	Namespace  string         `json:"namespace,omitempty" jsonschema:"tenant namespace; defaults to the server namespace"`
+	Content string `json:"content" jsonschema:"the fact to store — atomic and self-contained, readable without this conversation's context"`
+	Tier    string `json:"tier,omitempty" jsonschema:"working, episodic, semantic, or procedural (omit to auto-classify)"`
+	Level   string `json:"level,omitempty" jsonschema:"provenance: explicit = user-stated, deduced = LLM-inferred; omit to leave unset"`
+	Summary string `json:"summary,omitempty" jsonschema:"optional one-line summary"`
+	//nolint:lll // the jsonschema description is agent-facing documentation and cannot be wrapped
+	Tags []string `json:"tags,omitempty" jsonschema:"topic labels for filtering and keyword search; tag a critical always-relevant fact 'pinned' so it surfaces in every session briefing"`
+	//nolint:lll // the jsonschema description is agent-facing documentation and cannot be wrapped
+	Metadata map[string]any `json:"metadata,omitempty" jsonschema:"structured key/values for later filtering; set 'category' to a topic bucket (e.g. bug_fixes, architecture_decisions, coding_conventions)"`
+	//nolint:lll // the jsonschema description is agent-facing documentation and cannot be wrapped
+	Importance float64  `json:"importance,omitempty" jsonschema:"0..1 ranking/retention bias — higher ranks higher and survives pruning longer; omit for the default"`
+	TTLSeconds *int     `json:"ttl_seconds,omitempty" jsonschema:"overrides the tier default TTL; negative means never expire"`
+	ID         string   `json:"id,omitempty" jsonschema:"upserts an existing memory when provided"`
+	Confidence *float64 `json:"confidence,omitempty" jsonschema:"0..1 seed corroboration for a durable fact; omit for default"`
+	ValidFrom  string   `json:"valid_from,omitempty" jsonschema:"RFC3339 start of the fact's validity; backdate for as_of recall"`
+	ValidTo    string   `json:"valid_to,omitempty" jsonschema:"RFC3339 end of the fact's validity; omit if still true"`
+	Namespace  string   `json:"namespace,omitempty" jsonschema:"tenant namespace; defaults to the server namespace"`
 }
 
 type rememberResult struct {
@@ -344,17 +424,20 @@ func (t *tools) remember(ctx context.Context, _ *mcpsdk.CallToolRequest, in reme
 }
 
 type recallArgs struct {
-	Query             string            `json:"query" jsonschema:"what to search for"`
-	Tiers             []string          `json:"tiers,omitempty" jsonschema:"restrict to tiers; empty means all"`
-	Levels            []string          `json:"levels,omitempty" jsonschema:"restrict to levels (explicit/deduced); empty means all"`
-	Tags              []string          `json:"tags,omitempty" jsonschema:"only memories carrying every listed tag (AND)"`
-	Metadata          map[string]string `json:"metadata,omitempty" jsonschema:"only memories whose metadata has each key=value pair (AND)"`
-	ExcludeMetadata   map[string]string `json:"exclude_metadata,omitempty" jsonschema:"inverse of metadata; drops matching memories"`
-	IncludeFreshTurns bool              `json:"include_fresh_turns,omitempty" jsonschema:"keep just-captured turns the echo guard would drop"`
-	QueryRewrite      bool              `json:"query_rewrite,omitempty" jsonschema:"rewrite query into 2-3 variants and fuse via RRF"`
-	Limit             int               `json:"limit,omitempty" jsonschema:"max results (default 10)"`
+	Query  string   `json:"query" jsonschema:"natural-language search text; short and descriptive works best (e.g. 'JWT auth setup')"`
+	Tiers  []string `json:"tiers,omitempty" jsonschema:"restrict to tiers; empty means all"`
+	Levels []string `json:"levels,omitempty" jsonschema:"restrict to levels (explicit/deduced); empty means all"`
+	Tags   []string `json:"tags,omitempty" jsonschema:"only memories carrying every listed tag (AND)"`
 	//nolint:lll // the jsonschema description is agent-facing documentation and cannot be wrapped
-	Scope     string `json:"scope,omitempty" jsonschema:"'subtree' also searches nested namespaces; default 'exact'; any other value is rejected as an error"`
+	Metadata map[string]string `json:"metadata,omitempty" jsonschema:"only memories whose metadata has each key=value pair (AND)"`
+	//nolint:lll // the jsonschema description is agent-facing documentation and cannot be wrapped
+	ExcludeMetadata map[string]string `json:"exclude_metadata,omitempty" jsonschema:"inverse of metadata; drops matching memories (e.g. {\"source\": \"turn_capture\"} hides auto-captured conversation turns)"`
+	//nolint:lll // the jsonschema description is agent-facing documentation and cannot be wrapped
+	IncludeFreshTurns bool `json:"include_fresh_turns,omitempty" jsonschema:"also return this session's just-captured conversation turns (hidden by default — they are still in your live context); only for 'what did I just say' queries"`
+	QueryRewrite      bool `json:"query_rewrite,omitempty" jsonschema:"rewrite query into 2-3 variants and fuse via RRF"`
+	Limit             int  `json:"limit,omitempty" jsonschema:"max results (default 10)"`
+	//nolint:lll // the jsonschema description is agent-facing documentation and cannot be wrapped
+	Scope     string `json:"scope,omitempty" jsonschema:"'subtree' also searches nested namespaces; default 'exact'"`
 	AsOf      string `json:"as_of,omitempty" jsonschema:"RFC3339 time for time-travel recall (facts true then)"`
 	Namespace string `json:"namespace,omitempty" jsonschema:"tenant namespace; defaults to the server namespace"`
 	//nolint:lll // the jsonschema description is agent-facing documentation and cannot be wrapped
@@ -488,7 +571,7 @@ type briefingArgs struct {
 	PerSectionRecent *int   `json:"per_section_recent,omitempty" jsonschema:"max recent episodic entries; 0 disables"`
 	Namespace        string `json:"namespace,omitempty" jsonschema:"tenant namespace; defaults to the server namespace"`
 	//nolint:lll // the jsonschema description is agent-facing documentation and cannot be wrapped
-	Scope string `json:"scope,omitempty" jsonschema:"'subtree' also includes namespaces nested under the namespace; default 'exact'; any other value is rejected as an error"`
+	Scope string `json:"scope,omitempty" jsonschema:"'subtree' also includes namespaces nested under the namespace; default 'exact'"`
 	//nolint:lll // the jsonschema description is agent-facing documentation and cannot be wrapped
 	Namespaces []string `json:"namespaces,omitempty" jsonschema:"brief exactly these namespaces instead of the default read set (namespace, its subtree, the tenant-shared namespace, and the global namespace); entry 'ns/*' also includes namespaces nested under ns; max 16; writes are unaffected"`
 }

--- a/internal/api/mcp/mcp_test.go
+++ b/internal/api/mcp/mcp_test.go
@@ -1193,6 +1193,52 @@ func TestToolDescriptions(t *testing.T) {
 	}
 }
 
+// TestServerInstructions pins that the initialize response carries the
+// cross-tool usage policy (briefing at session start, recall-before,
+// remember-after, the pinned/category conventions) — the only guidance a
+// bare MCP client sees beyond per-tool descriptions.
+func TestServerInstructions(t *testing.T) {
+	cs := connect(t)
+	instr := cs.InitializeResult().Instructions
+	if instr == "" {
+		t.Fatal("initialize result has no instructions")
+	}
+	for _, phrase := range []string{"memory_briefing", "memory_recall", "memory_remember", "pinned", "category", "memory_update"} {
+		if !strings.Contains(instr, phrase) {
+			t.Errorf("instructions missing %q", phrase)
+		}
+	}
+}
+
+// TestToolSchemaEnums pins that constrained string parameters advertise real
+// JSON Schema enums (not just prose), so clients can validate before calling.
+func TestToolSchemaEnums(t *testing.T) {
+	tools := listTools(t, service.WithAnswerer(&fakeAnswerer{resp: "n/a"}))
+	want := map[string][]string{
+		"memory_remember": {`"tier"`, `"enum":["working","episodic","semantic","procedural"]`},
+		"memory_recall":   {`"enum":["exact","subtree"]`, `"enum":["concise","detailed"]`},
+		"memory_briefing": {`"enum":["exact","subtree"]`},
+		"memory_answer":   {`"enum":["minimal","low","medium","high"]`},
+		"memory_list":     {`"enum":["working","episodic","semantic","procedural"]`},
+		"memory_update":   {`"enum":["working","episodic","semantic","procedural"]`},
+	}
+	for name, fragments := range want {
+		tool := tools[name]
+		if tool == nil {
+			t.Fatalf("%s: tool not found", name)
+		}
+		raw, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("%s: marshal schema: %v", name, err)
+		}
+		for _, frag := range fragments {
+			if !strings.Contains(string(raw), frag) {
+				t.Errorf("%s input schema missing %s, got: %s", name, frag, raw)
+			}
+		}
+	}
+}
+
 func TestToolAnnotations(t *testing.T) {
 	tools := listTools(t, service.WithAnswerer(&fakeAnswerer{resp: "n/a"}))
 	want := map[string]struct{ readOnly, destructive bool }{

--- a/plugin/scripts/_shared.mjs
+++ b/plugin/scripts/_shared.mjs
@@ -881,14 +881,18 @@ export const MEMORY_INSTRUCTION = `
 
 <memini-memory-directive>
 When you learn something durable worth persisting for future sessions (a
-decision, a fact, a convention, a gotcha), save it by calling the memini
-memory_remember MCP tool (tier "semantic", one memory per call).
+decision, a fact, a convention, a gotcha, a user preference), save it by
+calling the memini memory_remember MCP tool — one memory per call.
 
 Rules:
 - Each memory should be a self-contained fact, readable without this
   conversation's context.
+- tier: "semantic" for facts, decisions, and preferences; "procedural"
+  for how-tos and commands. Tag a critical, always-relevant fact "pinned"
+  so it surfaces in every session briefing.
 - Save nothing when nothing is worth keeping. This is reference memory,
-  not scratch space: prefer quality over quantity.
+  not scratch space: prefer quality over quantity, and skip anything
+  already in CLAUDE.md or project docs.
 - If a stale or wrong fact turns up (rather than a new one), correct it in
   place with the memory_update MCP tool instead of saving a duplicate.
 - Never print memory markup or JSON memory payloads in your reply text.
@@ -963,8 +967,10 @@ export function isRealUserMessage(content) {
   if (typeof content !== "string") return false; // arrays are tool_results, not user turns
   // Skipped: slash-command / local-command scaffolding, memini's own injected
   // recall blocks (<memini-context>/<memini-pretool> — capturing one would echo
-  // recalled memories back into memory), and hook-injected system reminders.
-  return !/^\s*<(local-command|command-|memini-|system-reminder)/.test(content);
+  // recalled memories back into memory), hook-injected system reminders, and
+  // harness-injected background-task events (<task-notification> /
+  // "[SYSTEM NOTIFICATION ...]"), which are not user turns.
+  return !/^\s*(<(local-command|command-|memini-|system-reminder|task-notification)|\[SYSTEM NOTIFICATION)/.test(content);
 }
 
 /**

--- a/plugin/scripts/_test.mjs
+++ b/plugin/scripts/_test.mjs
@@ -1366,6 +1366,9 @@ test("isRealUserMessage: strings pass, tool_result arrays and command noise skip
   assert.equal(isRealUserMessage('<memini-pretool tool="Read" read-only>x'), false);
   assert.equal(isRealUserMessage('<memini-context project="p" read-only>x'), false);
   assert.equal(isRealUserMessage("<system-reminder>injected</system-reminder>"), false);
+  // Harness-injected background-task events are not user turns either.
+  assert.equal(isRealUserMessage("<task-notification>\n<task-id>abc</task-id>"), false);
+  assert.equal(isRealUserMessage("[SYSTEM NOTIFICATION - NOT USER INPUT]\nThis is an automated event"), false);
 });
 
 test("extractLastTurn: returns the final user→assistant turn, skips noise", async () => {

--- a/plugin/scripts/stop.mjs
+++ b/plugin/scripts/stop.mjs
@@ -35,8 +35,9 @@ const DEFAULT_INTERVAL = 10;
 const autoSaveReason = (n) =>
   `[memini auto-save] ${n} user messages since the last save. Before stopping, ` +
   `review this conversation for durable decisions, facts, and user preferences, ` +
-  `and persist each with the memini memory_remember MCP tool (tier "semantic", ` +
-  `one memory per item). If nothing new is worth keeping, just stop again.`;
+  `and persist each with the memini memory_remember MCP tool (tier "semantic" ` +
+  `for facts/decisions, "procedural" for how-tos; one memory per item). ` +
+  `If nothing new is worth keeping, just stop again.`;
 
 /** Count real user messages in a Claude Code transcript (JSONL string). */
 function countUserMessages(raw) {

--- a/plugin/skills/recall/SKILL.md
+++ b/plugin/skills/recall/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   current task. Use this skill when the user asks "what do you know
   about X", "did we discuss Y before", or before starting work that may
   have prior context (a file edit, an architectural change, debugging a
-  recurring issue). The MCP tool name is `memory_recall`.
+  recurring issue). The MCP tool is `memory_recall` on the bundled `memini` server.
 ---
 
 # recall (memini)

--- a/plugin/skills/recap/SKILL.md
+++ b/plugin/skills/recap/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Summarize what's known about a project, area, or topic from memini. Use
   this skill when the user asks "catch me up on X", "what's the state of
   Y", or "summarize what we know about Z". Builds on recall with a
-  larger limit and tiered grouping. The MCP tool name is `memory_recall`.
+  larger limit and tiered grouping. The MCP tool is `memory_recall` on the bundled `memini` server.
 ---
 
 # recap (memini)

--- a/plugin/skills/remember/SKILL.md
+++ b/plugin/skills/remember/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   proactively when the user says "remember this", after discovering a bug,
   after making an architectural decision, after learning a project
   convention, or whenever something learned in this session should outlive
-  the session itself. The MCP tool name is `memory_remember`.
+  the session itself. The MCP tool is `memory_remember` on the bundled `memini` server.
 ---
 
 # remember (memini)


### PR DESCRIPTION
I spent some time auditing every string memini shows to a model (tool descriptions, parameter schemas, the plugin's injected directives, the integration plugins) against Anthropic's tool-writing and skill-authoring guidance and the MCP spec, and then checked the theory against a real deployment: my production memini instance, running 0.6.4, with 182 memories accumulated across 8 namespaces. The good news is that the existing descriptions hold up well. The trigger language ("call BEFORE starting work that may have history"), the degraded-mode caveats, and the read-only framing on injected blocks are all things the guidance recommends and memini already does. But the live data surfaced a handful of gaps where the prompts and reality disagree, and they were all measurable in the stored data.

## What the deployment data showed

**The `pinned` tag was used once in 182 memories, and `metadata.category` almost never.** Every session briefing was rendering with an empty Pinned section. The interesting part is *why*: both conventions are taught only in the optional `remember` skill, which a model frequently never loads before calling `memory_remember` directly. The one namespace where categories were set consistently (20 of 24 memories) was the one where I had explicitly asked the agent to tag things properly in the prompt. So models follow these conventions fine when told; the tool schema just never tells them.

**The procedural tier was starving: 7 procedural vs 89 semantic.** Clearly procedural content (toolchain workarounds, command recipes) was sitting in the semantic tier. This traces directly to the plugin's session-start directive and auto-save nudge, which both hard-coded `tier "semantic"` for every save.

**7 of 31 auto-captured turns in my main namespace were junk.** `isRealUserMessage` predates background-task notifications, so `<task-notification>` and `[SYSTEM NOTIFICATION - NOT USER INPUT]` blocks from the harness were being captured as episodic "user" turns, complete with task ids and output-file paths, and then surfacing in recall results and the briefing's recent-activity section.

## What changed and why

**The MCP server now sends `instructions` in the initialize response** (`NewServer` was passing nil options). Per-tool descriptions are read in isolation during tool selection, so they can't express cross-tool policy: call `memory_briefing` at session start, recall before work that may have history, remember proactively, correct with `memory_update` instead of writing near-duplicates. Server instructions are the one place that policy can live for a bare MCP client that doesn't have the plugin's hooks and skills. This is also where `pinned` and `metadata.category` are now taught, alongside the parameter descriptions themselves (`tags` and `metadata` now carry the conventions in the schema, where every client sees them).

**Constrained params now carry real JSON Schema enums.** `tier`, `level`, `scope`, `response_format`, `reasoning_level`, and the `tiers`/`levels` filter items previously documented their legal values in prose ("any other value is rejected as an error"). jsonschema struct tags can only hold a description, so the enums are applied by building the inferred schema explicitly and setting them via `Tool.InputSchema` before `AddTool` (see `enumSchema` in mcp.go). One wrinkle worth knowing about: for an `omitempty` slice the enum has to go on `Items`, and the check has to be `Items != nil` rather than `Type == "array"`, because the inferred schema uses the multi-type `Types` field there. Getting that wrong makes every filtered call fail schema validation, which the new tests would catch. A side effect of this change is that invalid enum values are now rejected by the SDK's schema validation before reaching the handler, so the error text for a bad tier differs from the old server-side message. The server-side validation stays as a backstop.

**Recall's description drops the `exclude_metadata` session-id advice.** It told the model to pass its own session id to avoid seeing its captured turns echoed back, but a model has no way to know its session id, the plugin's hooks already exclude it client side, and the server has a temporal echo guard on top. It was dead weight in every session's token budget. `exclude_metadata` keeps a usable example instead.

**The plugin directives are tier-aware and the capture filter is stricter.** The session-start directive and auto-save nudge now route facts/decisions/preferences to semantic and how-tos to procedural, teach `pinned`, and tell the model to skip anything already covered by CLAUDE.md or project docs. `isRealUserMessage` rejects the two harness-notification shapes above, with test cases for both.

**The REST integrations stop recommending forget-and-re-remember for corrections.** openclaw, pi, hermes, and openwebui all claimed the only way to correct a fact over REST is to delete it and write a replacement, because there is no partial-update endpoint. That's technically true but stale in effect: `POST /v1/memories` upserts when given an `id`, which keeps the memory's identity and history where forget+re-remember destroys both. All four now accept an optional `id` on `memory_remember`, their forget descriptions point there, and `integrations/README.md` explains the actual distinction (the MCP `memory_update` merges field by field, the REST upsert replaces what you send). While in there I also ported the stronger trigger language these descriptions had fallen behind on ("empty results mean nothing is known, never invent a remembered fact", the don't-store-what's-in-docs caveat, and `pinned`).

One drive-by fix: the openclaw `helpers.test.ts` mock was missing `deleteJson`, so `pnpm typecheck` in that package was already failing on main before this branch. The mock now implements it.

## Verification

- `go build ./...` and `go test ./...` pass (new tests pin the instructions on initialize and the enums on tools/list, alongside the existing description-phrase pins)
- `golangci-lint` v2.12.2 (the CI version) reports 0 issues
- `node --test plugin/scripts/_test.mjs`: 60 pass, including the two new `isRealUserMessage` cases
- `pnpm -r build`, `pnpm -r typecheck`, `pnpm -r test`: all green (openclaw 53+41, pi 15, namespace-resolver 33)
- hermes `python3 -m unittest`: 38 pass
- stdio smoke test against the built binary: initialize carries the instructions, tools/list shows the enums and the new parameter descriptions on the wire

Happy to split this into separate PRs if you'd rather take the server changes and the integration changes independently; the three commits are already cut along those lines.
