### PR TITLE
Activity log: record what memory was served and why, plus browse/activity filters

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -137,9 +137,42 @@ paths:
           description: >
             Aggregate across every namespace, ignoring the namespace header. The
             server merges all namespaces and applies limit as a single global cap
-            (newest first), so the admin UI's "All projects" view fetches one
-            response instead of one request per namespace.
+            under the requested sort, so the admin UI's "All projects" view fetches
+            one response instead of one request per namespace.
           schema: { type: boolean, default: false }
+        - name: namespace
+          in: query
+          description: >
+            With all_namespaces=true, restrict the aggregate to these namespaces
+            (repeatable, exact match); ignored otherwise. Lets the browser narrow
+            an "All projects" listing without changing the active namespace.
+          schema: { type: array, items: { type: string } }
+        - name: memory_type
+          in: query
+          description: >
+            Repeatable and/or comma-separated metadata.memory_type filter; a memory
+            matches if its type is ANY of the listed values (OR). Distinct from
+            "meta", which ANDs one value per key.
+          schema: { type: array, items: { type: string } }
+        - name: created_after
+          in: query
+          description: Only memories created at or after this instant.
+          schema: { type: string, format: date-time }
+        - name: accessed_after
+          in: query
+          description: Only memories last accessed at or after this instant.
+          schema: { type: string, format: date-time }
+        - name: sort
+          in: query
+          description: Column to order by. Defaults to created_at.
+          schema:
+            type: string
+            enum: [created_at, updated_at, last_accessed_at, access_count, importance]
+            default: created_at
+        - name: order
+          in: query
+          description: Sort direction. Defaults to desc (newest / highest first).
+          schema: { type: string, enum: [asc, desc], default: desc }
       responses:
         "200":
           description: OK
@@ -725,6 +758,72 @@ paths:
         "404": { $ref: "#/components/responses/Error" }
         "409": { $ref: "#/components/responses/Error" }
         "501": { $ref: "#/components/responses/Error" }
+  /v1/activity:
+    get:
+      operationId: listActivity
+      tags: [memory]
+      summary: Recent memory activity — what was served or written, and why
+      description: >
+        The activity log: reads (recall, get, session briefing) and writes
+        (remember, update, forget, supersede), newest first. A recall event
+        carries the query that ran and, for each memory it served, the rank and
+        composite score it was served at — the "why" that per-memory access
+        counters cannot reconstruct. Events are grouped by operation, so one
+        recall serving five memories is one event with five memories.
+
+        Returns 501 against a storage backend with no activity log.
+      parameters:
+        - { $ref: "#/components/parameters/Namespace" }
+        - name: kind
+          in: query
+          description: Repeatable and/or comma-separated event-kind filter; omitted means all kinds.
+          schema: { type: array, items: { $ref: "#/components/schemas/EventKind" } }
+        - name: tier
+          in: query
+          description: >
+            Repeatable and/or comma-separated tier filter. Selects whole
+            operations that touched a memory of a listed tier — a matching event
+            is returned with every memory it served, so its counts stay truthful.
+          schema: { type: array, items: { $ref: "#/components/schemas/Tier" } }
+        - name: q
+          in: query
+          description: >
+            Free-text filter, case-insensitive. Selects whole operations whose
+            recall query or any served memory's summary contains it.
+          schema: { type: string }
+        - name: since
+          in: query
+          description: Only events recorded at or after this instant.
+          schema: { type: string, format: date-time }
+        - name: namespace
+          in: query
+          description: >
+            With all_namespaces=true, restrict the feed to these namespaces
+            (repeatable, exact match); ignored otherwise.
+          schema: { type: array, items: { type: string } }
+        - name: limit
+          in: query
+          description: Caps the returned events (operations, not rows). Default 50, max 200.
+          schema: { type: integer }
+        - name: before
+          in: query
+          description: >
+            Opaque cursor from a previous response's next_cursor; returns the page
+            of events strictly older than it.
+          schema: { type: string }
+        - name: all_namespaces
+          in: query
+          description: Aggregate across every namespace, ignoring the namespace header.
+          schema: { type: boolean, default: false }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ActivityResponse" }
+        "400": { $ref: "#/components/responses/Error" }
+        "401": { $ref: "#/components/responses/Error" }
+        "501": { $ref: "#/components/responses/Error" }
 components:
   securitySchemes:
     bearerAuth:
@@ -1005,6 +1104,68 @@ components:
         memories:
           type: array
           items: { $ref: "#/components/schemas/Memory" }
+    EventKind:
+      type: string
+      description: >
+        The operation an activity event records. Reads: recall, get, briefing.
+        Writes: remember, update, forget, supersede.
+      enum: [recall, get, briefing, remember, update, forget, supersede]
+    ActivityMemory:
+      type: object
+      description: >
+        One memory as it appeared in an event — a snapshot taken at serve time,
+        so a forgotten memory still renders — plus why it was there.
+      required: [id, namespace, summary, tier]
+      properties:
+        id: { type: string }
+        namespace:
+          type: string
+          description: The memory's own namespace, which for a cascading recall may differ from the event's.
+        summary: { type: string }
+        tier: { $ref: "#/components/schemas/Tier" }
+        rank:
+          type: integer
+          description: 1-based position the memory was served at; absent when not applicable.
+        score:
+          type: number
+          format: double
+          description: Composite relevance score it was served with; recall only.
+        section:
+          type: string
+          description: Which briefing section it appeared under; briefing only.
+    ActivityEvent:
+      type: object
+      description: One logical operation, with the memories it served or wrote.
+      required: [op_id, kind, time, namespace]
+      properties:
+        op_id: { type: string }
+        kind: { $ref: "#/components/schemas/EventKind" }
+        time: { type: string, format: date-time }
+        namespace:
+          type: string
+          description: The namespace the request was made against.
+        query:
+          type: string
+          description: The recall query; absent for every other kind.
+        detail:
+          type: object
+          additionalProperties: true
+          description: Kind-specific context — a recall's degraded mode, a supersession's replacement id.
+        memories:
+          type: array
+          description: Empty for a recall that matched nothing.
+          items: { $ref: "#/components/schemas/ActivityMemory" }
+    ActivityResponse:
+      type: object
+      required: [events, has_more]
+      properties:
+        events:
+          type: array
+          items: { $ref: "#/components/schemas/ActivityEvent" }
+        next_cursor:
+          type: string
+          description: Pass as "before" to fetch the next page; absent on the last page.
+        has_more: { type: boolean }
     Briefing:
       type: object
       required: [namespace]

--- a/cmd/memini/root.go
+++ b/cmd/memini/root.go
@@ -339,6 +339,7 @@ func buildServiceStack(
 		service.WithRecallSemanticReserve(cfg.RecallSemanticReserve),
 		service.WithTurnEchoWindow(cfg.TurnEchoWindow),
 		service.WithEpisodicMinChars(cfg.EpisodicMinChars),
+		service.WithEventLog(cfg.ActivityLog),
 		// Write-time fact building self-selects: distill (LLM) no-ops without a
 		// consolidator; extract (heuristic) only fires when no LLM is configured.
 		service.WithDistillOnWrite(true),
@@ -365,10 +366,12 @@ func buildServiceStack(
 	workers.Go(func() { svc.RunPromoter(workerCtx, cfg.PromoteInterval) })
 	workers.Go(func() { svc.RunEmbedBackfill(workerCtx, cfg.BackfillInterval) })
 	sweeper := maintenance.NewSweeper(st, log, maintenance.SweeperConfig{
-		Interval:     cfg.SweepInterval,
-		ShortTermCap: cfg.ShortTermCap,
-		TombstoneTTL: cfg.TombstoneTTL,
-		DemoteAfter:  cfg.DemoteAfter,
+		Interval:          cfg.SweepInterval,
+		ShortTermCap:      cfg.ShortTermCap,
+		TombstoneTTL:      cfg.TombstoneTTL,
+		DemoteAfter:       cfg.DemoteAfter,
+		ActivityRetention: cfg.ActivityRetention,
+		ActivityMaxRows:   cfg.ActivityMaxRows,
 	})
 	workers.Go(func() { sweeper.Run(workerCtx) })
 	if cfg.DedupInterval > 0 {

--- a/internal/api/mcp/mcp.go
+++ b/internal/api/mcp/mcp.go
@@ -363,8 +363,11 @@ func HTTPHandlerWithAuth(svc *service.Service, nsHeader, defaultNS, homeHeader s
 		// changing it is out of scope here.
 		home := httputil.NormalizeNamespace(r.Header.Get(homeHeader))
 		if p.HomeNS != "" {
-			if home != "" && home != p.HomeNS {
-				slog.DebugContext(r.Context(), "X-Memini-Home ignored: request key is bound to a home namespace",
+			if warn := httputil.HomeConflictWarning(p.Name, p.HomeNS, home); warn != "" {
+				// Warn, don't whisper: the caller asked for one home namespace and
+				// is getting another. The outer handler also puts this on the
+				// response as X-Memini-Warning (it holds the ResponseWriter).
+				slog.WarnContext(r.Context(), "X-Memini-Home ignored: request key is bound to a home namespace",
 					"key", p.Name, "key_home", p.HomeNS, "header_home", home)
 			}
 			home = p.HomeNS
@@ -405,6 +408,12 @@ func HTTPHandlerWithAuth(svc *service.Service, nsHeader, defaultNS, homeHeader s
 		}
 		if p != nil {
 			r = r.WithContext(context.WithValue(r.Context(), mcpPrincipalKey, *p))
+			// Surface a home-header override on the response, as REST does: the
+			// getServer callback above logs it but never sees the ResponseWriter.
+			if warn := httputil.HomeConflictWarning(p.Name, p.HomeNS,
+				httputil.NormalizeNamespace(r.Header.Get(homeHeader))); warn != "" {
+				w.Header().Set(httputil.WarningHeader, warn)
+			}
 		}
 		h.ServeHTTP(w, r)
 	})

--- a/internal/api/rest/activity.go
+++ b/internal/api/rest/activity.go
@@ -1,0 +1,156 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/eleboucher/memini/internal/httputil"
+	"github.com/eleboucher/memini/internal/service"
+	"github.com/eleboucher/memini/internal/store"
+)
+
+// eventLogStore type-asserts the backing store to store.EventLogStore, the
+// optional capability the activity log requires (sqlitevec and postgres both
+// implement it). Returns false — a 501 to the caller — for a driver that
+// predates it, mirroring linkStore's graceful degrade.
+func (h *Server) eventLogStore() bool {
+	_, ok := h.svc.Store().(store.EventLogStore)
+	return ok
+}
+
+// ListActivity implements GET /v1/activity: the newest page of the activity
+// log, grouped into whole operations.
+func (h *Server) ListActivity(w http.ResponseWriter, r *http.Request, params ListActivityParams) {
+	if !h.eventLogStore() {
+		httputil.Error(w, http.StatusNotImplemented,
+			"the activity log is not supported by this storage backend")
+		return
+	}
+	kinds, err := queryEventKinds(params.Kind)
+	if err != nil {
+		httputil.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	tiers, err := queryTiers(params.Tier)
+	if err != nil {
+		httputil.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	in := service.EventsInput{
+		Kinds: kinds,
+		Tiers: tiers,
+		Text:  strings.TrimSpace(deref(params.Q)),
+		Since: deref(params.Since),
+	}
+	// An aggregate view ignores the namespace header entirely; a scoped one is
+	// pinned to it, exactly as the memory listing behaves. The namespace filter
+	// only narrows the aggregate — with a header-scoped feed there is nothing
+	// left to narrow.
+	if deref(params.AllNamespaces) {
+		in.Namespaces = deref(params.Namespace)
+	} else {
+		in.Namespace = namespaceFromContext(r.Context())
+	}
+	if params.Limit != nil {
+		if *params.Limit < 0 {
+			httputil.Error(w, http.StatusBadRequest, fmt.Sprintf("invalid limit %d", *params.Limit))
+			return
+		}
+		in.Limit = *params.Limit
+	}
+	if params.Before != nil && *params.Before != "" {
+		before, beforeID, err := decodeCursor(*params.Before)
+		if err != nil {
+			httputil.Error(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		in.Before, in.BeforeID = before, beforeID
+	}
+
+	page, err := h.svc.Events(r.Context(), in)
+	if err != nil {
+		writeError(w, r, statusFor(err), err)
+		return
+	}
+
+	out := ActivityResponse{
+		Events:  make([]ActivityEvent, len(page.Events)),
+		HasMore: page.HasMore,
+	}
+	for i, ev := range page.Events {
+		out.Events[i] = apiActivityEvent(ev)
+	}
+	if page.HasMore {
+		cursor := encodeCursor(page.NextBefore, page.NextBeforeID)
+		out.NextCursor = &cursor
+	}
+	httputil.JSON(w, http.StatusOK, out)
+}
+
+// apiActivityEvent maps a service event onto the wire shape.
+func apiActivityEvent(ev service.ActivityEvent) ActivityEvent {
+	out := ActivityEvent{
+		OpId:      ev.OpID,
+		Kind:      EventKind(ev.Kind),
+		Time:      ev.Time,
+		Namespace: ev.Namespace,
+	}
+	if ev.Query != "" {
+		q := ev.Query
+		out.Query = &q
+	}
+	if len(ev.Detail) > 0 {
+		d := ev.Detail
+		out.Detail = &d
+	}
+	if len(ev.Memories) > 0 {
+		mems := make([]ActivityMemory, len(ev.Memories))
+		for i, m := range ev.Memories {
+			am := ActivityMemory{
+				Id:        m.ID,
+				Namespace: m.Namespace,
+				Summary:   m.Summary,
+				Tier:      Tier(m.Tier),
+				Score:     m.Score,
+			}
+			if m.Rank > 0 {
+				rank := m.Rank
+				am.Rank = &rank
+			}
+			if m.Section != "" {
+				sec := m.Section
+				am.Section = &sec
+			}
+			mems[i] = am
+		}
+		out.Memories = &mems
+	}
+	return out
+}
+
+// encodeCursor renders a keyset position as an opaque "<unixmilli>-<id>" token.
+// It is opaque by contract — clients round-trip it verbatim — so its shape can
+// change without a spec change.
+func encodeCursor(t time.Time, id int64) string {
+	return strconv.FormatInt(t.UnixMilli(), 10) + "-" + strconv.FormatInt(id, 10)
+}
+
+// decodeCursor parses a token produced by encodeCursor.
+func decodeCursor(s string) (time.Time, int64, error) {
+	ms, idStr, ok := strings.Cut(s, "-")
+	if !ok {
+		return time.Time{}, 0, fmt.Errorf("invalid cursor %q", s)
+	}
+	msec, err := strconv.ParseInt(ms, 10, 64)
+	if err != nil {
+		return time.Time{}, 0, fmt.Errorf("invalid cursor %q", s)
+	}
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		return time.Time{}, 0, fmt.Errorf("invalid cursor %q", s)
+	}
+	return time.UnixMilli(msec).UTC(), id, nil
+}

--- a/internal/api/rest/activity_test.go
+++ b/internal/api/rest/activity_test.go
@@ -1,0 +1,305 @@
+package rest_test
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/eleboucher/memini/internal/api/rest"
+	"github.com/eleboucher/memini/internal/embed/embedtest"
+	"github.com/eleboucher/memini/internal/memory"
+	"github.com/eleboucher/memini/internal/service"
+	"github.com/eleboucher/memini/internal/store/sqlitevec"
+)
+
+// activityEvent mirrors the ActivityEvent wire shape for assertions.
+type activityEvent struct {
+	OpID      string         `json:"op_id"`
+	Kind      string         `json:"kind"`
+	Namespace string         `json:"namespace"`
+	Query     string         `json:"query"`
+	Detail    map[string]any `json:"detail"`
+	Memories  []struct {
+		ID      string   `json:"id"`
+		Summary string   `json:"summary"`
+		Tier    string   `json:"tier"`
+		Rank    int      `json:"rank"`
+		Score   *float64 `json:"score"`
+		Section string   `json:"section"`
+	} `json:"memories"`
+}
+
+type activityResponse struct {
+	Events     []activityEvent `json:"events"`
+	NextCursor string          `json:"next_cursor"`
+	HasMore    bool            `json:"has_more"`
+}
+
+// newActivityServer is newServer with the activity log on and synchronous, so
+// a request's events are visible to the next request.
+func newActivityServer(t *testing.T) http.Handler {
+	t.Helper()
+	st, err := sqlitevec.Open(context.Background(), filepath.Join(t.TempDir(), "activity.db"), dims)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	svc := service.New(st, embedtest.New(dims),
+		service.WithEventLog(true), service.WithSyncEventLog(), service.WithSyncReinforce())
+	r := chi.NewRouter()
+	rest.New(svc, rest.AuthConfig{
+		APIKey: apiKey, NamespaceHeader: nsHdr, DefaultNamespace: "default", HomeHeader: homeHdr,
+	}).Mount(r)
+	return r
+}
+
+func TestListActivity(t *testing.T) {
+	h := newActivityServer(t)
+
+	rec := do(t, h, http.MethodPost, "/v1/memories", "acme", apiKey, map[string]any{
+		"content": "the database is postgres", "tier": string(memory.TierSemantic),
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("remember: want 201, got %d (%s)", rec.Code, rec.Body)
+	}
+	rec = do(t, h, http.MethodPost, "/v1/search", "acme", apiKey, map[string]any{
+		"query": "which database", "limit": 5,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("search: want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+
+	t.Run("feed carries the recall query, rank and score", func(t *testing.T) {
+		rec := do(t, h, http.MethodGet, "/v1/activity?kind=recall", "acme", apiKey, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d (%s)", rec.Code, rec.Body)
+		}
+		var out activityResponse
+		mustJSON(t, rec, &out)
+		if len(out.Events) != 1 {
+			t.Fatalf("got %d recall events, want 1", len(out.Events))
+		}
+		ev := out.Events[0]
+		if ev.Kind != "recall" || ev.Query != "which database" {
+			t.Fatalf("event = %+v, want a recall of %q", ev, "which database")
+		}
+		if len(ev.Memories) != 1 {
+			t.Fatalf("recall served %d memories, want 1", len(ev.Memories))
+		}
+		m := ev.Memories[0]
+		if m.Rank != 1 || m.Score == nil {
+			t.Errorf("memory = %+v, want rank 1 with a score", m)
+		}
+		if m.Summary != "the database is postgres" {
+			t.Errorf("summary snapshot = %q", m.Summary)
+		}
+	})
+
+	t.Run("kind filter", func(t *testing.T) {
+		rec := do(t, h, http.MethodGet, "/v1/activity?kind=remember", "acme", apiKey, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d (%s)", rec.Code, rec.Body)
+		}
+		var out activityResponse
+		mustJSON(t, rec, &out)
+		if len(out.Events) != 1 || out.Events[0].Kind != "remember" {
+			t.Fatalf("kind=remember returned %+v", out.Events)
+		}
+	})
+
+	t.Run("comma-separated kinds", func(t *testing.T) {
+		rec := do(t, h, http.MethodGet, "/v1/activity?kind=recall,remember", "acme", apiKey, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d (%s)", rec.Code, rec.Body)
+		}
+		var out activityResponse
+		mustJSON(t, rec, &out)
+		if len(out.Events) != 2 {
+			t.Fatalf("got %d events, want 2", len(out.Events))
+		}
+	})
+
+	t.Run("unknown kind is a 400", func(t *testing.T) {
+		rec := do(t, h, http.MethodGet, "/v1/activity?kind=bogus", "acme", apiKey, nil)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("want 400 for an unknown kind, got %d (%s)", rec.Code, rec.Body)
+		}
+	})
+
+	t.Run("namespace scoping", func(t *testing.T) {
+		// A different namespace sees none of acme's activity.
+		rec := do(t, h, http.MethodGet, "/v1/activity", "other", apiKey, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d (%s)", rec.Code, rec.Body)
+		}
+		var out activityResponse
+		mustJSON(t, rec, &out)
+		if len(out.Events) != 0 {
+			t.Fatalf("namespace 'other' sees %d of acme's events", len(out.Events))
+		}
+		// all_namespaces aggregates regardless of the header.
+		rec = do(t, h, http.MethodGet, "/v1/activity?all_namespaces=true", "other", apiKey, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d (%s)", rec.Code, rec.Body)
+		}
+		mustJSON(t, rec, &out)
+		if len(out.Events) == 0 {
+			t.Fatal("all_namespaces=true returned nothing")
+		}
+	})
+
+	t.Run("pagination round trip", func(t *testing.T) {
+		rec := do(t, h, http.MethodGet, "/v1/activity?limit=1", "acme", apiKey, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d (%s)", rec.Code, rec.Body)
+		}
+		var page1 activityResponse
+		mustJSON(t, rec, &page1)
+		if len(page1.Events) != 1 || !page1.HasMore || page1.NextCursor == "" {
+			t.Fatalf("page 1 = %+v, want 1 event, has_more and a cursor", page1)
+		}
+		rec = do(t, h, http.MethodGet, "/v1/activity?limit=1&before="+page1.NextCursor, "acme", apiKey, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("page 2: want 200, got %d (%s)", rec.Code, rec.Body)
+		}
+		var page2 activityResponse
+		mustJSON(t, rec, &page2)
+		if len(page2.Events) != 1 {
+			t.Fatalf("page 2 returned %d events, want 1", len(page2.Events))
+		}
+		if page2.Events[0].OpID == page1.Events[0].OpID {
+			t.Fatal("the cursor re-returned page 1's event")
+		}
+	})
+
+	t.Run("malformed cursor is a 400", func(t *testing.T) {
+		rec := do(t, h, http.MethodGet, "/v1/activity?before=nonsense", "acme", apiKey, nil)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("want 400 for a malformed cursor, got %d (%s)", rec.Code, rec.Body)
+		}
+	})
+}
+
+// TestListActivityFilters covers the feed's filters, and in particular that
+// tier and text select whole operations: a filtered recall must still report
+// every memory it served, not just the ones that matched the filter.
+func TestListActivityFilters(t *testing.T) {
+	h := newActivityServer(t)
+
+	seed := func(content string, tier memory.Tier) {
+		t.Helper()
+		rec := do(t, h, http.MethodPost, "/v1/memories", "acme", apiKey, map[string]any{
+			"content": content, "tier": string(tier),
+		})
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("seed %q: %d (%s)", content, rec.Code, rec.Body)
+		}
+	}
+	seed("the production database is postgres", memory.TierSemantic)
+	seed("ran the database migration today", memory.TierEpisodic)
+
+	// One recall spanning both tiers.
+	rec := do(t, h, http.MethodPost, "/v1/search", "acme", apiKey, map[string]any{
+		"query": "database", "limit": 10,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("search: %d (%s)", rec.Code, rec.Body)
+	}
+
+	get := func(t *testing.T, query string) activityResponse {
+		t.Helper()
+		rec := do(t, h, http.MethodGet, "/v1/activity"+query, "acme", apiKey, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET %s: want 200, got %d (%s)", query, rec.Code, rec.Body)
+		}
+		var out activityResponse
+		mustJSON(t, rec, &out)
+		return out
+	}
+
+	// How many memories the unfiltered recall served — the number a tier-filtered
+	// view must keep reporting.
+	base := get(t, "?kind=recall")
+	if len(base.Events) != 1 {
+		t.Fatalf("expected 1 recall event, got %d", len(base.Events))
+	}
+	served := len(base.Events[0].Memories)
+	if served < 2 {
+		t.Fatalf("recall served %d memories, want both seeded tiers", served)
+	}
+
+	t.Run("tier selects whole operations", func(t *testing.T) {
+		// The recall touched a semantic memory, so it matches — and comes back
+		// whole. Returning only its semantic row would misreport the recall as
+		// having served fewer memories than it did.
+		out := get(t, "?kind=recall&tier=semantic")
+		if len(out.Events) != 1 {
+			t.Fatalf("tier=semantic returned %d recall events, want 1", len(out.Events))
+		}
+		if got := len(out.Events[0].Memories); got != served {
+			t.Fatalf("tier-filtered recall reports %d memories, want all %d it actually served",
+				got, served)
+		}
+		// A tier nothing touched matches nothing.
+		if out := get(t, "?tier=working"); len(out.Events) != 0 {
+			t.Fatalf("tier=working matched %d events, want 0", len(out.Events))
+		}
+	})
+
+	t.Run("text filter", func(t *testing.T) {
+		// Matches the recall's query...
+		if out := get(t, "?q=database&kind=recall"); len(out.Events) != 1 {
+			t.Fatalf("q=database matched %d recall events, want 1", len(out.Events))
+		}
+		// ...and a served memory's summary, case-insensitively.
+		if out := get(t, "?q=POSTGRES"); len(out.Events) == 0 {
+			t.Fatal("q=POSTGRES matched nothing; the text filter should be case-insensitive")
+		}
+		if out := get(t, "?q=kangaroo"); len(out.Events) != 0 {
+			t.Fatalf("q=kangaroo matched %d events, want 0", len(out.Events))
+		}
+	})
+
+	t.Run("since window", func(t *testing.T) {
+		if out := get(t, "?since=2020-01-01T00:00:00Z"); len(out.Events) == 0 {
+			t.Fatal("since=2020 matched nothing, want the recent events")
+		}
+		if out := get(t, "?since=2030-01-01T00:00:00Z"); len(out.Events) != 0 {
+			t.Fatalf("since=2030 matched %d events, want 0", len(out.Events))
+		}
+	})
+
+	t.Run("invalid tier is a 400", func(t *testing.T) {
+		rec := do(t, h, http.MethodGet, "/v1/activity?tier=bogus", "acme", apiKey, nil)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("want 400 for an unknown tier, got %d (%s)", rec.Code, rec.Body)
+		}
+	})
+
+	t.Run("namespace narrowing in all_namespaces mode", func(t *testing.T) {
+		rec := do(t, h, http.MethodPost, "/v1/memories", "other", apiKey, map[string]any{
+			"content": "a memory elsewhere", "tier": string(memory.TierSemantic),
+		})
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("seed other ns: %d (%s)", rec.Code, rec.Body)
+		}
+		rec = do(t, h, http.MethodGet, "/v1/activity?all_namespaces=true&namespace=other", "acme", apiKey, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d (%s)", rec.Code, rec.Body)
+		}
+		var out activityResponse
+		mustJSON(t, rec, &out)
+		if len(out.Events) == 0 {
+			t.Fatal("namespace=other matched nothing")
+		}
+		for _, ev := range out.Events {
+			if ev.Namespace != "other" {
+				t.Fatalf("namespace=other leaked an event from %q", ev.Namespace)
+			}
+		}
+	})
+}

--- a/internal/api/rest/api.gen.go
+++ b/internal/api/rest/api.gen.go
@@ -63,6 +63,39 @@ func (e ApiKeySource) Valid() bool {
 	}
 }
 
+// Defines values for EventKind.
+const (
+	EventKindBriefing  EventKind = "briefing"
+	EventKindForget    EventKind = "forget"
+	EventKindGet       EventKind = "get"
+	EventKindRecall    EventKind = "recall"
+	EventKindRemember  EventKind = "remember"
+	EventKindSupersede EventKind = "supersede"
+	EventKindUpdate    EventKind = "update"
+)
+
+// Valid indicates whether the value is a known member of the EventKind enum.
+func (e EventKind) Valid() bool {
+	switch e {
+	case EventKindBriefing:
+		return true
+	case EventKindForget:
+		return true
+	case EventKindGet:
+		return true
+	case EventKindRecall:
+		return true
+	case EventKindRemember:
+		return true
+	case EventKindSupersede:
+		return true
+	case EventKindUpdate:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for Level.
 const (
 	Deduced  Level = "deduced"
@@ -159,6 +192,51 @@ func (e Tier) Valid() bool {
 	}
 }
 
+// Defines values for ListMemoriesParamsSort.
+const (
+	AccessCount    ListMemoriesParamsSort = "access_count"
+	CreatedAt      ListMemoriesParamsSort = "created_at"
+	Importance     ListMemoriesParamsSort = "importance"
+	LastAccessedAt ListMemoriesParamsSort = "last_accessed_at"
+	UpdatedAt      ListMemoriesParamsSort = "updated_at"
+)
+
+// Valid indicates whether the value is a known member of the ListMemoriesParamsSort enum.
+func (e ListMemoriesParamsSort) Valid() bool {
+	switch e {
+	case AccessCount:
+		return true
+	case CreatedAt:
+		return true
+	case Importance:
+		return true
+	case LastAccessedAt:
+		return true
+	case UpdatedAt:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListMemoriesParamsOrder.
+const (
+	Asc  ListMemoriesParamsOrder = "asc"
+	Desc ListMemoriesParamsOrder = "desc"
+)
+
+// Valid indicates whether the value is a known member of the ListMemoriesParamsOrder enum.
+func (e ListMemoriesParamsOrder) Valid() bool {
+	switch e {
+	case Asc:
+		return true
+	case Desc:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for GetBriefingParamsScope.
 const (
 	Everywhere GetBriefingParamsScope = "everywhere"
@@ -184,6 +262,54 @@ func (e GetBriefingParamsScope) Valid() bool {
 	default:
 		return false
 	}
+}
+
+// ActivityEvent One logical operation, with the memories it served or wrote.
+type ActivityEvent struct {
+	// Detail Kind-specific context — a recall's degraded mode, a supersession's replacement id.
+	Detail *map[string]interface{} `json:"detail,omitempty"`
+
+	// Kind The operation an activity event records. Reads: recall, get, briefing. Writes: remember, update, forget, supersede.
+	Kind EventKind `json:"kind"`
+
+	// Memories Empty for a recall that matched nothing.
+	Memories *[]ActivityMemory `json:"memories,omitempty"`
+
+	// Namespace The namespace the request was made against.
+	Namespace string `json:"namespace"`
+	OpId      string `json:"op_id"`
+
+	// Query The recall query; absent for every other kind.
+	Query *string   `json:"query,omitempty"`
+	Time  time.Time `json:"time"`
+}
+
+// ActivityMemory One memory as it appeared in an event — a snapshot taken at serve time, so a forgotten memory still renders — plus why it was there.
+type ActivityMemory struct {
+	Id string `json:"id"`
+
+	// Namespace The memory's own namespace, which for a cascading recall may differ from the event's.
+	Namespace string `json:"namespace"`
+
+	// Rank 1-based position the memory was served at; absent when not applicable.
+	Rank *int `json:"rank,omitempty"`
+
+	// Score Composite relevance score it was served with; recall only.
+	Score *float64 `json:"score,omitempty"`
+
+	// Section Which briefing section it appeared under; briefing only.
+	Section *string `json:"section,omitempty"`
+	Summary string  `json:"summary"`
+	Tier    Tier    `json:"tier"`
+}
+
+// ActivityResponse defines model for ActivityResponse.
+type ActivityResponse struct {
+	Events  []ActivityEvent `json:"events"`
+	HasMore bool            `json:"has_more"`
+
+	// NextCursor Pass as "before" to fetch the next page; absent on the last page.
+	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
 // AnswerRequest defines model for AnswerRequest.
@@ -365,6 +491,9 @@ type DeleteNamespaceResponse struct {
 	// Deleted Number of memories deleted
 	Deleted int `json:"deleted"`
 }
+
+// EventKind The operation an activity event records. Reads: recall, get, briefing. Writes: remember, update, forget, supersede.
+type EventKind string
 
 // FsckReport defines model for FsckReport.
 type FsckReport struct {
@@ -627,6 +756,36 @@ type Error struct {
 // bearerAuthContextKey is the context key for bearerAuth security scheme
 type bearerAuthContextKey string
 
+// ListActivityParams defines parameters for ListActivity.
+type ListActivityParams struct {
+	// Kind Repeatable and/or comma-separated event-kind filter; omitted means all kinds.
+	Kind *[]EventKind `form:"kind,omitempty" json:"kind,omitempty"`
+
+	// Tier Repeatable and/or comma-separated tier filter. Selects whole operations that touched a memory of a listed tier — a matching event is returned with every memory it served, so its counts stay truthful.
+	Tier *[]Tier `form:"tier,omitempty" json:"tier,omitempty"`
+
+	// Q Free-text filter, case-insensitive. Selects whole operations whose recall query or any served memory's summary contains it.
+	Q *string `form:"q,omitempty" json:"q,omitempty"`
+
+	// Since Only events recorded at or after this instant.
+	Since *time.Time `form:"since,omitempty" json:"since,omitempty"`
+
+	// Namespace With all_namespaces=true, restrict the feed to these namespaces (repeatable, exact match); ignored otherwise.
+	Namespace *[]string `form:"namespace,omitempty" json:"namespace,omitempty"`
+
+	// Limit Caps the returned events (operations, not rows). Default 50, max 200.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Before Opaque cursor from a previous response's next_cursor; returns the page of events strictly older than it.
+	Before *string `form:"before,omitempty" json:"before,omitempty"`
+
+	// AllNamespaces Aggregate across every namespace, ignoring the namespace header.
+	AllNamespaces *bool `form:"all_namespaces,omitempty" json:"all_namespaces,omitempty"`
+
+	// XMeminiNamespace Tenant/agent namespace; falls back to the server default.
+	XMeminiNamespace *Namespace `json:"X-Memini-Namespace,omitempty"`
+}
+
 // AnswerQuestionParams defines parameters for AnswerQuestion.
 type AnswerQuestionParams struct {
 	// XMeminiNamespace Tenant/agent namespace; falls back to the server default.
@@ -712,12 +871,36 @@ type ListMemoriesParams struct {
 	// Limit Caps the result count; 0 or absent returns all matches.
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 
-	// AllNamespaces Aggregate across every namespace, ignoring the namespace header. The server merges all namespaces and applies limit as a single global cap (newest first), so the admin UI's "All projects" view fetches one response instead of one request per namespace.
+	// AllNamespaces Aggregate across every namespace, ignoring the namespace header. The server merges all namespaces and applies limit as a single global cap under the requested sort, so the admin UI's "All projects" view fetches one response instead of one request per namespace.
 	AllNamespaces *bool `form:"all_namespaces,omitempty" json:"all_namespaces,omitempty"`
+
+	// Namespace With all_namespaces=true, restrict the aggregate to these namespaces (repeatable, exact match); ignored otherwise. Lets the browser narrow an "All projects" listing without changing the active namespace.
+	Namespace *[]string `form:"namespace,omitempty" json:"namespace,omitempty"`
+
+	// MemoryType Repeatable and/or comma-separated metadata.memory_type filter; a memory matches if its type is ANY of the listed values (OR). Distinct from "meta", which ANDs one value per key.
+	MemoryType *[]string `form:"memory_type,omitempty" json:"memory_type,omitempty"`
+
+	// CreatedAfter Only memories created at or after this instant.
+	CreatedAfter *time.Time `form:"created_after,omitempty" json:"created_after,omitempty"`
+
+	// AccessedAfter Only memories last accessed at or after this instant.
+	AccessedAfter *time.Time `form:"accessed_after,omitempty" json:"accessed_after,omitempty"`
+
+	// Sort Column to order by. Defaults to created_at.
+	Sort *ListMemoriesParamsSort `form:"sort,omitempty" json:"sort,omitempty"`
+
+	// Order Sort direction. Defaults to desc (newest / highest first).
+	Order *ListMemoriesParamsOrder `form:"order,omitempty" json:"order,omitempty"`
 
 	// XMeminiNamespace Tenant/agent namespace; falls back to the server default.
 	XMeminiNamespace *Namespace `json:"X-Memini-Namespace,omitempty"`
 }
+
+// ListMemoriesParamsSort defines parameters for ListMemories.
+type ListMemoriesParamsSort string
+
+// ListMemoriesParamsOrder defines parameters for ListMemories.
+type ListMemoriesParamsOrder string
 
 // RememberMemoryParams defines parameters for RememberMemory.
 type RememberMemoryParams struct {
@@ -883,6 +1066,9 @@ type SearchMemoriesJSONRequestBody = SearchRequest
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// Recent memory activity — what was served or written, and why
+	// (GET /v1/activity)
+	ListActivity(w http.ResponseWriter, r *http.Request, params ListActivityParams)
 	// Recall memories and answer a question grounded on them (requires an LLM)
 	// (POST /v1/answer)
 	AnswerQuestion(w http.ResponseWriter, r *http.Request, params AnswerQuestionParams)
@@ -969,6 +1155,12 @@ type ServerInterface interface {
 // Unimplemented server implementation that returns http.StatusNotImplemented for each endpoint.
 
 type Unimplemented struct{}
+
+// Recent memory activity — what was served or written, and why
+// (GET /v1/activity)
+func (_ Unimplemented) ListActivity(w http.ResponseWriter, r *http.Request, params ListActivityParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
 
 // Recall memories and answer a question grounded on them (requires an LLM)
 // (POST /v1/answer)
@@ -1140,6 +1332,157 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(http.Handler) http.Handler
+
+// ListActivity operation middleware
+func (siw *ServerInterfaceWrapper) ListActivity(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListActivityParams
+
+	// ------------- Optional query parameter "kind" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "kind", r.URL.Query(), &params.Kind, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "kind"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "kind", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "tier" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "tier", r.URL.Query(), &params.Tier, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tier"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tier", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "q" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "q", r.URL.Query(), &params.Q, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "q"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "q", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "since" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "since", r.URL.Query(), &params.Since, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "since"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "since", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "namespace" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "namespace", r.URL.Query(), &params.Namespace, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "namespace"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "namespace", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "before" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "before", r.URL.Query(), &params.Before, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "before"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "before", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "all_namespaces" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "all_namespaces", r.URL.Query(), &params.AllNamespaces, runtime.BindQueryParameterOptions{Type: "boolean", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "all_namespaces"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "all_namespaces", Err: err})
+		}
+		return
+	}
+
+	headers := r.Header
+
+	// ------------- Optional header parameter "X-Memini-Namespace" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Memini-Namespace")]; found {
+		var XMeminiNamespace Namespace
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Memini-Namespace", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Memini-Namespace", valueList[0], &XMeminiNamespace, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Memini-Namespace", Err: err})
+			return
+		}
+
+		params.XMeminiNamespace = &XMeminiNamespace
+
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListActivity(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
 
 // AnswerQuestion operation middleware
 func (siw *ServerInterfaceWrapper) AnswerQuestion(w http.ResponseWriter, r *http.Request) {
@@ -1747,6 +2090,84 @@ func (siw *ServerInterfaceWrapper) ListMemories(w http.ResponseWriter, r *http.R
 			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "all_namespaces"})
 		} else {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "all_namespaces", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "namespace" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "namespace", r.URL.Query(), &params.Namespace, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "namespace"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "namespace", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "memory_type" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "memory_type", r.URL.Query(), &params.MemoryType, runtime.BindQueryParameterOptions{Type: "array", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "memory_type"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "memory_type", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "created_after" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "created_after", r.URL.Query(), &params.CreatedAfter, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "created_after"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "created_after", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "accessed_after" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "accessed_after", r.URL.Query(), &params.AccessedAfter, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "accessed_after"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "accessed_after", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "sort" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "sort", r.URL.Query(), &params.Sort, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "sort"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sort", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "order" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "order", r.URL.Query(), &params.Order, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "order"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "order", Err: err})
 		}
 		return
 	}
@@ -2676,6 +3097,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		ErrorHandlerFunc:   options.ErrorHandlerFunc,
 	}
 
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v1/activity", wrapper.ListActivity)
+	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v1/answer", wrapper.AnswerQuestion)
 	})

--- a/internal/api/rest/apikey_test.go
+++ b/internal/api/rest/apikey_test.go
@@ -6,12 +6,14 @@ import (
 	"encoding/hex"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/eleboucher/memini/internal/api/rest"
 	"github.com/eleboucher/memini/internal/embed/embedtest"
+	"github.com/eleboucher/memini/internal/httputil"
 	"github.com/eleboucher/memini/internal/service"
 	"github.com/eleboucher/memini/internal/store"
 	"github.com/eleboucher/memini/internal/store/sqlitevec"
@@ -151,8 +153,10 @@ func TestBoundKeyHomeWinsNoHeader(t *testing.T) {
 }
 
 // TestBoundKeyHomeWinsOverConflictingHeader: a conflicting X-Memini-Home
-// header must be silently ignored (never a 400) for a bound key — the key's
-// own home always wins.
+// header must be ignored (never a 400) for a bound key — the key's own home
+// always wins — but not silently: the override is announced on the response
+// via X-Memini-Warning, since a caller reading the wrong namespace's memories
+// deserves to know why.
 func TestBoundKeyHomeWinsOverConflictingHeader(t *testing.T) {
 	h, ks := newServerWithKeyStore(t, "")
 	if err := ks.PutAPIKey(context.Background(), store.APIKey{
@@ -184,6 +188,62 @@ func TestBoundKeyHomeWinsOverConflictingHeader(t *testing.T) {
 	mustJSON(t, rec, &out)
 	if len(out.Results) != 1 || out.Results[0].Memory.Namespace != "acme/home2" {
 		t.Fatalf("bound key home must win over a conflicting header, got %+v", out.Results)
+	}
+	// The override is announced, not silent.
+	warn := rec.Header().Get(httputil.WarningHeader)
+	if warn == "" {
+		t.Fatal("no X-Memini-Warning on a request whose home header the server overrode")
+	}
+	for _, want := range []string{"someone/elses/home", "acme/home2", "bound-bot2"} {
+		if !strings.Contains(warn, want) {
+			t.Errorf("warning %q does not mention %q; it should name the ignored header, "+
+				"the winning home, and the key that decided it", warn, want)
+		}
+	}
+}
+
+// TestBoundKeyMatchingHomeHeaderIsNotAWarning: a header that agrees with the
+// key's binding is not a conflict, so it must not warn — a warning that fires
+// when nothing was overridden is noise, and noise gets ignored.
+func TestBoundKeyMatchingHomeHeaderIsNotAWarning(t *testing.T) {
+	h, ks := newServerWithKeyStore(t, "")
+	if err := ks.PutAPIKey(context.Background(), store.APIKey{
+		Name: "bound-bot3", Hash: hashOf("tok-bound3"), HomeNS: "acme/home3",
+	}); err != nil {
+		t.Fatalf("PutAPIKey: %v", err)
+	}
+	// Same home the key is bound to, and the non-canonical spelling of it —
+	// both normalize to the key's home, so neither is an override.
+	for _, home := range []string{"acme/home3", "acme/home3/"} {
+		rec := doHome(t, h, http.MethodPost, "/v1/search", "acme/unrelated", home, "tok-bound3", map[string]any{
+			"query": "anything", "limit": 5,
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("search: want 200, got %d (%s)", rec.Code, rec.Body)
+		}
+		if warn := rec.Header().Get(httputil.WarningHeader); warn != "" {
+			t.Errorf("home header %q agrees with the key's binding but still warned: %q", home, warn)
+		}
+	}
+}
+
+// TestUnboundKeyHomeHeaderIsNotAWarning: an unbound key has nothing to
+// override, so an ordinary home header must pass through unremarked.
+func TestUnboundKeyHomeHeaderIsNotAWarning(t *testing.T) {
+	h, ks := newServerWithKeyStore(t, "")
+	if err := ks.PutAPIKey(context.Background(), store.APIKey{
+		Name: "unbound-bot2", Hash: hashOf("tok-unbound2"),
+	}); err != nil {
+		t.Fatalf("PutAPIKey: %v", err)
+	}
+	rec := doHome(t, h, http.MethodPost, "/v1/search", "acme/x", "acme/theirhome", "tok-unbound2", map[string]any{
+		"query": "anything", "limit": 5,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("search: want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+	if warn := rec.Header().Get(httputil.WarningHeader); warn != "" {
+		t.Errorf("unbound key honors the header, so nothing was overridden, but it warned: %q", warn)
 	}
 }
 

--- a/internal/api/rest/list_sort_test.go
+++ b/internal/api/rest/list_sort_test.go
@@ -1,0 +1,174 @@
+package rest_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/eleboucher/memini/internal/memory"
+)
+
+// listOut mirrors the ListResponse wire shape for ordering assertions.
+type listOut struct {
+	Memories []struct {
+		ID         string         `json:"id"`
+		Namespace  string         `json:"namespace"`
+		Content    string         `json:"content"`
+		Importance float64        `json:"importance"`
+		Metadata   map[string]any `json:"metadata"`
+		CreatedAt  time.Time      `json:"created_at"`
+	} `json:"memories"`
+}
+
+func (l listOut) contents() []string {
+	out := make([]string, len(l.Memories))
+	for i, m := range l.Memories {
+		out[i] = m.Content
+	}
+	return out
+}
+
+// TestListSortAndFilters covers the browse page's server-side sort and the new
+// filters, through the generated params and into the store's ORDER BY.
+func TestListSortAndFilters(t *testing.T) {
+	h := newServer(t)
+
+	// Importance ascends in the order written, so a created_at sort and an
+	// importance sort disagree — a handler wired to the wrong column can't pass
+	// both assertions below by accident.
+	for i, c := range []struct {
+		content    string
+		importance float64
+		memType    string
+	}{
+		{"first written", 0.1, "decision"},
+		{"second written", 0.5, "preference"},
+		{"third written", 0.9, ""},
+	} {
+		body := map[string]any{
+			"content": c.content, "tier": string(memory.TierSemantic), "importance": c.importance,
+		}
+		if c.memType != "" {
+			body["metadata"] = map[string]any{"memory_type": c.memType}
+		}
+		rec := do(t, h, http.MethodPost, "/v1/memories", "acme", apiKey, body)
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("seed %d: want 201, got %d (%s)", i, rec.Code, rec.Body)
+		}
+		// Keep created_at strictly ordered; the store's tie-break is the id, which
+		// would otherwise decide a same-millisecond race.
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	get := func(t *testing.T, query string) listOut {
+		t.Helper()
+		rec := do(t, h, http.MethodGet, "/v1/memories"+query, "acme", apiKey, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET %s: want 200, got %d (%s)", query, rec.Code, rec.Body)
+		}
+		var out listOut
+		mustJSON(t, rec, &out)
+		return out
+	}
+
+	t.Run("default is newest first", func(t *testing.T) {
+		got := get(t, "").contents()
+		want := []string{"third written", "second written", "first written"}
+		if !slicesEqual(got, want) {
+			t.Fatalf("default order = %v, want %v (newest created first)", got, want)
+		}
+	})
+
+	t.Run("sort by importance", func(t *testing.T) {
+		got := get(t, "?sort=importance&order=asc").contents()
+		want := []string{"first written", "second written", "third written"}
+		if !slicesEqual(got, want) {
+			t.Fatalf("importance asc = %v, want %v", got, want)
+		}
+		got = get(t, "?sort=importance&order=desc").contents()
+		want = []string{"third written", "second written", "first written"}
+		if !slicesEqual(got, want) {
+			t.Fatalf("importance desc = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("sort combines with limit", func(t *testing.T) {
+		got := get(t, "?sort=importance&order=asc&limit=1").contents()
+		if !slicesEqual(got, []string{"first written"}) {
+			t.Fatalf("limit under sort = %v, want the least-important memory only", got)
+		}
+	})
+
+	t.Run("invalid sort and order are 400s", func(t *testing.T) {
+		// The last one is the point of the enum whitelist: an unknown sort key is
+		// rejected outright rather than reaching the driver's ORDER BY.
+		for _, q := range []string{"?sort=bogus", "?order=sideways", "?sort=created_at%3B%20DROP%20TABLE%20memories"} {
+			rec := do(t, h, http.MethodGet, "/v1/memories"+q, "acme", apiKey, nil)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("GET %s: want 400, got %d (%s)", q, rec.Code, rec.Body)
+			}
+		}
+	})
+
+	t.Run("memory_type filter ORs its values", func(t *testing.T) {
+		got := get(t, "?memory_type=decision").contents()
+		if !slicesEqual(got, []string{"first written"}) {
+			t.Fatalf("memory_type=decision = %v", got)
+		}
+		got = get(t, "?memory_type=decision,preference&sort=created_at&order=asc").contents()
+		want := []string{"first written", "second written"}
+		if !slicesEqual(got, want) {
+			t.Fatalf("memory_type=decision,preference = %v, want %v", got, want)
+		}
+		// The untyped memory is never swept in by a type filter.
+		if got := get(t, "?memory_type=decision,preference,nonesuch").contents(); len(got) != 2 {
+			t.Fatalf("an unknown type pulled in extra memories: %v", got)
+		}
+	})
+
+	t.Run("created_after window", func(t *testing.T) {
+		all := get(t, "?sort=created_at&order=asc")
+		if len(all.Memories) != 3 {
+			t.Fatalf("expected 3 seeded memories, got %d", len(all.Memories))
+		}
+		// Everything created at or after the second memory: excludes the first.
+		cutoff := all.Memories[1].CreatedAt.UTC().Format(time.RFC3339Nano)
+		got := get(t, fmt.Sprintf("?created_after=%s&sort=created_at&order=asc", cutoff)).contents()
+		want := []string{"second written", "third written"}
+		if !slicesEqual(got, want) {
+			t.Fatalf("created_after=%s = %v, want %v", cutoff, got, want)
+		}
+	})
+
+	t.Run("namespace narrowing in all_namespaces mode", func(t *testing.T) {
+		rec := do(t, h, http.MethodPost, "/v1/memories", "other", apiKey, map[string]any{
+			"content": "a memory elsewhere", "tier": string(memory.TierSemantic),
+		})
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("seed other-namespace: %d (%s)", rec.Code, rec.Body)
+		}
+		// The aggregate sees both namespaces...
+		all := get(t, "?all_namespaces=true")
+		if len(all.Memories) != 4 {
+			t.Fatalf("all_namespaces returned %d memories, want 4", len(all.Memories))
+		}
+		// ...and narrows to the ones asked for, without touching the header.
+		narrowed := get(t, "?all_namespaces=true&namespace=other")
+		if len(narrowed.Memories) != 1 || narrowed.Memories[0].Namespace != "other" {
+			t.Fatalf("namespace=other returned %+v, want only the 'other' memory", narrowed.contents())
+		}
+	})
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/rest/middleware.go
+++ b/internal/api/rest/middleware.go
@@ -145,9 +145,17 @@ func (a AuthConfig) homeMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if p, ok := principalFromContext(r.Context()); ok && p.HomeNS != "" {
 			if raw := strings.TrimSpace(r.Header.Get(a.HomeHeader)); raw != "" {
-				if hdr := httputil.NormalizeNamespace(raw); hdr != "" && hdr != p.HomeNS {
-					slog.DebugContext(r.Context(), "X-Memini-Home ignored: request key is bound to a home namespace",
+				hdr := httputil.NormalizeNamespace(raw)
+				if warn := httputil.HomeConflictWarning(p.Name, p.HomeNS, hdr); warn != "" {
+					// The override is silent from the caller's side — they asked for
+					// one home and got another — so say so loudly enough to be
+					// noticed: a warn-level log for the operator, and a response
+					// header the client (and the admin UI) can surface. Still never
+					// a 400: a shared client config that always sets the header is
+					// not a caller error.
+					slog.WarnContext(r.Context(), "X-Memini-Home ignored: request key is bound to a home namespace",
 						"key", p.Name, "key_home", p.HomeNS, "header_home", hdr)
+					w.Header().Set(httputil.WarningHeader, warn)
 				}
 			}
 			ctx := context.WithValue(r.Context(), homeKey, p.HomeNS)

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -512,13 +512,26 @@ func (h *Server) ListMemories(w http.ResponseWriter, r *http.Request, params Lis
 		httputil.Error(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	sort, err := querySort(params.Sort, params.Order)
+	if err != nil {
+		httputil.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	in := service.ListInput{
 		Namespace: namespaceFromContext(r.Context()),
 		Tiers:     tiers,
 		Levels:    levels,
 		Tags:      queryTags(params.Tag),
 		Metadata:  meta,
+		// memory_type is comma-splittable like tags; namespace is not, since a
+		// namespace may legitimately contain characters we would rather not
+		// start carving on.
+		MemoryTypes: queryTags(params.MemoryType),
+		Namespaces:  deref(params.Namespace),
+		Sort:        sort,
 	}
+	in.CreatedAfter = deref(params.CreatedAfter)
+	in.AccessedAfter = deref(params.AccessedAfter)
 	in.IncludeExpired = deref(params.IncludeExpired)
 	in.IncludeSuperseded = deref(params.IncludeSuperseded)
 	in.AllNamespaces = deref(params.AllNamespaces)
@@ -1169,6 +1182,46 @@ func queryTiers(in *[]Tier) ([]memory.Tier, error) {
 		}
 	}
 	return tiers, nil
+}
+
+// querySort maps the ?sort=/?order= params onto a store.Sort. Both are enums in
+// the spec, so an unknown value is the caller's error (400) rather than a
+// silently-ignored parameter that would hand back a differently-ordered list
+// than asked for. Absent params mean the zero Sort: created_at, descending.
+func querySort(sort *ListMemoriesParamsSort, order *ListMemoriesParamsOrder) (store.Sort, error) {
+	var s store.Sort
+	if sort != nil {
+		if !sort.Valid() {
+			return s, fmt.Errorf("invalid sort %q", string(*sort))
+		}
+		s.Key = store.SortKey(*sort)
+	}
+	if order != nil {
+		if !order.Valid() {
+			return s, fmt.Errorf("invalid order %q", string(*order))
+		}
+		s.Asc = *order == Asc
+	}
+	return s, nil
+}
+
+// queryEventKinds expands and validates the ?kind= activity filter. Like ?tier=,
+// it supports repeatable and/or comma-separated values.
+func queryEventKinds(in *[]EventKind) ([]store.EventKind, error) {
+	if in == nil {
+		return nil, nil
+	}
+	var kinds []store.EventKind
+	for _, v := range *in {
+		for part := range strings.SplitSeq(string(v), ",") {
+			k := store.EventKind(strings.TrimSpace(part))
+			if !store.ValidEventKind(k) {
+				return nil, fmt.Errorf("invalid event kind %q", k)
+			}
+			kinds = append(kinds, k)
+		}
+	}
+	return kinds, nil
 }
 
 // queryLevels expands and validates the ?level= filter. Like ?tier=, it supports

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -280,6 +280,19 @@ type Config struct {
 	// removing it is the only irreversible maintenance action. Set e.g. 720h
 	// (30d) to enable.
 	TombstoneTTL time.Duration `env:"MEMINI_TOMBSTONE_TTL" envDefault:"0"`
+
+	// ActivityLog records reads (recall/get/briefing) and writes
+	// (remember/update/forget/supersede) to the activity log that backs the UI's
+	// Activity page. Writes are best-effort and off the request path, so the cost
+	// is storage, not latency; set false to record nothing.
+	ActivityLog bool `env:"MEMINI_ACTIVITY_LOG" envDefault:"true"`
+	// ActivityRetention drops activity events older than this. 0 keeps them
+	// forever (bounded only by ActivityMaxRows).
+	ActivityRetention time.Duration `env:"MEMINI_ACTIVITY_RETENTION" envDefault:"720h"`
+	// ActivityMaxRows caps the activity log, dropping the oldest rows beyond it.
+	// A busy agent writes several rows per recall, so the cap — not the retention
+	// window — is usually what bounds the table. 0 disables the cap.
+	ActivityMaxRows int `env:"MEMINI_ACTIVITY_MAX_ROWS" envDefault:"100000"`
 	// DemoteAfter demotes durable memories older than this to the episodic tier
 	// when they have never been recalled, are not important, and are
 	// uncorroborated (low confidence) — so an old bulk import ages out while

--- a/internal/httputil/httputil.go
+++ b/internal/httputil/httputil.go
@@ -49,3 +49,24 @@ func ValidateNamespace(ns string) error {
 	}
 	return nil
 }
+
+// WarningHeader carries a non-fatal advisory about how the server interpreted a
+// request — something the caller almost certainly wants to know but which is not
+// an error, so it must not fail the request. Clients surface it; the UI renders
+// it as a banner.
+const WarningHeader = "X-Memini-Warning"
+
+// HomeConflictWarning describes a home-namespace header the server overrode
+// because the request's API key is bound to a home namespace of its own. The
+// key's binding is identity, so it always wins — but silently ignoring an
+// explicit header is exactly the kind of thing that leaves someone staring at
+// the wrong namespace's memories wondering why. Returns "" when there is no
+// conflict (no binding, no header, or they agree).
+func HomeConflictWarning(keyName, keyHome, headerHome string) string {
+	if keyHome == "" || headerHome == "" || keyHome == headerHome {
+		return ""
+	}
+	return fmt.Sprintf(
+		"home namespace %q from %s ignored: API key %q is bound to home %q, which wins",
+		headerHome, "X-Memini-Home", keyName, keyHome)
+}

--- a/internal/maintenance/events.go
+++ b/internal/maintenance/events.go
@@ -1,0 +1,27 @@
+package maintenance
+
+import (
+	"context"
+	"time"
+
+	"github.com/eleboucher/memini/internal/store"
+)
+
+// PruneEvents trims the activity log to a retention window and a row cap.
+// A retention of 0 prunes nothing by age; a cap of 0 applies no cap. Returns
+// the number of rows deleted, and 0 against a driver with no activity log
+// (the same degrade-gracefully type assertion the log's writers use).
+func PruneEvents(ctx context.Context, st store.Store, now time.Time, retention time.Duration, maxRows int) (int64, error) {
+	els, ok := st.(store.EventLogStore)
+	if !ok {
+		return 0, nil
+	}
+	var olderThan time.Time
+	if retention > 0 {
+		olderThan = now.Add(-retention)
+	}
+	if olderThan.IsZero() && maxRows <= 0 {
+		return 0, nil
+	}
+	return els.PruneEvents(ctx, olderThan, maxRows)
+}

--- a/internal/maintenance/maintenance.go
+++ b/internal/maintenance/maintenance.go
@@ -145,6 +145,12 @@ type SweeperConfig struct {
 	// DemoteAfter demotes never-recalled, low-importance durable memories older
 	// than this to the episodic tier so unused debris ages out. 0 disables it.
 	DemoteAfter time.Duration
+	// ActivityRetention drops activity-log events older than now-retention.
+	// 0 disables age-based pruning.
+	ActivityRetention time.Duration
+	// ActivityMaxRows caps the activity log, dropping the oldest rows beyond it.
+	// 0 disables the cap. With both bounds 0 the log grows without limit.
+	ActivityMaxRows int
 }
 
 // Sweeper periodically purges expired memories, enforces the short-term cap, and
@@ -206,5 +212,10 @@ func (s *Sweeper) sweep(ctx context.Context) {
 		} else if n > 0 {
 			s.log.Info("demoted stale durable memories to episodic", "count", n)
 		}
+	}
+	if n, err := PruneEvents(ctx, s.store, now, s.cfg.ActivityRetention, s.cfg.ActivityMaxRows); err != nil {
+		s.log.Warn("activity log pruning failed", "error", err)
+	} else if n > 0 {
+		s.log.Info("pruned activity log", "count", n)
 	}
 }

--- a/internal/service/events.go
+++ b/internal/service/events.go
@@ -1,0 +1,404 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/eleboucher/memini/internal/memory"
+	"github.com/eleboucher/memini/internal/store"
+)
+
+// eventLogTimeout bounds a detached activity-log write, mirroring
+// reinforceTimeout: the log is best-effort, so a wedged store must not leak a
+// goroutine for the life of the process.
+const eventLogTimeout = 10 * time.Second
+
+// eventSummaryMax caps the snapshot text stored per event row. The feed renders
+// a one-line summary, so storing whole memories would bloat the log for nothing.
+const eventSummaryMax = 200
+
+// defaultEventsLimit and maxEventsLimit bound a page of the activity feed,
+// counted in operations (a recall serving 20 memories is one operation).
+const (
+	defaultEventsLimit = 50
+	maxEventsLimit     = 200
+)
+
+// eventRowFanout is how many flat rows Events fetches per requested operation.
+// One operation is usually 1 row (a write, a get) and at most recall-K rows, so
+// 8x comfortably covers a page of mixed traffic in a single query while keeping
+// a pathological all-recalls page to one extra round trip.
+const eventRowFanout = 8
+
+// eventLog returns the store's activity-log capability, and whether logging is
+// both supported and enabled. Drivers that predate the log simply don't
+// implement it — the type assertion is the same degrade-gracefully pattern the
+// link and API-key capabilities use.
+func (s *Service) eventLog() (store.EventLogStore, bool) {
+	if !s.eventLogOn {
+		return nil, false
+	}
+	els, ok := s.store.(store.EventLogStore)
+	return els, ok
+}
+
+// logEvents appends one operation's rows. By default it runs in the background
+// so the user-facing call's latency excludes the write; tests force synchronous
+// behaviour with WithSyncEventLog. Best-effort throughout: a failure here is
+// logged, never returned — losing an audit row must not fail a recall.
+func (s *Service) logEvents(ctx context.Context, events []store.Event) {
+	els, ok := s.eventLog()
+	if !ok || len(events) == 0 {
+		return
+	}
+	write := func(ctx context.Context) {
+		if err := els.AppendEvents(ctx, events); err != nil {
+			slog.WarnContext(ctx, "activity: append events failed",
+				"kind", string(events[0].Kind), "count", len(events), "err", err)
+		}
+	}
+	if s.syncEventLog {
+		write(ctx)
+		return
+	}
+	// Detach from the request lifetime but keep its values; bound the work.
+	bg := context.WithoutCancel(ctx)
+	s.bg.Go(func() {
+		ectx, cancel := context.WithTimeout(bg, eventLogTimeout)
+		defer cancel()
+		write(ectx)
+	})
+}
+
+// logRecallEvent records what a recall served and why: the query, and each
+// memory's rank and composite score. This is the signal access_count cannot
+// carry — a counter says a memory was used, the log says which question it
+// answered and how well it scored against it.
+//
+// A recall that returned nothing is still recorded, as a single row with no
+// memory: "this query found nothing" is exactly the kind of thing you go to an
+// activity feed to discover.
+func (s *Service) logRecallEvent(ctx context.Context, in RecallInput, results []store.Scored) {
+	if _, ok := s.eventLog(); !ok {
+		return
+	}
+	detail := map[string]any{}
+	if in.Degraded != nil && *in.Degraded != "" {
+		detail["degraded"] = *in.Degraded
+	}
+	base := store.Event{
+		OpID:      s.newID(),
+		Kind:      store.EventRecall,
+		Namespace: in.Namespace,
+		Query:     in.Query,
+		Detail:    detail,
+		CreatedAt: s.now(),
+	}
+	if len(results) == 0 {
+		s.logEvents(ctx, []store.Event{base})
+		return
+	}
+	events := make([]store.Event, 0, len(results))
+	for i, r := range results {
+		e := base
+		e.Rank = i + 1
+		e.Score = &r.Score
+		applyMemory(&e, r.Memory)
+		events = append(events, e)
+	}
+	s.logEvents(ctx, events)
+}
+
+// logBriefingEvent records the memories a session-start briefing served, tagged
+// with the section each appeared in. Unlike recall this does not reinforce:
+// see the note on Briefing's call site.
+func (s *Service) logBriefingEvent(ctx context.Context, namespace string, b Briefing) {
+	if _, ok := s.eventLog(); !ok {
+		return
+	}
+	opID := s.newID()
+	now := s.now()
+	var events []store.Event
+	seen := map[string]bool{}
+	// Section order is the order the briefing itself presents them, so the
+	// first section a memory appears in is the one the reader saw it under.
+	for _, sec := range []struct {
+		name string
+		mems []*memory.Memory
+	}{
+		{"pinned", b.Pinned},
+		{"facts", b.Facts},
+		{"procedures", b.Procedures},
+		{"recent", b.Recent},
+	} {
+		for i, m := range sec.mems {
+			if m == nil || seen[m.ID] {
+				continue
+			}
+			seen[m.ID] = true
+			e := store.Event{
+				OpID:      opID,
+				Kind:      store.EventBriefing,
+				Namespace: namespace,
+				Rank:      i + 1,
+				Detail:    map[string]any{"section": sec.name},
+				CreatedAt: now,
+			}
+			applyMemory(&e, m)
+			events = append(events, e)
+		}
+	}
+	if len(events) == 0 {
+		return
+	}
+	s.logEvents(ctx, events)
+}
+
+// logWriteEvent records a completed write. One Upsert backs both verbs: an ID
+// that already resolved to a row (existing != nil) is an update, anything else
+// is a new memory. Distinguishing them here is what lets the feed say "updated"
+// rather than "remembered" for MCP's memory_update, which composes Get+Remember.
+func (s *Service) logWriteEvent(ctx context.Context, m, existing *memory.Memory) {
+	kind := store.EventRemember
+	if existing != nil {
+		kind = store.EventUpdate
+	}
+	s.logMemoryEvent(ctx, kind, m.Namespace, m, nil)
+}
+
+// logMemoryEvent records a single-memory operation (a get, or a write).
+func (s *Service) logMemoryEvent(ctx context.Context, kind store.EventKind, namespace string, m *memory.Memory, detail map[string]any) {
+	if _, ok := s.eventLog(); !ok || m == nil {
+		return
+	}
+	e := store.Event{
+		OpID:      s.newID(),
+		Kind:      kind,
+		Namespace: namespace,
+		Detail:    detail,
+		CreatedAt: s.now(),
+	}
+	applyMemory(&e, m)
+	s.logEvents(ctx, []store.Event{e})
+}
+
+// applyMemory stamps the memory snapshot onto an event row. The snapshot is
+// what keeps the feed a single query (no per-row fetch) and what keeps a forget
+// event readable once its memory no longer exists.
+func applyMemory(e *store.Event, m *memory.Memory) {
+	e.MemoryID = m.ID
+	e.MemoryNS = m.Namespace
+	e.MemoryTier = m.Tier
+	e.MemorySummary = eventSummary(m)
+}
+
+// eventSummary is the memory's own summary, else a clipped prefix of its content.
+func eventSummary(m *memory.Memory) string {
+	s := m.Summary
+	if s == "" {
+		s = m.Content
+	}
+	if len(s) > eventSummaryMax {
+		// Clip on a rune boundary so a multi-byte character is never halved.
+		r := []rune(s)
+		if len(r) > eventSummaryMax {
+			return string(r[:eventSummaryMax]) + "…"
+		}
+	}
+	return s
+}
+
+// ActivityMemory is one memory as it appeared in an activity event: the
+// snapshot taken at serve time, plus why it was there (rank, score, section).
+type ActivityMemory struct {
+	ID        string
+	Namespace string
+	Summary   string
+	Tier      memory.Tier
+	Rank      int
+	Score     *float64
+	Section   string // briefing only
+}
+
+// ActivityEvent is one logical operation: what happened, when, against which
+// namespace, and — for a recall — the query and the memories it served.
+type ActivityEvent struct {
+	OpID      string
+	Kind      store.EventKind
+	Time      time.Time
+	Namespace string
+	Query     string
+	Detail    map[string]any
+	Memories  []ActivityMemory
+}
+
+// EventsInput selects a page of the activity feed.
+//
+// Tiers and Text select whole operations rather than individual memories — see
+// store.EventFilter — so a filtered recall still reports everything it served.
+type EventsInput struct {
+	// Namespace restricts the feed to one namespace; "" means every namespace.
+	Namespace string
+	// Namespaces narrows an all-namespaces feed to these namespaces (OR);
+	// ignored when Namespace is set.
+	Namespaces []string
+	// Kinds restricts to these event kinds; empty means all.
+	Kinds []store.EventKind
+	// Tiers restricts to operations that touched a memory of one of these tiers.
+	Tiers []memory.Tier
+	// Text restricts to operations whose query or a served memory's summary
+	// contains it, case-insensitively.
+	Text string
+	// Since restricts to events at or after the instant.
+	Since time.Time
+	// Before/BeforeID is the keyset cursor from a previous page.
+	Before   time.Time
+	BeforeID int64
+	// Limit caps the returned operations (not rows); <= 0 uses the default.
+	Limit int
+}
+
+// EventsPage is one page of the feed, with the cursor for the next.
+type EventsPage struct {
+	Events       []ActivityEvent
+	NextBefore   time.Time
+	NextBeforeID int64
+	HasMore      bool
+}
+
+// Events reads the activity feed, regrouping the store's flat (event, memory)
+// rows back into whole operations. Returns ErrUnsupported when the driver has
+// no activity log.
+//
+// The regrouping leans on a property the store guarantees: one operation's rows
+// are written as a single batch, so they share a created_at and sit contiguously
+// in the (created_at DESC, id DESC) ordering. That lets a flat row page be
+// grouped by walking consecutive rows — no join table, no second query.
+func (s *Service) Events(ctx context.Context, in EventsInput) (EventsPage, error) {
+	els, ok := s.store.(store.EventLogStore)
+	if !ok {
+		return EventsPage{}, ErrUnsupported
+	}
+	limit := in.Limit
+	if limit <= 0 {
+		limit = defaultEventsLimit
+	}
+	if limit > maxEventsLimit {
+		limit = maxEventsLimit
+	}
+	rowLimit := limit * eventRowFanout
+
+	rows, err := els.ListEvents(ctx, store.EventFilter{
+		Namespace:  in.Namespace,
+		Namespaces: in.Namespaces,
+		Kinds:      in.Kinds,
+		Tiers:      in.Tiers,
+		Text:       in.Text,
+		Since:      in.Since,
+		Before:     in.Before,
+		BeforeID:   in.BeforeID,
+		Limit:      rowLimit,
+	})
+	if err != nil {
+		return EventsPage{}, err
+	}
+	if len(rows) == 0 {
+		return EventsPage{}, nil
+	}
+
+	groups := groupEvents(rows)
+
+	page := EventsPage{Events: groups}
+	truncated := false
+	switch {
+	case len(groups) > limit:
+		page.Events = groups[:limit]
+		truncated = true
+	case len(rows) == rowLimit && len(groups) > 1:
+		// The fetch hit its row cap, so the oldest group may be only partially
+		// read — its remaining rows sit just past the boundary. Drop it and let
+		// the next page re-read it whole. Guarded on len(groups) > 1 so a single
+		// operation larger than rowLimit still renders (truncated) rather than
+		// vanishing and stalling the cursor.
+		page.Events = groups[:len(groups)-1]
+		truncated = true
+	}
+	if truncated {
+		// The cursor is the oldest row we actually kept, so the next page picks
+		// up strictly after it.
+		last := page.Events[len(page.Events)-1]
+		var oldest store.Event
+		for _, r := range rows {
+			if r.OpID == last.OpID {
+				oldest = r
+			}
+		}
+		page.NextBefore = oldest.CreatedAt
+		page.NextBeforeID = oldest.ID
+		page.HasMore = true
+	}
+	return page, nil
+}
+
+// groupEvents folds consecutive same-operation rows into whole events,
+// preserving the newest-first row order across groups. Within a group the rows
+// arrive in reverse rank order (they share a created_at, so the id tiebreak
+// runs backwards), so memories are re-sorted by rank.
+func groupEvents(rows []store.Event) []ActivityEvent {
+	var out []ActivityEvent
+	for i := 0; i < len(rows); {
+		j := i
+		for j < len(rows) && rows[j].OpID == rows[i].OpID {
+			j++
+		}
+		head := rows[i]
+		ev := ActivityEvent{
+			OpID:      head.OpID,
+			Kind:      head.Kind,
+			Time:      head.CreatedAt,
+			Namespace: head.Namespace,
+			Query:     head.Query,
+			Detail:    head.Detail,
+		}
+		for _, r := range rows[i:j] {
+			// The sentinel row of a zero-hit recall carries no memory.
+			if r.MemoryID == "" {
+				continue
+			}
+			am := ActivityMemory{
+				ID:        r.MemoryID,
+				Namespace: r.MemoryNS,
+				Summary:   r.MemorySummary,
+				Tier:      r.MemoryTier,
+				Rank:      r.Rank,
+				Score:     r.Score,
+			}
+			if sec, ok := r.Detail["section"].(string); ok {
+				am.Section = sec
+			}
+			ev.Memories = append(ev.Memories, am)
+		}
+		sort.SliceStable(ev.Memories, func(a, b int) bool {
+			return ev.Memories[a].Rank < ev.Memories[b].Rank
+		})
+		out = append(out, ev)
+		i = j
+	}
+	return out
+}
+
+// PruneEvents trims the activity log to the configured retention window and row
+// cap. Called by the maintenance sweeper; a no-op against a driver with no
+// activity log, or when both bounds are unset (keep forever).
+func (s *Service) PruneEvents(ctx context.Context, olderThan time.Time, keepMax int) (int64, error) {
+	els, ok := s.store.(store.EventLogStore)
+	if !ok {
+		return 0, nil
+	}
+	if olderThan.IsZero() && keepMax <= 0 {
+		return 0, nil
+	}
+	return els.PruneEvents(ctx, olderThan, keepMax)
+}

--- a/internal/service/events_test.go
+++ b/internal/service/events_test.go
@@ -1,0 +1,392 @@
+package service_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/eleboucher/memini/internal/embed/embedtest"
+	"github.com/eleboucher/memini/internal/memory"
+	"github.com/eleboucher/memini/internal/service"
+	"github.com/eleboucher/memini/internal/store"
+	"github.com/eleboucher/memini/internal/store/sqlitevec"
+)
+
+// newEventSvc builds a service with the activity log on and synchronous, so
+// assertions see the log without racing the background writer.
+func newEventSvc(t *testing.T) *service.Service {
+	t.Helper()
+	ctx := context.Background()
+	st, err := sqlitevec.Open(ctx, filepath.Join(t.TempDir(), "events.db"), dims)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return service.New(st, embedtest.New(dims),
+		service.WithSyncReinforce(),
+		service.WithEventLog(true),
+		service.WithSyncEventLog(),
+	)
+}
+
+// TestRecallLogsQueryRankAndScore is the point of the whole activity log: a
+// recall must record which query served each memory, at what rank, and with
+// what score — the detail access_count rolls away.
+func TestRecallLogsQueryRankAndScore(t *testing.T) {
+	ctx := context.Background()
+	svc := newEventSvc(t)
+
+	for _, c := range []string{"the database is postgres", "the cache is redis"} {
+		if _, err := svc.Remember(ctx, service.RememberInput{
+			Namespace: "n", Content: c, Tier: memory.TierSemantic,
+		}); err != nil {
+			t.Fatalf("remember %q: %v", c, err)
+		}
+	}
+	if _, err := svc.Recall(ctx, service.RecallInput{Namespace: "n", Query: "which database", Limit: 5}); err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+
+	page, err := svc.Events(ctx, service.EventsInput{
+		Namespace: "n", Kinds: []store.EventKind{store.EventRecall},
+	})
+	if err != nil {
+		t.Fatalf("events: %v", err)
+	}
+	if len(page.Events) != 1 {
+		t.Fatalf("got %d recall events, want 1", len(page.Events))
+	}
+	ev := page.Events[0]
+	if ev.Query != "which database" {
+		t.Errorf("query = %q, want %q", ev.Query, "which database")
+	}
+	if len(ev.Memories) == 0 {
+		t.Fatal("recall event served no memories")
+	}
+	// Memories come back rank-ordered even though the store hands an
+	// operation's rows back in reverse (they share a created_at, so the id
+	// tiebreak runs backwards) — the grouped reader re-sorts them.
+	for i, m := range ev.Memories {
+		if m.Rank != i+1 {
+			t.Errorf("memory %d has rank %d, want %d", i, m.Rank, i+1)
+		}
+		if m.Score == nil {
+			t.Errorf("memory %d (%s) has no score", i, m.ID)
+		}
+		if m.Summary == "" {
+			t.Errorf("memory %d (%s) has no summary snapshot", i, m.ID)
+		}
+	}
+}
+
+// TestRecallWithNoHitsIsLogged pins the sentinel row: "this query found
+// nothing" is exactly what an activity feed exists to surface.
+func TestRecallWithNoHitsIsLogged(t *testing.T) {
+	ctx := context.Background()
+	svc := newEventSvc(t)
+
+	if _, err := svc.Recall(ctx, service.RecallInput{Namespace: "empty", Query: "anything at all", Limit: 5}); err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	page, err := svc.Events(ctx, service.EventsInput{Namespace: "empty"})
+	if err != nil {
+		t.Fatalf("events: %v", err)
+	}
+	if len(page.Events) != 1 {
+		t.Fatalf("got %d events, want 1 (the zero-hit sentinel)", len(page.Events))
+	}
+	ev := page.Events[0]
+	if ev.Kind != store.EventRecall || ev.Query != "anything at all" {
+		t.Fatalf("event = %+v, want a recall of the query", ev)
+	}
+	if len(ev.Memories) != 0 {
+		t.Fatalf("zero-hit recall listed %d memories, want none", len(ev.Memories))
+	}
+}
+
+// TestBriefingAndGetLogButDoNotReinforce protects the invariant the whole
+// log-vs-reinforce split rests on: reads that are not relevance signals must
+// appear in the feed without touching access_count, which gates promotion and
+// durable ranking.
+func TestBriefingAndGetLogButDoNotReinforce(t *testing.T) {
+	ctx := context.Background()
+	svc := newEventSvc(t)
+
+	m, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "n", Content: "the database is postgres", Tier: memory.TierSemantic,
+	})
+	if err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+	before, err := svc.Get(ctx, "n", m.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	baseline := before.AccessCount
+
+	if _, err := svc.Briefing(ctx, "n", service.BriefingOpts{}); err != nil {
+		t.Fatalf("briefing: %v", err)
+	}
+	if _, err := svc.Get(ctx, "n", m.ID); err != nil {
+		t.Fatalf("get after briefing: %v", err)
+	}
+
+	after, err := svc.Get(ctx, "n", m.ID)
+	if err != nil {
+		t.Fatalf("final get: %v", err)
+	}
+	if after.AccessCount != baseline {
+		t.Errorf("access_count = %d after briefing+gets, want %d unchanged: "+
+			"briefing/get must not reinforce, or every session start would inflate the counter",
+			after.AccessCount, baseline)
+	}
+
+	// But both are in the feed.
+	page, err := svc.Events(ctx, service.EventsInput{Namespace: "n"})
+	if err != nil {
+		t.Fatalf("events: %v", err)
+	}
+	kinds := map[store.EventKind]int{}
+	for _, ev := range page.Events {
+		kinds[ev.Kind]++
+	}
+	if kinds[store.EventBriefing] != 1 {
+		t.Errorf("briefing events = %d, want 1", kinds[store.EventBriefing])
+	}
+	if kinds[store.EventGet] == 0 {
+		t.Error("no get events logged")
+	}
+
+	// A recall, by contrast, does reinforce.
+	if _, err := svc.Recall(ctx, service.RecallInput{Namespace: "n", Query: "database", Limit: 5}); err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	recalled, err := svc.Get(ctx, "n", m.ID)
+	if err != nil {
+		t.Fatalf("get after recall: %v", err)
+	}
+	if recalled.AccessCount <= baseline {
+		t.Errorf("access_count = %d after recall, want > %d: recall must still reinforce",
+			recalled.AccessCount, baseline)
+	}
+}
+
+// TestBriefingEventCarriesSections checks the "why" for a briefing row: which
+// section of the briefing the memory was served under.
+func TestBriefingEventCarriesSections(t *testing.T) {
+	ctx := context.Background()
+	svc := newEventSvc(t)
+
+	if _, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "n", Content: "deploys go through CI", Tier: memory.TierSemantic,
+	}); err != nil {
+		t.Fatalf("remember fact: %v", err)
+	}
+	if _, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "n", Content: "run mise test to verify", Tier: memory.TierProcedural,
+	}); err != nil {
+		t.Fatalf("remember procedure: %v", err)
+	}
+	if _, err := svc.Briefing(ctx, "n", service.BriefingOpts{}); err != nil {
+		t.Fatalf("briefing: %v", err)
+	}
+
+	page, err := svc.Events(ctx, service.EventsInput{
+		Namespace: "n", Kinds: []store.EventKind{store.EventBriefing},
+	})
+	if err != nil {
+		t.Fatalf("events: %v", err)
+	}
+	if len(page.Events) != 1 {
+		t.Fatalf("got %d briefing events, want 1", len(page.Events))
+	}
+	sections := map[string]bool{}
+	for _, m := range page.Events[0].Memories {
+		sections[m.Section] = true
+	}
+	for _, want := range []string{"facts", "procedures"} {
+		if !sections[want] {
+			t.Errorf("no briefing memory tagged section %q (got %v)", want, sections)
+		}
+	}
+}
+
+// TestWriteEventsDistinguishRememberFromUpdate covers the one Upsert that backs
+// two verbs, plus forget and supersede snapshotting.
+func TestWriteEventsDistinguishRememberFromUpdate(t *testing.T) {
+	ctx := context.Background()
+	svc := newEventSvc(t)
+
+	m, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "n", Content: "original content", Tier: memory.TierSemantic,
+	})
+	if err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+	// Re-writing the same ID is an update, not a new memory.
+	if _, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "n", ID: m.ID, Content: "revised content", Tier: memory.TierSemantic,
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	page, err := svc.Events(ctx, service.EventsInput{
+		Namespace: "n", Kinds: []store.EventKind{store.EventRemember, store.EventUpdate},
+	})
+	if err != nil {
+		t.Fatalf("events: %v", err)
+	}
+	kinds := map[store.EventKind]int{}
+	for _, ev := range page.Events {
+		kinds[ev.Kind]++
+	}
+	if kinds[store.EventRemember] != 1 || kinds[store.EventUpdate] != 1 {
+		t.Fatalf("kinds = %v, want exactly one remember and one update", kinds)
+	}
+}
+
+// TestForgetEventKeepsSnapshot is why the log denormalizes the memory: after
+// the row is deleted, the snapshot is the only thing left that can describe
+// what was forgotten.
+func TestForgetEventKeepsSnapshot(t *testing.T) {
+	ctx := context.Background()
+	svc := newEventSvc(t)
+
+	m, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "n", Content: "a fact that will be deleted", Tier: memory.TierSemantic,
+	})
+	if err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+	if err := svc.Forget(ctx, "n", m.ID); err != nil {
+		t.Fatalf("forget: %v", err)
+	}
+
+	page, err := svc.Events(ctx, service.EventsInput{
+		Namespace: "n", Kinds: []store.EventKind{store.EventForget},
+	})
+	if err != nil {
+		t.Fatalf("events: %v", err)
+	}
+	if len(page.Events) != 1 || len(page.Events[0].Memories) != 1 {
+		t.Fatalf("forget event = %+v, want one event describing one memory", page.Events)
+	}
+	got := page.Events[0].Memories[0]
+	if got.ID != m.ID {
+		t.Errorf("forget event memory id = %q, want %q", got.ID, m.ID)
+	}
+	if got.Summary != "a fact that will be deleted" {
+		t.Errorf("forget event lost its snapshot: summary = %q", got.Summary)
+	}
+	// And the memory really is gone.
+	if _, err := svc.Get(ctx, "n", m.ID); err == nil {
+		t.Error("memory still readable after forget")
+	}
+}
+
+// TestEventsPaginationAndKindFilter covers the reader: newest-first ordering,
+// the operation-counted limit, and a cursor that neither repeats nor skips.
+func TestEventsPaginationAndKindFilter(t *testing.T) {
+	ctx := context.Background()
+	svc := newEventSvc(t)
+
+	const n = 5
+	for i := range n {
+		if _, err := svc.Remember(ctx, service.RememberInput{
+			Namespace: "n", Content: "fact number " + string(rune('a'+i)), Tier: memory.TierSemantic,
+		}); err != nil {
+			t.Fatalf("remember %d: %v", i, err)
+		}
+	}
+
+	page1, err := svc.Events(ctx, service.EventsInput{
+		Namespace: "n", Kinds: []store.EventKind{store.EventRemember}, Limit: 2,
+	})
+	if err != nil {
+		t.Fatalf("page 1: %v", err)
+	}
+	if len(page1.Events) != 2 || !page1.HasMore {
+		t.Fatalf("page 1: %d events, hasMore=%v; want 2 and true", len(page1.Events), page1.HasMore)
+	}
+	page2, err := svc.Events(ctx, service.EventsInput{
+		Namespace: "n", Kinds: []store.EventKind{store.EventRemember}, Limit: 2,
+		Before: page1.NextBefore, BeforeID: page1.NextBeforeID,
+	})
+	if err != nil {
+		t.Fatalf("page 2: %v", err)
+	}
+	if len(page2.Events) != 2 {
+		t.Fatalf("page 2 returned %d events, want 2", len(page2.Events))
+	}
+	seen := map[string]bool{}
+	for _, ev := range append(append([]service.ActivityEvent{}, page1.Events...), page2.Events...) {
+		if seen[ev.OpID] {
+			t.Fatalf("op %s returned on both pages: the cursor repeats rows", ev.OpID)
+		}
+		seen[ev.OpID] = true
+	}
+}
+
+// TestEventLogOffRecordsNothing checks the config toggle actually gates writes.
+func TestEventLogOffRecordsNothing(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlitevec.Open(ctx, filepath.Join(t.TempDir(), "off.db"), dims)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	svc := service.New(st, embedtest.New(dims), service.WithSyncReinforce(), service.WithEventLog(false))
+
+	if _, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "n", Content: "unlogged", Tier: memory.TierSemantic,
+	}); err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+	if _, err := svc.Recall(ctx, service.RecallInput{Namespace: "n", Query: "unlogged", Limit: 5}); err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	page, err := svc.Events(ctx, service.EventsInput{Namespace: "n"})
+	if err != nil {
+		t.Fatalf("events: %v", err)
+	}
+	if len(page.Events) != 0 {
+		t.Fatalf("event log disabled but %d events recorded", len(page.Events))
+	}
+}
+
+// TestPruneEvents covers the retention path the sweeper drives.
+func TestPruneEvents(t *testing.T) {
+	ctx := context.Background()
+	svc := newEventSvc(t)
+
+	for i := range 3 {
+		if _, err := svc.Remember(ctx, service.RememberInput{
+			Namespace: "n", Content: "fact " + string(rune('a'+i)), Tier: memory.TierSemantic,
+		}); err != nil {
+			t.Fatalf("remember %d: %v", i, err)
+		}
+	}
+	// Cap the log at one row; the newest survives.
+	if _, err := svc.PruneEvents(ctx, time.Time{}, 1); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	page, err := svc.Events(ctx, service.EventsInput{Namespace: "n"})
+	if err != nil {
+		t.Fatalf("events: %v", err)
+	}
+	if len(page.Events) != 1 {
+		t.Fatalf("after cap prune, %d events remain, want 1", len(page.Events))
+	}
+	// Both bounds unset means keep forever — a prune must not empty the log.
+	if _, err := svc.PruneEvents(ctx, time.Time{}, 0); err != nil {
+		t.Fatalf("no-op prune: %v", err)
+	}
+	page, err = svc.Events(ctx, service.EventsInput{Namespace: "n"})
+	if err != nil {
+		t.Fatalf("events after no-op prune: %v", err)
+	}
+	if len(page.Events) != 1 {
+		t.Fatalf("no-op prune deleted rows: %d events remain, want 1", len(page.Events))
+	}
+}

--- a/internal/service/query.go
+++ b/internal/service/query.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
@@ -25,15 +26,28 @@ type ListInput struct {
 	Tags []string
 	// Metadata narrows the listing to memories whose top-level metadata contains
 	// each listed key=value string pair (AND).
-	Metadata          map[string]string
+	Metadata map[string]string
+	// MemoryTypes narrows to memories whose metadata.memory_type is any of the
+	// listed values (OR) — the multi-select the browser's type filter needs,
+	// which Metadata's AND-one-value-per-key semantics cannot express.
+	MemoryTypes []string
+	// CreatedAfter/AccessedAfter narrow to memories created / last accessed at or
+	// after the instant. Zero means no constraint.
+	CreatedAfter      time.Time
+	AccessedAfter     time.Time
 	IncludeExpired    bool
 	IncludeSuperseded bool
+	// Sort orders the listing; the zero value is newest-created first.
+	Sort store.Sort
 	// Limit caps the result count; <= 0 returns all matches.
 	Limit int
 	// AllNamespaces lists across every namespace instead of in.Namespace, with
-	// Limit applied as a single global cap (newest first). Backs the admin UI's
+	// Limit applied as a single global cap under Sort. Backs the admin UI's
 	// "All projects" view.
 	AllNamespaces bool
+	// Namespaces, with AllNamespaces, restricts the aggregate to these namespaces
+	// (exact match); empty means every namespace. Ignored without AllNamespaces.
+	Namespaces []string
 }
 
 // List returns memories in a namespace matching the filter, without embeddings.
@@ -44,34 +58,72 @@ func (s *Service) List(ctx context.Context, in ListInput) ([]*memory.Memory, err
 		Levels:            in.Levels,
 		Tags:              in.Tags,
 		Metadata:          in.Metadata,
+		MemoryTypes:       in.MemoryTypes,
+		CreatedAfter:      in.CreatedAfter,
+		AccessedAfter:     in.AccessedAfter,
 		IncludeExpired:    in.IncludeExpired,
 		IncludeSuperseded: in.IncludeSuperseded,
+		Sort:              in.Sort,
 		Now:               s.now(),
 	}
 	if !in.AllNamespaces {
 		return s.store.List(ctx, in.Namespace, f, in.Limit)
 	}
 
-	names, err := s.store.ListNamespaces(ctx)
-	if err != nil {
-		return nil, err
+	names := in.Namespaces
+	if len(names) == 0 {
+		var err error
+		if names, err = s.store.ListNamespaces(ctx); err != nil {
+			return nil, err
+		}
 	}
 	var all []*memory.Memory
 	for _, ns := range names {
-		// Each namespace contributes its top Limit: any of them may hold the
-		// globally newest memories, decided by the merge sort below.
+		// Each namespace contributes its top Limit under the same sort: any of
+		// them may hold the globally top memories, and a per-namespace top-N
+		// always contains that namespace's share of the global top-N, so the
+		// merge below cannot miss a row the global query would have returned.
 		mems, err := s.store.List(ctx, ns, f, in.Limit)
 		if err != nil {
 			return nil, err
 		}
 		all = append(all, mems...)
 	}
-	// Newest first, so the global cap keeps the most recent memories.
-	sort.SliceStable(all, func(i, j int) bool { return all[i].CreatedAt.After(all[j].CreatedAt) })
+	sortMemories(all, in.Sort)
 	if in.Limit > 0 && len(all) > in.Limit {
 		all = all[:in.Limit]
 	}
 	return all, nil
+}
+
+// sortMemories orders ms the way the store's ORDER BY does, so merging
+// per-namespace pages reproduces the order a single global query would have
+// returned. Keep this in lockstep with the drivers' orderClause — same key,
+// same direction, same id tie-break.
+func sortMemories(ms []*memory.Memory, s store.Sort) {
+	less := func(a, b *memory.Memory) int {
+		var c int
+		switch s.Key {
+		case store.SortUpdatedAt:
+			c = a.UpdatedAt.Compare(b.UpdatedAt)
+		case store.SortLastAccessedAt:
+			c = a.LastAccessedAt.Compare(b.LastAccessedAt)
+		case store.SortAccessCount:
+			c = cmp.Compare(a.AccessCount, b.AccessCount)
+		case store.SortImportance:
+			c = cmp.Compare(a.Importance, b.Importance)
+		default: // store.SortCreatedAt and the zero value
+			c = a.CreatedAt.Compare(b.CreatedAt)
+		}
+		if !s.Asc {
+			c = -c
+		}
+		if c != 0 {
+			return c
+		}
+		return cmp.Compare(a.ID, b.ID) // ties break on id ascending, as in SQL
+	}
+	slices.SortStableFunc(ms, less)
 }
 
 // Stats summarizes a namespace for the UI dashboard. Counts are computed from a
@@ -386,6 +438,13 @@ func (s *Service) Briefing(ctx context.Context, namespace string, opts BriefingO
 			return Briefing{}, err
 		}
 	}
+	// Log what the briefing served, after the per-section caps, so the feed
+	// records the memories actually handed to the caller. Logged but never
+	// reinforced: a briefing fires on every session start over the same top-N
+	// regardless of relevance, so counting it as "used" would inflate
+	// access_count uniformly and distort the promotion and ranking that depend
+	// on it. The activity log carries the fact; the counters stay clean.
+	s.logBriefingEvent(ctx, namespace, b)
 	return b, nil
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -192,6 +192,11 @@ func invalidInputf(format string, args ...any) error {
 	return fmt.Errorf(format+": %w", append(args, ErrInvalidInput)...)
 }
 
+// ErrUnsupported marks an operation the configured storage driver cannot serve
+// because it lacks the optional capability the operation needs (e.g. reading
+// the activity log from a driver with no event log). API layers map it to 501.
+var ErrUnsupported = errors.New("unsupported by this storage backend")
+
 // Service wires storage and embeddings together. It is safe for concurrent use.
 type Service struct {
 	store    store.Store
@@ -285,6 +290,10 @@ type Service struct {
 	metrics Metrics
 	// syncReinforce makes recall reinforcement synchronous (deterministic tests).
 	syncReinforce bool
+	// eventLogOn records reads and writes to the activity log (see events.go).
+	eventLogOn bool
+	// syncEventLog makes activity-log writes synchronous (deterministic tests).
+	syncEventLog bool
 
 	// shortTermCap bounds short-term memories per namespace during fsck (0 = off).
 	shortTermCap int
@@ -479,6 +488,13 @@ func WithMetrics(m Metrics) Option { return func(s *Service) { s.metrics = m } }
 
 // WithSyncReinforce makes recall reinforcement run synchronously (tests).
 func WithSyncReinforce() Option { return func(s *Service) { s.syncReinforce = true } }
+
+// WithEventLog records reads and writes to the activity log (see events.go).
+// A no-op against a driver that does not implement store.EventLogStore.
+func WithEventLog(on bool) Option { return func(s *Service) { s.eventLogOn = on } }
+
+// WithSyncEventLog makes activity-log writes run synchronously (tests).
+func WithSyncEventLog() Option { return func(s *Service) { s.syncEventLog = true } }
 
 // WithShortTermCap bounds short-term memories per namespace, enforced by fsck.
 func WithShortTermCap(cap int) Option { return func(s *Service) { s.shortTermCap = cap } }
@@ -1108,6 +1124,8 @@ func (s *Service) Remember(ctx context.Context, in RememberInput) (*memory.Memor
 		s.metrics.RememberResult("error", string(tier))
 		return nil, fmt.Errorf("remember: store: %w", err)
 	}
+
+	s.logWriteEvent(ctx, m, existing)
 
 	// Auto-supersede: now that the replacement is durably stored, tombstone the
 	// near-duplicate in the background. Deferred to here so a failed Upsert above
@@ -1928,6 +1946,10 @@ func (s *Service) Recall(ctx context.Context, in RecallInput) ([]store.Scored, e
 	results := s.finalizeRecall(ctx, in.Query, ranked, k)
 	results = s.maybeExpandLinked(ctx, in, results, k)
 	s.reinforceResults(ctx, results)
+	// Reinforcement rolls usage up into per-memory counters; the activity log
+	// keeps the detail those counters throw away — which query served this
+	// memory, at what rank, with what score.
+	s.logRecallEvent(ctx, in, results)
 	s.metrics.RecallResult("ok", tf, hitsBucket(len(results)))
 	return results, nil
 }
@@ -2682,8 +2704,18 @@ func metaSeconds(v any) (int64, bool) {
 }
 
 // Get returns a single memory by ID.
+//
+// A get is logged to the activity feed but deliberately does not reinforce:
+// reinforcement is a relevance signal (it slides TTLs and gates promotion), and
+// addressing a memory by ID — which is what the UI drawer does — says nothing
+// about whether it answered a question.
 func (s *Service) Get(ctx context.Context, namespace, id string) (*memory.Memory, error) {
-	return s.store.Get(ctx, namespace, id)
+	m, err := s.store.Get(ctx, namespace, id)
+	if err != nil {
+		return nil, err
+	}
+	s.logMemoryEvent(ctx, store.EventGet, namespace, m, nil)
+	return m, nil
 }
 
 // History returns the full supersession lineage of a memory: the memory itself,
@@ -2752,10 +2784,19 @@ func (s *Service) History(ctx context.Context, namespace, id string) ([]*memory.
 func (s *Service) Forget(ctx context.Context, namespace, id string) error {
 	start := time.Now()
 	defer func() { s.metrics.OpDuration("forget", time.Since(start)) }()
+	// Snapshot before deleting: after the row is gone there is nothing left to
+	// describe it, and an activity feed that can only say "some memory was
+	// forgotten" is not worth much. Best-effort — a failed read here must not
+	// block the delete.
+	var doomed *memory.Memory
+	if _, ok := s.eventLog(); ok {
+		doomed, _ = s.store.Get(ctx, namespace, id)
+	}
 	err := s.store.Delete(ctx, namespace, id)
 	switch {
 	case err == nil:
 		s.metrics.ForgetResult("ok")
+		s.logMemoryEvent(ctx, store.EventForget, namespace, doomed, nil)
 	case errors.Is(err, store.ErrNotFound):
 		s.metrics.ForgetResult("not_found")
 	default:
@@ -2776,10 +2817,18 @@ func (s *Service) Supersede(ctx context.Context, namespace, id, supersededBy str
 	if strings.TrimSpace(supersededBy) == "" {
 		return invalidInputf("supersede: supersededBy is required")
 	}
+	// Snapshot the memory as it was before the tombstone, so the feed can say
+	// what was replaced rather than just that something was.
+	var replaced *memory.Memory
+	if _, ok := s.eventLog(); ok {
+		replaced, _ = s.store.Get(ctx, namespace, id)
+	}
 	err := s.store.SetSuperseded(ctx, namespace, id, supersededBy)
 	switch {
 	case err == nil:
 		s.metrics.SupersedeResult("ok")
+		s.logMemoryEvent(ctx, store.EventSupersede, namespace, replaced,
+			map[string]any{"superseded_by": supersededBy})
 	case errors.Is(err, store.ErrNotFound):
 		s.metrics.SupersedeResult("not_found")
 	default:

--- a/internal/store/postgres/events.go
+++ b/internal/store/postgres/events.go
@@ -1,0 +1,157 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/eleboucher/memini/internal/memory"
+	"github.com/eleboucher/memini/internal/store"
+)
+
+var _ store.EventLogStore = (*Store)(nil)
+
+const eventColumns = `id, op_id, kind, namespace, query, memory_id, memory_ns,
+	memory_tier, memory_summary, rank, score, detail, created_at`
+
+// AppendEvents inserts one operation's rows in a single batch, so they land
+// contiguously and share a created_at — the adjacency ListEvents' ordering
+// relies on to let the reader regroup flat rows back into whole events.
+func (s *Store) AppendEvents(ctx context.Context, events []store.Event) error {
+	if len(events) == 0 {
+		return nil
+	}
+	batch := &pgx.Batch{}
+	for _, e := range events {
+		detail, err := json.Marshal(store.OrEmptyMap(e.Detail))
+		if err != nil {
+			return fmt.Errorf("postgres: marshal event detail: %w", err)
+		}
+		batch.Queue(
+			`INSERT INTO memory_events
+				(op_id, kind, namespace, query, memory_id, memory_ns, memory_tier,
+				 memory_summary, rank, score, detail, created_at)
+			 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb,$12)`,
+			e.OpID, string(e.Kind), e.Namespace, e.Query, e.MemoryID, e.MemoryNS,
+			string(e.MemoryTier), e.MemorySummary, e.Rank, e.Score,
+			string(detail), e.CreatedAt,
+		)
+	}
+	if err := s.pool.SendBatch(ctx, batch).Close(); err != nil {
+		return fmt.Errorf("postgres: insert events: %w", err)
+	}
+	return nil
+}
+
+// ListEvents returns rows matching f, newest first.
+func (s *Store) ListEvents(ctx context.Context, f store.EventFilter) ([]store.Event, error) {
+	b := &args{}
+	var q strings.Builder
+	q.WriteString(`SELECT ` + eventColumns + ` FROM memory_events WHERE true`)
+
+	if f.Namespace != "" {
+		q.WriteString(" AND namespace = " + b.add(f.Namespace))
+	} else if len(f.Namespaces) > 0 {
+		q.WriteString(" AND namespace = ANY(" + b.add(f.Namespaces) + ")")
+	}
+	if len(f.Kinds) > 0 {
+		kinds := make([]string, len(f.Kinds))
+		for i, k := range f.Kinds {
+			kinds[i] = string(k)
+		}
+		q.WriteString(" AND kind = ANY(" + b.add(kinds) + ")")
+	}
+	if !f.Since.IsZero() {
+		q.WriteString(" AND created_at >= " + b.add(f.Since))
+	}
+	// Tiers and Text match the operation, not the row: a recall that served a
+	// semantic memory is returned whole — all of its rows — so the event still
+	// reports what it actually served. Filtering rows here instead would make a
+	// 5-memory recall render as a 2-memory one.
+	if len(f.Tiers) > 0 {
+		tiers := make([]string, len(f.Tiers))
+		for i, t := range f.Tiers {
+			tiers[i] = string(t)
+		}
+		q.WriteString(" AND op_id IN (SELECT op_id FROM memory_events WHERE memory_tier = ANY(" +
+			b.add(tiers) + "))")
+	}
+	if f.Text != "" {
+		pat := b.add("%" + escapeLike(f.Text) + "%")
+		q.WriteString(" AND op_id IN (SELECT op_id FROM memory_events WHERE query ILIKE " + pat +
+			" ESCAPE '\\' OR memory_summary ILIKE " + pat + " ESCAPE '\\')")
+	}
+	// Keyset cursor: strictly older than (Before, BeforeID) in the
+	// (created_at DESC, id DESC) ordering, so a page never repeats or skips a
+	// row when new events land mid-pagination (an OFFSET would do both).
+	if !f.Before.IsZero() {
+		before := b.add(f.Before)
+		q.WriteString(" AND (created_at < " + before +
+			" OR (created_at = " + before + " AND id < " + b.add(f.BeforeID) + "))")
+	}
+	q.WriteString(" ORDER BY created_at DESC, id DESC")
+	if f.Limit > 0 {
+		q.WriteString(" LIMIT " + b.add(f.Limit))
+	}
+
+	rs, err := s.pool.Query(ctx, q.String(), b.vals...)
+	if err != nil {
+		return nil, err
+	}
+	defer rs.Close()
+
+	var out []store.Event
+	for rs.Next() {
+		var (
+			e      store.Event
+			kind   string
+			tier   string
+			detail []byte
+		)
+		if err := rs.Scan(&e.ID, &e.OpID, &kind, &e.Namespace, &e.Query, &e.MemoryID,
+			&e.MemoryNS, &tier, &e.MemorySummary, &e.Rank, &e.Score, &detail, &e.CreatedAt); err != nil {
+			return nil, err
+		}
+		e.Kind = store.EventKind(kind)
+		e.MemoryTier = memory.Tier(tier)
+		e.CreatedAt = e.CreatedAt.UTC()
+		if len(detail) > 0 {
+			if err := json.Unmarshal(detail, &e.Detail); err != nil {
+				return nil, fmt.Errorf("postgres: unmarshal event detail: %w", err)
+			}
+		}
+		out = append(out, e)
+	}
+	return out, rs.Err()
+}
+
+// PruneEvents trims the log by age and by row cap.
+func (s *Store) PruneEvents(ctx context.Context, olderThan time.Time, keepMax int) (int64, error) {
+	var deleted int64
+	if !olderThan.IsZero() {
+		tag, err := s.pool.Exec(ctx,
+			`DELETE FROM memory_events WHERE created_at < $1`, olderThan)
+		if err != nil {
+			return deleted, fmt.Errorf("postgres: prune events by age: %w", err)
+		}
+		deleted += tag.RowsAffected()
+	}
+	if keepMax > 0 {
+		// Delete everything outside the newest keepMax rows.
+		tag, err := s.pool.Exec(ctx,
+			`DELETE FROM memory_events WHERE id IN (
+				SELECT id FROM memory_events
+				ORDER BY created_at DESC, id DESC
+				OFFSET $1
+			)`, keepMax)
+		if err != nil {
+			return deleted, fmt.Errorf("postgres: prune events by cap: %w", err)
+		}
+		deleted += tag.RowsAffected()
+	}
+	return deleted, nil
+}

--- a/internal/store/postgres/helpers.go
+++ b/internal/store/postgres/helpers.go
@@ -59,6 +59,17 @@ func filterClause(b *args, f store.Filter) string {
 		}
 		clause += ex.String()
 	}
+	// MemoryTypes: metadata.memory_type matching ANY listed value (OR), unlike
+	// Metadata's AND-with-one-value-per-key.
+	if len(f.MemoryTypes) > 0 {
+		clause += " AND metadata->>'memory_type' = ANY(" + b.add(f.MemoryTypes) + ")"
+	}
+	if !f.CreatedAfter.IsZero() {
+		clause += " AND created_at >= " + b.add(f.CreatedAfter)
+	}
+	if !f.AccessedAfter.IsZero() {
+		clause += " AND last_accessed_at >= " + b.add(f.AccessedAfter)
+	}
 	// For a time-travel query, "live" means live at AsOf, not at the current
 	// wall clock — a memory that has since expired was still valid then.
 	ref := f.Now
@@ -253,4 +264,36 @@ func tsQuery(query string) string {
 	}
 	flush()
 	return strings.Join(terms, " | ")
+}
+
+// orderClause maps a sort onto an ORDER BY over the memories table. The column
+// comes from a whitelist switch, never from the caller's string, so an
+// unrecognized key degrades to created_at rather than reaching SQL. Ties break
+// on id so a capped listing is deterministic — and so the ordering matches the
+// sqlite driver's byte for byte, which the all-namespaces merge relies on.
+func orderClause(s store.Sort) string {
+	col := "created_at"
+	switch s.Key {
+	case store.SortUpdatedAt:
+		col = "updated_at"
+	case store.SortLastAccessedAt:
+		col = "last_accessed_at"
+	case store.SortAccessCount:
+		col = "access_count"
+	case store.SortImportance:
+		col = "importance"
+	}
+	dir := "DESC"
+	if s.Asc {
+		dir = "ASC"
+	}
+	return " ORDER BY " + col + " " + dir + ", id ASC"
+}
+
+// escapeLike neutralizes LIKE/ILIKE's wildcards so a user's literal "%" or "_"
+// searches for that character instead of matching everything. Pair it with
+// ESCAPE '\' on the LIKE.
+func escapeLike(s string) string {
+	r := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return r.Replace(s)
 }

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -148,6 +148,31 @@ func migrate(ctx context.Context, conn *pgx.Conn, dims int) error {
 		)`,
 		// Backfill default_ns on databases whose api_keys table predates it.
 		`ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS default_ns text NOT NULL DEFAULT ''`,
+		// memory_events is the activity log (see store.EventLogStore): one row
+		// per (operation, memory), rows of one operation sharing op_id. The
+		// memory_* columns are a snapshot, not a join — they keep the feed a
+		// single query and keep a forget event readable after its memory is gone.
+		`CREATE TABLE IF NOT EXISTS memory_events (
+			id             bigserial PRIMARY KEY,
+			op_id          text NOT NULL,
+			kind           text NOT NULL,
+			namespace      text NOT NULL,
+			query          text NOT NULL DEFAULT '',
+			memory_id      text NOT NULL DEFAULT '',
+			memory_ns      text NOT NULL DEFAULT '',
+			memory_tier    text NOT NULL DEFAULT '',
+			memory_summary text NOT NULL DEFAULT '',
+			rank           integer NOT NULL DEFAULT 0,
+			score          double precision,
+			detail         jsonb NOT NULL DEFAULT '{}',
+			created_at     timestamptz NOT NULL
+		)`,
+		// The read path is always newest-first, optionally narrowed by namespace;
+		// the (created_at DESC, id DESC) tail matches ListEvents' ordering so the
+		// keyset cursor walks the index.
+		`CREATE INDEX IF NOT EXISTS idx_memory_events_ns_time ON memory_events(namespace, created_at DESC, id DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_memory_events_time ON memory_events(created_at DESC, id DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_memory_events_memory ON memory_events(memory_id)`,
 	}
 	for _, q := range stmts {
 		if _, err := conn.Exec(ctx, q); err != nil {
@@ -450,12 +475,14 @@ func (s *Store) ListExpired(ctx context.Context, now time.Time, limit int) ([]*m
 	return out, rows.Err()
 }
 
-// List returns memories in a namespace matching f (without embeddings).
+// List returns memories in a namespace matching f (without embeddings),
+// ordered by f.Sort (newest-created first by default).
 func (s *Store) List(ctx context.Context, namespace string, f store.Filter, limit int) ([]*memory.Memory, error) {
 	b := &args{}
 	ns := b.add(namespace)
 	where := filterClause(b, f)
-	q := fmt.Sprintf(`SELECT %s FROM memories WHERE namespace = %s%s`, memoryColumns, ns, where)
+	q := fmt.Sprintf(`SELECT %s FROM memories WHERE namespace = %s%s%s`,
+		memoryColumns, ns, where, orderClause(f.Sort))
 	if limit > 0 {
 		q += " LIMIT " + b.add(limit)
 	}

--- a/internal/store/sqlitevec/events.go
+++ b/internal/store/sqlitevec/events.go
@@ -1,0 +1,189 @@
+package sqlitevec
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/eleboucher/memini/internal/memory"
+	"github.com/eleboucher/memini/internal/store"
+)
+
+var _ store.EventLogStore = (*Store)(nil)
+
+const eventColumns = `id, op_id, kind, namespace, query, memory_id, memory_ns,
+	memory_tier, memory_summary, rank, score, detail, created_at`
+
+// AppendEvents inserts one operation's rows in a single transaction, so they
+// land contiguously and share a created_at — the adjacency ListEvents' ordering
+// relies on to let the reader regroup flat rows back into whole events.
+func (s *Store) AppendEvents(ctx context.Context, events []store.Event) error {
+	if len(events) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, e := range events {
+		detail, err := json.Marshal(store.OrEmptyMap(e.Detail))
+		if err != nil {
+			return fmt.Errorf("sqlitevec: marshal event detail: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO memory_events
+				(op_id, kind, namespace, query, memory_id, memory_ns, memory_tier,
+				 memory_summary, rank, score, detail, created_at)
+			 VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+			e.OpID, string(e.Kind), e.Namespace, e.Query, e.MemoryID, e.MemoryNS,
+			string(e.MemoryTier), e.MemorySummary, e.Rank, f64Ptr(e.Score),
+			string(detail), ms(e.CreatedAt),
+		); err != nil {
+			return fmt.Errorf("sqlitevec: insert event: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+// ListEvents returns rows matching f, newest first.
+func (s *Store) ListEvents(ctx context.Context, f store.EventFilter) ([]store.Event, error) {
+	var b strings.Builder
+	var args []any
+	b.WriteString(`SELECT ` + eventColumns + ` FROM memory_events WHERE 1=1`)
+
+	if f.Namespace != "" {
+		b.WriteString(" AND namespace = ?")
+		args = append(args, f.Namespace)
+	} else if len(f.Namespaces) > 0 {
+		b.WriteString(" AND namespace IN (")
+		for i, ns := range f.Namespaces {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			b.WriteString("?")
+			args = append(args, ns)
+		}
+		b.WriteString(")")
+	}
+	if len(f.Kinds) > 0 {
+		b.WriteString(" AND kind IN (")
+		for i, k := range f.Kinds {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			b.WriteString("?")
+			args = append(args, string(k))
+		}
+		b.WriteString(")")
+	}
+	if !f.Since.IsZero() {
+		b.WriteString(" AND created_at >= ?")
+		args = append(args, ms(f.Since))
+	}
+	// Tiers and Text match the operation, not the row: a recall that served a
+	// semantic memory is returned whole — all of its rows — so the event still
+	// reports what it actually served. Filtering rows here instead would make a
+	// 5-memory recall render as a 2-memory one.
+	if len(f.Tiers) > 0 {
+		b.WriteString(" AND op_id IN (SELECT op_id FROM memory_events WHERE memory_tier IN (")
+		for i, t := range f.Tiers {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			b.WriteString("?")
+			args = append(args, string(t))
+		}
+		b.WriteString("))")
+	}
+	if f.Text != "" {
+		pat := "%" + escapeLike(strings.ToLower(f.Text)) + "%"
+		b.WriteString(` AND op_id IN (SELECT op_id FROM memory_events
+			WHERE lower(query) LIKE ? ESCAPE '\' OR lower(memory_summary) LIKE ? ESCAPE '\')`)
+		args = append(args, pat, pat)
+	}
+	// Keyset cursor: strictly older than (Before, BeforeID) in the
+	// (created_at DESC, id DESC) ordering, so a page never repeats or skips a
+	// row when new events land mid-pagination (an OFFSET would do both).
+	if !f.Before.IsZero() {
+		b.WriteString(" AND (created_at < ? OR (created_at = ? AND id < ?))")
+		args = append(args, ms(f.Before), ms(f.Before), f.BeforeID)
+	}
+	b.WriteString(" ORDER BY created_at DESC, id DESC")
+	if f.Limit > 0 {
+		b.WriteString(" LIMIT ?")
+		args = append(args, f.Limit)
+	}
+
+	rows, err := s.db.QueryContext(ctx, b.String(), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []store.Event
+	for rows.Next() {
+		var (
+			e         store.Event
+			kind      string
+			tier      string
+			detail    string
+			score     *float64
+			createdAt int64
+		)
+		if err := rows.Scan(&e.ID, &e.OpID, &kind, &e.Namespace, &e.Query, &e.MemoryID,
+			&e.MemoryNS, &tier, &e.MemorySummary, &e.Rank, &score, &detail, &createdAt); err != nil {
+			return nil, err
+		}
+		e.Kind = store.EventKind(kind)
+		e.MemoryTier = memory.Tier(tier)
+		e.Score = score
+		e.CreatedAt = fromMs(createdAt)
+		if detail != "" {
+			if err := json.Unmarshal([]byte(detail), &e.Detail); err != nil {
+				return nil, fmt.Errorf("sqlitevec: unmarshal event detail: %w", err)
+			}
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// PruneEvents trims the log by age and by row cap.
+func (s *Store) PruneEvents(ctx context.Context, olderThan time.Time, keepMax int) (int64, error) {
+	var deleted int64
+	if !olderThan.IsZero() {
+		res, err := s.db.ExecContext(ctx,
+			`DELETE FROM memory_events WHERE created_at < ?`, ms(olderThan))
+		if err != nil {
+			return deleted, fmt.Errorf("sqlitevec: prune events by age: %w", err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return deleted, err
+		}
+		deleted += n
+	}
+	if keepMax > 0 {
+		// Delete everything outside the newest keepMax rows. LIMIT -1 means "no
+		// limit" in SQLite, which is how an OFFSET-only subselect is spelled.
+		res, err := s.db.ExecContext(ctx,
+			`DELETE FROM memory_events WHERE id IN (
+				SELECT id FROM memory_events
+				ORDER BY created_at DESC, id DESC
+				LIMIT -1 OFFSET ?
+			)`, keepMax)
+		if err != nil {
+			return deleted, fmt.Errorf("sqlitevec: prune events by cap: %w", err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return deleted, err
+		}
+		deleted += n
+	}
+	return deleted, nil
+}

--- a/internal/store/sqlitevec/helpers.go
+++ b/internal/store/sqlitevec/helpers.go
@@ -131,6 +131,27 @@ func filterClause(f store.Filter) (string, []any) {
 		b.WriteString(" AND NOT EXISTS (SELECT 1 FROM json_each(" + alias + ".metadata) WHERE key = ? AND value = ?)")
 		args = append(args, k, v)
 	}
+	// MemoryTypes: metadata.memory_type matching ANY listed value (OR), unlike
+	// Metadata's AND-with-one-value-per-key.
+	if len(f.MemoryTypes) > 0 {
+		b.WriteString(" AND EXISTS (SELECT 1 FROM json_each(" + alias + ".metadata) WHERE key = 'memory_type' AND value IN (")
+		for i, t := range f.MemoryTypes {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			b.WriteString("?")
+			args = append(args, t)
+		}
+		b.WriteString("))")
+	}
+	if !f.CreatedAfter.IsZero() {
+		b.WriteString(" AND " + alias + ".created_at >= ?")
+		args = append(args, ms(f.CreatedAfter))
+	}
+	if !f.AccessedAfter.IsZero() {
+		b.WriteString(" AND " + alias + ".last_accessed_at >= ?")
+		args = append(args, ms(f.AccessedAfter))
+	}
 	// For a time-travel query, "live" means live at AsOf, not at the current
 	// wall clock — a memory that has since expired was still valid then.
 	ref := f.Now
@@ -314,4 +335,35 @@ func strPtr(s *string) any {
 		return nil
 	}
 	return *s
+}
+
+// escapeLike neutralizes LIKE's wildcards so a user's literal "%" or "_"
+// searches for that character instead of matching everything. Pair it with
+// ESCAPE '\' on the LIKE.
+func escapeLike(s string) string {
+	r := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return r.Replace(s)
+}
+
+// orderClause maps a sort onto an ORDER BY over the memories table aliased as
+// "m". The column comes from a whitelist switch, never from the caller's
+// string, so an unrecognized key degrades to created_at rather than reaching
+// SQL. Ties break on id so a capped listing is deterministic.
+func orderClause(s store.Sort) string {
+	col := "m.created_at"
+	switch s.Key {
+	case store.SortUpdatedAt:
+		col = "m.updated_at"
+	case store.SortLastAccessedAt:
+		col = "m.last_accessed_at"
+	case store.SortAccessCount:
+		col = "m.access_count"
+	case store.SortImportance:
+		col = "m.importance"
+	}
+	dir := "DESC"
+	if s.Asc {
+		dir = "ASC"
+	}
+	return " ORDER BY " + col + " " + dir + ", m.id ASC"
 }

--- a/internal/store/sqlitevec/store.go
+++ b/internal/store/sqlitevec/store.go
@@ -141,6 +141,32 @@ func (s *Store) migrate(ctx context.Context) error {
 			created_at TEXT NOT NULL,
 			disabled   INTEGER NOT NULL DEFAULT 0
 		)`,
+		// memory_events is the activity log (see store.EventLogStore): one row
+		// per (operation, memory), rows of one operation sharing op_id. The
+		// memory_* columns are a snapshot, not a join — they keep the feed a
+		// single query and keep a forget event readable after its memory is
+		// gone. Timestamps are unix millis, as in memories above.
+		`CREATE TABLE IF NOT EXISTS memory_events (
+			id             INTEGER PRIMARY KEY,
+			op_id          TEXT NOT NULL,
+			kind           TEXT NOT NULL,
+			namespace      TEXT NOT NULL,
+			query          TEXT NOT NULL DEFAULT '',
+			memory_id      TEXT NOT NULL DEFAULT '',
+			memory_ns      TEXT NOT NULL DEFAULT '',
+			memory_tier    TEXT NOT NULL DEFAULT '',
+			memory_summary TEXT NOT NULL DEFAULT '',
+			rank           INTEGER NOT NULL DEFAULT 0,
+			score          REAL,
+			detail         TEXT NOT NULL DEFAULT '{}',
+			created_at     INTEGER NOT NULL
+		)`,
+		// The read path is always newest-first, optionally narrowed by namespace;
+		// the (created_at DESC, id DESC) tail matches ListEvents' ordering so the
+		// keyset cursor walks the index.
+		`CREATE INDEX IF NOT EXISTS idx_memory_events_ns_time ON memory_events(namespace, created_at DESC, id DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_memory_events_time ON memory_events(created_at DESC, id DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_memory_events_memory ON memory_events(memory_id)`,
 	}
 	for _, q := range stmts {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -597,10 +623,11 @@ func (s *Store) ListExpired(ctx context.Context, now time.Time, limit int) ([]*m
 	return out, rows.Err()
 }
 
-// List returns memories in a namespace matching f (without embeddings).
+// List returns memories in a namespace matching f (without embeddings),
+// ordered by f.Sort (newest-created first by default).
 func (s *Store) List(ctx context.Context, namespace string, f store.Filter, limit int) ([]*memory.Memory, error) {
 	where, args := filterClause(f)
-	q := `SELECT ` + memoryColumns + ` FROM memories m WHERE m.namespace = ?` + where
+	q := `SELECT ` + memoryColumns + ` FROM memories m WHERE m.namespace = ?` + where + orderClause(f.Sort)
 	callArgs := append([]any{namespace}, args...)
 	if limit > 0 {
 		q += " LIMIT ?"

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -61,6 +61,43 @@ type Filter struct {
 	// treating NULL bounds as open). It overrides the superseded exclusion, so a
 	// fact that was true then but has since been replaced is still returned.
 	AsOf time.Time
+	// MemoryTypes restricts results to memories whose top-level
+	// metadata["memory_type"] equals one of the listed values (OR). Empty means
+	// no constraint. Unlike Metadata (AND, one value per key), this expresses the
+	// multi-select the UI's memory-type filter needs.
+	MemoryTypes []string
+	// CreatedAfter restricts results to memories created at or after the instant.
+	// The zero value means no constraint.
+	CreatedAfter time.Time
+	// AccessedAfter restricts results to memories last accessed at or after the
+	// instant. The zero value means no constraint.
+	AccessedAfter time.Time
+	// Sort orders the results. It is honored by List only: the search methods
+	// return results best-first by relevance and ignore it.
+	Sort Sort
+}
+
+// SortKey names a column List can order by. Values are the wire-level names the
+// REST layer accepts, so an unknown key never reaches SQL — drivers map keys
+// through a whitelist switch and fall back to SortCreatedAt.
+type SortKey string
+
+const (
+	SortCreatedAt      SortKey = "created_at"
+	SortUpdatedAt      SortKey = "updated_at"
+	SortLastAccessedAt SortKey = "last_accessed_at"
+	SortAccessCount    SortKey = "access_count"
+	SortImportance     SortKey = "importance"
+)
+
+// Sort orders a listing. The zero value means created_at descending (newest
+// first) — the order the UI browser wants by default, and the order the
+// all-namespaces aggregate has always merged in.
+type Sort struct {
+	// Key is the column to order by; "" means SortCreatedAt.
+	Key SortKey
+	// Asc orders ascending; the zero value orders descending.
+	Asc bool
 }
 
 // Store is the persistence and retrieval contract for memories. Implementations
@@ -126,6 +163,8 @@ type Store interface {
 
 	// List returns memories in a namespace matching f (without embeddings),
 	// for maintenance tasks (short-term capacity, fsck). limit <= 0 means all.
+	// Results are ordered by f.Sort — newest-created first by default — with
+	// ties broken by id ascending, so a capped listing is deterministic.
 	List(ctx context.Context, namespace string, f Filter, limit int) ([]*memory.Memory, error)
 
 	// ListNamespaces returns the distinct namespaces that hold memories.
@@ -301,6 +340,118 @@ type APIKeyStore interface {
 	// column of a partially-matching key, are untouched; CreatedAt is never
 	// modified. A no-op when from == to.
 	RenameAPIKeyNamespaces(ctx context.Context, from, to string) error
+}
+
+// EventKind names an operation the activity log records. Reads and writes are
+// both logged; the kinds are the wire-level values the REST filter accepts.
+type EventKind string
+
+const (
+	EventRecall    EventKind = "recall"
+	EventGet       EventKind = "get"
+	EventBriefing  EventKind = "briefing"
+	EventRemember  EventKind = "remember"
+	EventUpdate    EventKind = "update"
+	EventForget    EventKind = "forget"
+	EventSupersede EventKind = "supersede"
+)
+
+// ValidEventKind reports whether k is one of the recorded kinds, so the REST
+// layer can reject an unknown filter value before it reaches SQL.
+func ValidEventKind(k EventKind) bool {
+	switch k {
+	case EventRecall, EventGet, EventBriefing, EventRemember, EventUpdate, EventForget, EventSupersede:
+		return true
+	}
+	return false
+}
+
+// Event is one (operation, memory) row of the activity log: what was served or
+// written, when, and — for a recall — the query that pulled it and where it
+// ranked. Memories served by one operation share an OpID, so a recall that
+// returned five memories is five rows the reader regroups into one event.
+//
+// The memory fields are a snapshot taken at event time, not a live join: they
+// keep the feed renderable in one query (no N+1 fetch per row) and keep a
+// forget event readable after its memory is gone.
+type Event struct {
+	// ID is assigned by the store, monotonic within a driver.
+	ID int64
+	// OpID groups the rows of one logical operation.
+	OpID string
+	Kind EventKind
+	// Namespace is the namespace the request was made against, which for a
+	// cascading recall may differ from the served memory's own MemoryNS.
+	Namespace string
+	// Query is the recall query; "" for every other kind.
+	Query string
+	// MemoryID is "" for the sentinel row of a recall that returned nothing —
+	// "the query found nothing" is itself worth recording.
+	MemoryID      string
+	MemoryNS      string
+	MemoryTier    memory.Tier
+	MemorySummary string
+	// Rank is the 1-based position the memory was served at; 0 when not applicable.
+	Rank int
+	// Score is the composite relevance score the memory was served with; nil
+	// when not applicable (every non-recall kind).
+	Score *float64
+	// Detail carries kind-specific context — a recall's degraded mode, a
+	// briefing row's section, a supersession's replacement id.
+	Detail    map[string]any
+	CreatedAt time.Time
+}
+
+// EventFilter narrows an activity-log read. The zero value returns the newest
+// events across every namespace and kind.
+//
+// Tiers and Text select whole operations, not individual rows: an event is a
+// group of rows, so dropping some of a recall's rows would misreport what that
+// recall actually served ("served 2 memories" when it served five). A matching
+// operation is therefore returned intact, with every memory it touched.
+type EventFilter struct {
+	// Namespace restricts to events recorded against this namespace; "" means all.
+	Namespace string
+	// Namespaces restricts to events recorded against any of these namespaces
+	// (OR); empty means no constraint. Used to narrow an all-namespaces feed;
+	// ignored when Namespace is set.
+	Namespaces []string
+	// Kinds restricts to these kinds; empty means all.
+	Kinds []EventKind
+	// Tiers restricts to operations that touched a memory of one of these tiers
+	// (OR); empty means no constraint.
+	Tiers []memory.Tier
+	// Text restricts to operations whose query or any served memory's summary
+	// contains it, case-insensitively. Empty means no constraint.
+	Text string
+	// Since restricts to events recorded at or after the instant; zero means no
+	// constraint.
+	Since time.Time
+	// Before and BeforeID are a keyset cursor: only rows strictly older than
+	// (Before, BeforeID) in the (created_at DESC, id DESC) ordering are
+	// returned. A zero Before starts from the newest row.
+	Before   time.Time
+	BeforeID int64
+	// Limit caps the returned rows (not operations); <= 0 means no cap.
+	Limit int
+}
+
+// EventLogStore is implemented by drivers that persist the activity log. It is
+// an optional capability interface — the EmbedModelStore/LinkStore/APIKeyStore
+// precedent — so callers type-assert and degrade gracefully: the service skips
+// logging and the REST layer answers 501 against a driver that lacks it.
+type EventLogStore interface {
+	// AppendEvents inserts the rows of one operation as a single batch, so they
+	// land contiguously. ListEvents' ordering then keeps an operation's rows
+	// adjacent, which is what lets the reader regroup a flat row page into
+	// whole events without a join table.
+	AppendEvents(ctx context.Context, events []Event) error
+	// ListEvents returns rows matching f, newest first (created_at DESC, id DESC).
+	ListEvents(ctx context.Context, f EventFilter) ([]Event, error)
+	// PruneEvents deletes rows older than olderThan (a zero olderThan prunes
+	// none by age) and, when keepMax > 0, the oldest rows beyond the newest
+	// keepMax. Returns the number of rows deleted.
+	PruneEvents(ctx context.Context, olderThan time.Time, keepMax int) (int64, error)
 }
 
 // OrEmptyMap returns m, or an empty map when m is nil, so drivers persist an

--- a/internal/store/storetest/conformance.go
+++ b/internal/store/storetest/conformance.go
@@ -53,6 +53,405 @@ func Run(t *testing.T, st store.Store, dims int) {
 	t.Run("NamespaceLinks", func(t *testing.T) { testNamespaceLinks(t, st, dims) })
 	t.Run("NamespaceActivity", func(t *testing.T) { testNamespaceActivity(t, st, dims) })
 	t.Run("APIKeys", func(t *testing.T) { testAPIKeys(t, st, dims) })
+	t.Run("ListSort", func(t *testing.T) { testListSort(t, st, dims) })
+	t.Run("MemoryTypeFilter", func(t *testing.T) { testMemoryTypeFilter(t, st, dims) })
+	t.Run("ListRecencyWindow", func(t *testing.T) { testListRecencyWindow(t, st, dims) })
+	t.Run("EventLog", func(t *testing.T) { testEventLog(t, st, dims) })
+}
+
+// Fixture labels shared by the sort/filter subtests below. They are constants
+// because the same three memories are asserted on by every ordering case.
+const (
+	memOld = "old"
+	memMid = "mid"
+	memNew = "new"
+
+	typeDecision   = "decision"
+	typePreference = "preference"
+
+	opRecall   = "op-recall"
+	eventQuery = "why sqlite"
+)
+
+// testListSort pins List's ordering contract: results come back ordered by
+// Filter.Sort, the zero value means created_at descending, and a limit takes
+// the top N of that order rather than an arbitrary N. Both drivers must agree
+// byte for byte, since the all-namespaces aggregate merges their outputs with
+// an equivalent Go comparator.
+func testListSort(t *testing.T, st store.Store, dims int) {
+	ctx := context.Background()
+	ns := t.Name()
+	base := time.Now().UTC().Truncate(time.Millisecond).Add(-72 * time.Hour)
+
+	// Three memories whose orderings differ per key, so a wrong ORDER BY column
+	// cannot accidentally produce the expected sequence.
+	for i, spec := range []struct {
+		short       string
+		createdOff  time.Duration // from base
+		updatedOff  time.Duration
+		accessedOff time.Duration
+		accessCount int
+		importance  float64
+	}{
+		{memOld, 0, 2 * time.Hour, 1 * time.Hour, 7, 0.1},
+		{memMid, 1 * time.Hour, 0, 2 * time.Hour, 1, 0.9},
+		{memNew, 2 * time.Hour, 1 * time.Hour, 0, 4, 0.5},
+	} {
+		m := mem(ns, spec.short, "sortable "+spec.short, vec(dims, float32(i+1)))
+		m.CreatedAt = base.Add(spec.createdOff)
+		m.UpdatedAt = base.Add(spec.updatedOff)
+		m.LastAccessedAt = base.Add(spec.accessedOff)
+		m.AccessCount = spec.accessCount
+		m.Importance = spec.importance
+		mustUpsert(t, st, m)
+	}
+
+	shorts := func(ms []*memory.Memory) []string {
+		out := make([]string, len(ms))
+		for i, m := range ms {
+			out[i] = strings.TrimPrefix(m.ID, ns+"/")
+		}
+		return out
+	}
+
+	for _, tc := range []struct {
+		name string
+		sort store.Sort
+		want []string
+	}{
+		{"default is created desc", store.Sort{}, []string{memNew, memMid, memOld}},
+		{"created asc", store.Sort{Key: store.SortCreatedAt, Asc: true}, []string{memOld, memMid, memNew}},
+		{"updated desc", store.Sort{Key: store.SortUpdatedAt}, []string{memOld, memNew, memMid}},
+		{"accessed desc", store.Sort{Key: store.SortLastAccessedAt}, []string{memMid, memOld, memNew}},
+		{"access count desc", store.Sort{Key: store.SortAccessCount}, []string{memOld, memNew, memMid}},
+		{"access count asc", store.Sort{Key: store.SortAccessCount, Asc: true}, []string{memMid, memNew, memOld}},
+		{"importance desc", store.Sort{Key: store.SortImportance}, []string{memMid, memNew, memOld}},
+		{"importance asc", store.Sort{Key: store.SortImportance, Asc: true}, []string{memOld, memNew, memMid}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shorts(mustList(t, st, ns, store.Filter{Sort: tc.sort}))
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("order = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// A limit must take the top of the sorted order, not an arbitrary subset:
+	// this is what makes server-side sort + limit meaningful for the browser.
+	top, err := st.List(ctx, ns, store.Filter{Sort: store.Sort{Key: store.SortImportance}}, 1)
+	if err != nil {
+		t.Fatalf("list with limit: %v", err)
+	}
+	if got := shorts(top); !slices.Equal(got, []string{memMid}) {
+		t.Fatalf("limit 1 by importance desc = %v, want [mid]", got)
+	}
+}
+
+// testMemoryTypeFilter covers the OR-semantics metadata.memory_type filter the
+// UI's multi-select needs — distinct from Filter.Metadata, which ANDs one value
+// per key. Memories carrying no memory_type must never match.
+func testMemoryTypeFilter(t *testing.T, st store.Store, dims int) {
+	ns := t.Name()
+
+	decision := mem(ns, "dec", "we chose sqlite", vec(dims, 1))
+	decision.Metadata = map[string]any{"memory_type": typeDecision}
+	mustUpsert(t, st, decision)
+
+	preference := mem(ns, "pref", "user prefers tabs", vec(dims, 2))
+	preference.Metadata = map[string]any{"memory_type": typePreference}
+	mustUpsert(t, st, preference)
+
+	untyped := mem(ns, "untyped", "no memory type at all", vec(dims, 3))
+	mustUpsert(t, st, untyped)
+
+	for _, tc := range []struct {
+		name  string
+		types []string
+		want  []string
+	}{
+		{"empty matches all", nil, []string{id(ns, "dec"), id(ns, "pref"), id(ns, "untyped")}},
+		{"single type", []string{typeDecision}, []string{id(ns, "dec")}},
+		{"two types OR", []string{typeDecision, typePreference}, []string{id(ns, "dec"), id(ns, "pref")}},
+		{"unknown type matches none", []string{"nonesuch"}, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := memIDs(mustList(t, st, ns, store.Filter{MemoryTypes: tc.types}))
+			slices.Sort(got)
+			want := slices.Clone(tc.want)
+			slices.Sort(want)
+			if !slices.Equal(got, want) {
+				t.Fatalf("memory_type=%v matched %v, want %v", tc.types, got, want)
+			}
+		})
+	}
+}
+
+// testListRecencyWindow covers the CreatedAfter/AccessedAfter window filters,
+// which are inclusive at the boundary (>=).
+func testListRecencyWindow(t *testing.T, st store.Store, dims int) {
+	ns := t.Name()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	cutoff := now.Add(-24 * time.Hour)
+
+	old := mem(ns, "old", "created long ago, accessed long ago", vec(dims, 1))
+	old.CreatedAt = now.Add(-48 * time.Hour)
+	old.LastAccessedAt = now.Add(-48 * time.Hour)
+	mustUpsert(t, st, old)
+
+	// Straddles the window: created before the cutoff but accessed after it, so
+	// each filter selects a different memory — a filter wired to the wrong
+	// column would still pass with a simpler fixture.
+	revisited := mem(ns, "revisited", "created long ago, accessed just now", vec(dims, 2))
+	revisited.CreatedAt = now.Add(-48 * time.Hour)
+	revisited.LastAccessedAt = now
+	mustUpsert(t, st, revisited)
+
+	fresh := mem(ns, "fresh", "created at the cutoff exactly", vec(dims, 3))
+	fresh.CreatedAt = cutoff
+	fresh.LastAccessedAt = now.Add(-48 * time.Hour)
+	mustUpsert(t, st, fresh)
+
+	got := memIDs(mustList(t, st, ns, store.Filter{CreatedAfter: cutoff}))
+	if want := []string{id(ns, "fresh")}; !slices.Equal(got, want) {
+		t.Fatalf("CreatedAfter matched %v, want %v (boundary is inclusive)", got, want)
+	}
+
+	got = memIDs(mustList(t, st, ns, store.Filter{AccessedAfter: cutoff}))
+	if want := []string{id(ns, "revisited")}; !slices.Equal(got, want) {
+		t.Fatalf("AccessedAfter matched %v, want %v", got, want)
+	}
+}
+
+// testEventLog exercises the optional EventLogStore capability. Split into
+// focused subtests over one shared fixture: an append/list round trip, the
+// filters, the keyset cursor, and pruning. Stores that do not implement
+// EventLogStore skip.
+func testEventLog(t *testing.T, st store.Store, _ int) {
+	els, ok := st.(store.EventLogStore)
+	if !ok {
+		t.Skip("store does not implement store.EventLogStore")
+	}
+	ns := t.Name()
+	other := ns + "-other"
+	base := time.Now().UTC().Truncate(time.Millisecond).Add(-time.Hour)
+
+	seedEvents(t, els, ns, other, base)
+
+	// Ordered: the prune subtests destroy the fixture the read subtests rely on,
+	// so they run last.
+	t.Run("RoundTripAndOrder", func(t *testing.T) { testEventRoundTrip(t, els, ns, base) })
+	t.Run("Filters", func(t *testing.T) { testEventFilters(t, els, ns, other, base) })
+	t.Run("Cursor", func(t *testing.T) { testEventCursor(t, els, ns) })
+	t.Run("Prune", func(t *testing.T) { testEventPrune(t, els, ns, base) })
+}
+
+// eventScore is the composite score the seeded recall's top hit was served with.
+const eventScore = 0.75
+
+// seedEvents writes the fixture the event-log subtests read: one recall serving
+// two memories of different tiers (two rows, one op_id, one timestamp), a later
+// write in the same namespace, and one event in another namespace.
+func seedEvents(t *testing.T, els store.EventLogStore, ns, other string, base time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	score := eventScore
+
+	if err := els.AppendEvents(ctx, []store.Event{
+		{
+			OpID: opRecall, Kind: store.EventRecall, Namespace: ns, Query: eventQuery,
+			MemoryID: "m1", MemoryNS: ns, MemoryTier: memory.TierSemantic,
+			MemorySummary: "we chose sqlite", Rank: 1, Score: &score,
+			Detail: map[string]any{"degraded": "vector"}, CreatedAt: base,
+		},
+		{
+			OpID: opRecall, Kind: store.EventRecall, Namespace: ns, Query: eventQuery,
+			MemoryID: "m2", MemoryNS: ns, MemoryTier: memory.TierEpisodic,
+			MemorySummary: "sqlite benchmark", Rank: 2, CreatedAt: base,
+		},
+	}); err != nil {
+		t.Fatalf("append recall: %v", err)
+	}
+	if err := els.AppendEvents(ctx, []store.Event{{
+		OpID: "op-remember", Kind: store.EventRemember, Namespace: ns,
+		MemoryID: "m3", MemoryNS: ns, MemoryTier: memory.TierSemantic,
+		MemorySummary: "a new fact", CreatedAt: base.Add(time.Minute),
+	}}); err != nil {
+		t.Fatalf("append remember: %v", err)
+	}
+	if err := els.AppendEvents(ctx, []store.Event{{
+		OpID: "op-elsewhere", Kind: store.EventGet, Namespace: other,
+		MemoryID: "m4", MemoryNS: other, CreatedAt: base.Add(2 * time.Minute),
+	}}); err != nil {
+		t.Fatalf("append other-namespace event: %v", err)
+	}
+}
+
+func mustListEvents(t *testing.T, els store.EventLogStore, f store.EventFilter) []store.Event {
+	t.Helper()
+	got, err := els.ListEvents(context.Background(), f)
+	if err != nil {
+		t.Fatalf("list events %+v: %v", f, err)
+	}
+	return got
+}
+
+// testEventRoundTrip covers newest-first ordering, an operation's rows staying
+// adjacent, and every field surviving the trip through the driver.
+func testEventRoundTrip(t *testing.T, els store.EventLogStore, ns string, base time.Time) {
+	all := mustListEvents(t, els, store.EventFilter{})
+	if len(all) < 4 {
+		t.Fatalf("expected at least 4 rows, got %d", len(all))
+	}
+	for i := 1; i < len(all); i++ {
+		if all[i-1].CreatedAt.Before(all[i].CreatedAt) {
+			t.Fatalf("rows not newest-first: row %d (%s) older than row %d (%s)",
+				i-1, all[i-1].CreatedAt, i, all[i].CreatedAt)
+		}
+	}
+
+	mine := mustListEvents(t, els, store.EventFilter{Namespace: ns})
+	if len(mine) != 3 {
+		t.Fatalf("namespace filter returned %d rows, want 3", len(mine))
+	}
+	if mine[0].Kind != store.EventRemember || mine[0].MemoryID != "m3" {
+		t.Fatalf("newest row = %+v, want the remember of m3", mine[0])
+	}
+	// The recall's two rows must be adjacent — the grouped reader regroups a
+	// flat page by walking consecutive rows sharing an op_id, so a driver that
+	// interleaved operations here would silently split events in the UI.
+	if mine[1].OpID != opRecall || mine[2].OpID != opRecall {
+		t.Fatalf("recall rows not adjacent: got op_ids %q, %q", mine[1].OpID, mine[2].OpID)
+	}
+	// Rows of one operation share a created_at, so the id-DESC tiebreak hands
+	// them back in reverse insertion order — rank 2 before rank 1. Adjacency is
+	// the store's contract; ordering *within* a group is the reader's job (it
+	// sorts by rank), so find the rows by rank rather than by position.
+	byRank := map[int]store.Event{mine[1].Rank: mine[1], mine[2].Rank: mine[2]}
+	top, ok := byRank[1]
+	if !ok {
+		t.Fatalf("no rank-1 row among the recall rows: %+v", mine[1:3])
+	}
+	if top.Score == nil || *top.Score != eventScore {
+		t.Fatalf("score round trip failed: %v", top.Score)
+	}
+	if top.Query != eventQuery || top.MemoryTier != memory.TierSemantic ||
+		top.MemorySummary != "we chose sqlite" || top.MemoryNS != ns {
+		t.Fatalf("recall row round trip failed: %+v", top)
+	}
+	if got := top.Detail["degraded"]; got != "vector" {
+		t.Fatalf("detail round trip: degraded = %v, want %q", got, "vector")
+	}
+	if !top.CreatedAt.Equal(base) {
+		t.Fatalf("created_at round trip: got %s, want %s", top.CreatedAt, base)
+	}
+	// A nil score must stay nil, not become 0 — "not applicable" and "scored
+	// zero" are different facts.
+	if second := byRank[2]; second.Score != nil {
+		t.Fatalf("rank-2 row score = %v, want nil", *second.Score)
+	}
+}
+
+// testEventFilters covers kind, tier, text, since and namespace narrowing.
+// Tier and text select whole operations, not rows.
+func testEventFilters(t *testing.T, els store.EventLogStore, ns, other string, base time.Time) {
+	if got := mustListEvents(t, els, store.EventFilter{
+		Namespace: ns, Kinds: []store.EventKind{store.EventRecall},
+	}); len(got) != 2 {
+		t.Fatalf("kind filter returned %d rows, want 2", len(got))
+	}
+
+	// The recall touched one semantic and one episodic memory, so filtering on
+	// either tier must return BOTH of its rows. Returning only the matching row
+	// would make the event misreport what it served.
+	for _, tier := range []memory.Tier{memory.TierSemantic, memory.TierEpisodic} {
+		got := mustListEvents(t, els, store.EventFilter{
+			Namespace: ns, Kinds: []store.EventKind{store.EventRecall}, Tiers: []memory.Tier{tier},
+		})
+		if len(got) != 2 {
+			t.Fatalf("tier=%s returned %d rows, want the recall's 2 rows intact "+
+				"(the operation matched, so all of its memories come back)", tier, len(got))
+		}
+	}
+	if got := mustListEvents(t, els, store.EventFilter{
+		Namespace: ns, Tiers: []memory.Tier{memory.TierWorking},
+	}); len(got) != 0 {
+		t.Fatalf("tier=working matched %d rows, want none", len(got))
+	}
+
+	for _, tc := range []struct {
+		name string
+		text string
+		want int
+	}{
+		{"matches a served memory's summary", "benchmark", 2},
+		{"matches the recall query", "why SQLite", 2}, // case-insensitive
+		{"matches a write's summary", "a new fact", 1},
+		{"matches nothing", "kangaroo", 0},
+		{"wildcards are literal, not patterns", "%", 0},
+	} {
+		if got := mustListEvents(t, els, store.EventFilter{Namespace: ns, Text: tc.text}); len(got) != tc.want {
+			t.Errorf("text=%q (%s) returned %d rows, want %d", tc.text, tc.name, len(got), tc.want)
+		}
+	}
+
+	since := mustListEvents(t, els, store.EventFilter{Namespace: ns, Since: base.Add(30 * time.Second)})
+	if len(since) != 1 || since[0].MemoryID != "m3" {
+		t.Fatalf("since filter returned %+v, want only the later remember", since)
+	}
+
+	narrowed := mustListEvents(t, els, store.EventFilter{Namespaces: []string{other}})
+	if len(narrowed) != 1 || narrowed[0].Namespace != other {
+		t.Fatalf("namespaces=[%s] returned %+v, want only that namespace's event", other, narrowed)
+	}
+}
+
+// testEventCursor covers the keyset cursor: paging must neither repeat a row
+// nor skip one.
+func testEventCursor(t *testing.T, els store.EventLogStore, ns string) {
+	page1 := mustListEvents(t, els, store.EventFilter{Namespace: ns, Limit: 1})
+	if len(page1) != 1 || page1[0].MemoryID != "m3" {
+		t.Fatalf("page 1 = %+v, want the single newest row (m3)", page1)
+	}
+	page2 := mustListEvents(t, els, store.EventFilter{
+		Namespace: ns, Limit: 2,
+		Before:   page1[0].CreatedAt,
+		BeforeID: page1[0].ID,
+	})
+	if len(page2) != 2 {
+		t.Fatalf("page 2 returned %d rows, want 2", len(page2))
+	}
+	for _, e := range page2 {
+		if e.ID == page1[0].ID {
+			t.Fatal("cursor re-returned the row it was taken from")
+		}
+	}
+}
+
+// testEventPrune covers pruning by age and by row cap. It destroys the fixture,
+// so it runs last.
+func testEventPrune(t *testing.T, els store.EventLogStore, ns string, base time.Time) {
+	ctx := context.Background()
+
+	// By age: drop the recall's rows (at base), keep everything later.
+	deleted, err := els.PruneEvents(ctx, base.Add(30*time.Second), 0)
+	if err != nil {
+		t.Fatalf("prune by age: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("prune by age deleted %d rows, want 2", deleted)
+	}
+	left := mustListEvents(t, els, store.EventFilter{Namespace: ns})
+	if len(left) != 1 || left[0].MemoryID != "m3" {
+		t.Fatalf("after age prune, remaining = %+v, want only m3", left)
+	}
+
+	// By cap: keep only the newest row across the whole log.
+	if _, err := els.PruneEvents(ctx, time.Time{}, 1); err != nil {
+		t.Fatalf("prune by cap: %v", err)
+	}
+	if remaining := mustListEvents(t, els, store.EventFilter{}); len(remaining) != 1 {
+		t.Fatalf("after cap prune, %d rows remain, want 1", len(remaining))
+	}
 }
 
 // testNamespaceActivity verifies the optional ActivityStore aggregate: one

--- a/ui/src/api-schema.gen.ts
+++ b/ui/src/api-schema.gen.ts
@@ -467,6 +467,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/activity": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Recent memory activity — what was served or written, and why
+         * @description The activity log: reads (recall, get, session briefing) and writes (remember, update, forget, supersede), newest first. A recall event carries the query that ran and, for each memory it served, the rank and composite score it was served at — the "why" that per-memory access counters cannot reconstruct. Events are grouped by operation, so one recall serving five memories is one event with five memories.
+         *     Returns 501 against a storage backend with no activity log.
+         */
+        get: operations["listActivity"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -618,6 +639,51 @@ export interface components {
         };
         ListResponse: {
             memories: components["schemas"]["Memory"][];
+        };
+        /**
+         * @description The operation an activity event records. Reads: recall, get, briefing. Writes: remember, update, forget, supersede.
+         * @enum {string}
+         */
+        EventKind: "recall" | "get" | "briefing" | "remember" | "update" | "forget" | "supersede";
+        /** @description One memory as it appeared in an event — a snapshot taken at serve time, so a forgotten memory still renders — plus why it was there. */
+        ActivityMemory: {
+            id: string;
+            /** @description The memory's own namespace, which for a cascading recall may differ from the event's. */
+            namespace: string;
+            summary: string;
+            tier: components["schemas"]["Tier"];
+            /** @description 1-based position the memory was served at; absent when not applicable. */
+            rank?: number;
+            /**
+             * Format: double
+             * @description Composite relevance score it was served with; recall only.
+             */
+            score?: number;
+            /** @description Which briefing section it appeared under; briefing only. */
+            section?: string;
+        };
+        /** @description One logical operation, with the memories it served or wrote. */
+        ActivityEvent: {
+            op_id: string;
+            kind: components["schemas"]["EventKind"];
+            /** Format: date-time */
+            time: string;
+            /** @description The namespace the request was made against. */
+            namespace: string;
+            /** @description The recall query; absent for every other kind. */
+            query?: string;
+            /** @description Kind-specific context — a recall's degraded mode, a supersession's replacement id. */
+            detail?: {
+                [key: string]: unknown;
+            };
+            /** @description Empty for a recall that matched nothing. */
+            memories?: components["schemas"]["ActivityMemory"][];
+        };
+        ActivityResponse: {
+            events: components["schemas"]["ActivityEvent"][];
+            /** @description Pass as "before" to fetch the next page; absent on the last page. */
+            next_cursor?: string;
+            has_more: boolean;
         };
         Briefing: {
             namespace: string;
@@ -1005,8 +1071,20 @@ export interface operations {
                 include_superseded?: boolean;
                 /** @description Caps the result count; 0 or absent returns all matches. */
                 limit?: number;
-                /** @description Aggregate across every namespace, ignoring the namespace header. The server merges all namespaces and applies limit as a single global cap (newest first), so the admin UI's "All projects" view fetches one response instead of one request per namespace. */
+                /** @description Aggregate across every namespace, ignoring the namespace header. The server merges all namespaces and applies limit as a single global cap under the requested sort, so the admin UI's "All projects" view fetches one response instead of one request per namespace. */
                 all_namespaces?: boolean;
+                /** @description With all_namespaces=true, restrict the aggregate to these namespaces (repeatable, exact match); ignored otherwise. Lets the browser narrow an "All projects" listing without changing the active namespace. */
+                namespace?: string[];
+                /** @description Repeatable and/or comma-separated metadata.memory_type filter; a memory matches if its type is ANY of the listed values (OR). Distinct from "meta", which ANDs one value per key. */
+                memory_type?: string[];
+                /** @description Only memories created at or after this instant. */
+                created_after?: string;
+                /** @description Only memories last accessed at or after this instant. */
+                accessed_after?: string;
+                /** @description Column to order by. Defaults to created_at. */
+                sort?: "created_at" | "updated_at" | "last_accessed_at" | "access_count" | "importance";
+                /** @description Sort direction. Defaults to desc (newest / highest first). */
+                order?: "asc" | "desc";
             };
             header?: {
                 /** @description Tenant/agent namespace; falls back to the server default. */
@@ -1712,6 +1790,41 @@ export interface operations {
             403: components["responses"]["Error"];
             404: components["responses"]["Error"];
             409: components["responses"]["Error"];
+            501: components["responses"]["Error"];
+        };
+    };
+    listActivity: {
+        parameters: {
+            query?: {
+                /** @description Repeatable and/or comma-separated event-kind filter; omitted means all kinds. */
+                kind?: components["schemas"]["EventKind"][];
+                /** @description Caps the returned events (operations, not rows). Default 50, max 200. */
+                limit?: number;
+                /** @description Opaque cursor from a previous response's next_cursor; returns the page of events strictly older than it. */
+                before?: string;
+                /** @description Aggregate across every namespace, ignoring the namespace header. */
+                all_namespaces?: boolean;
+            };
+            header?: {
+                /** @description Tenant/agent namespace; falls back to the server default. */
+                "X-Memini-Namespace"?: components["parameters"]["Namespace"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActivityResponse"];
+                };
+            };
+            400: components["responses"]["Error"];
+            401: components["responses"]["Error"];
             501: components["responses"]["Error"];
         };
     };

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,13 +1,18 @@
-import { apiToken, baseUrl, namespace, namespaceHeader } from './store'
+import { apiToken, baseUrl, namespace, namespaceHeader, serverWarning } from './store'
 import type {
+  ActivityResponse,
   ApiKeysResponse,
   ApiKeyWithSecret,
   CreateApiKeyRequest,
   DedupReport,
   DedupRequest,
+  EventKind,
   FsckReport,
+  Level,
   ListResponse,
   Memory,
+  SortKey,
+  SortOrder,
   NamespaceLink,
   NamespaceLinksResponse,
   NamespacesResponse,
@@ -56,6 +61,12 @@ async function req<T>(method: string, path: string, body?: unknown, ns?: string)
     throw new ApiError(0, `network error: ${(e as Error).message}`)
   }
 
+  // The server announces non-fatal overrides here — most notably an
+  // X-Memini-Home header it ignored because the API key is bound to a home
+  // namespace of its own. Every request passes through this function, so
+  // capturing it once surfaces it no matter which view made the call.
+  serverWarning.value = res.headers.get('X-Memini-Warning') ?? ''
+
   if (res.status === 204) return undefined as T
   const text = await res.text()
   const data = text ? safeParse(text) : undefined
@@ -76,21 +87,67 @@ function safeParse(text: string): unknown {
 
 export interface ListParams {
   tiers?: Tier[]
+  levels?: Level[]
   tags?: string[]
   metadata?: Record<string, string>
+  memoryTypes?: string[]
+  createdAfter?: string
+  accessedAfter?: string
   includeExpired?: boolean
   includeSuperseded?: boolean
+  sort?: SortKey
+  order?: SortOrder
   limit?: number
+  // namespaces narrows an "All projects" listing; ignored when a namespace is
+  // active (scopedList doesn't send it — the header already scopes the request).
+  namespaces?: string[]
 }
 
-// appendFilters adds the shared tier/tag/meta query params to a list request.
+// appendFilters adds the shared filter/sort query params to a list request.
+// Sorting is server-side: with limit capping the response, sorting in the
+// browser would only ever reorder whichever rows the server happened to return.
 function appendFilters(q: URLSearchParams, p: ListParams) {
   p.tiers?.forEach((t) => q.append('tier', t))
+  p.levels?.forEach((l) => q.append('level', l))
   p.tags?.forEach((t) => q.append('tag', t))
+  p.memoryTypes?.forEach((t) => q.append('memory_type', t))
   Object.entries(p.metadata ?? {}).forEach(([k, v]) => q.append('meta', `${k}=${v}`))
+  if (p.createdAfter) q.set('created_after', p.createdAfter)
+  if (p.accessedAfter) q.set('accessed_after', p.accessedAfter)
   if (p.includeExpired) q.set('include_expired', 'true')
   if (p.includeSuperseded) q.set('include_superseded', 'true')
+  if (p.sort) q.set('sort', p.sort)
+  if (p.order) q.set('order', p.order)
   if (p.limit) q.set('limit', String(p.limit))
+}
+
+export interface ActivityParams {
+  kinds?: EventKind[]
+  tiers?: Tier[]
+  text?: string
+  since?: string
+  namespaces?: string[]
+  limit?: number
+  before?: string
+}
+
+// activity fetches a page of the activity feed. Every filter is applied
+// server-side so paging stays correct — dropping events client-side would make
+// a page of N events arrive as fewer than N and misreport how much is left.
+function fetchActivity(p: ActivityParams): Promise<ActivityResponse> {
+  const q = new URLSearchParams()
+  p.kinds?.forEach((k) => q.append('kind', k))
+  p.tiers?.forEach((t) => q.append('tier', t))
+  if (p.text) q.set('q', p.text)
+  if (p.since) q.set('since', p.since)
+  if (p.limit) q.set('limit', String(p.limit))
+  if (p.before) q.set('before', p.before)
+  if (isAllProjects()) {
+    q.set('all_namespaces', 'true')
+    p.namespaces?.forEach((n) => q.append('namespace', n))
+  }
+  const qs = q.toString()
+  return req<ActivityResponse>('GET', '/v1/activity' + (qs ? `?${qs}` : ''))
 }
 
 // isAllProjects reports the "All projects" aggregate mode: the active namespace
@@ -152,6 +209,10 @@ function listAll(p: ListParams): Promise<Memory[]> {
   const q = new URLSearchParams()
   appendFilters(q, p)
   q.set('all_namespaces', 'true')
+  // Narrowing the aggregate happens server-side: the global limit is applied
+  // under the sort, so filtering the response here could starve a selected
+  // namespace whose rows fell outside the cap.
+  p.namespaces?.forEach((n) => q.append('namespace', n))
   return req<ListResponse>('GET', '/v1/memories?' + q.toString()).then((r) => r.memories ?? [])
 }
 
@@ -184,6 +245,10 @@ export const api = {
   list: (p: ListParams = {}) => (isAllProjects() ? listAll(p) : scopedList(p)),
   search: (query: string, opts: SearchOpts = {}) =>
     isAllProjects() ? searchAll(query, opts) : scopedSearch(query, opts),
+
+  // activity is namespace-aware via the header, or aggregates in All-projects
+  // mode; see fetchActivity.
+  activity: (p: ActivityParams = {}) => fetchActivity(p),
 
   // statsFor fetches stats for one explicit namespace, ignoring the active
   // selection. Backs the Projects landing.

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -1,10 +1,11 @@
 import { LocationProvider, Router, Route, useLocation } from 'preact-iso'
-import { theme } from './store'
+import { serverWarning, theme } from './store'
 import { NamespaceSelect } from './components/NamespaceSelect'
 import { Projects } from './views/Projects'
 import { Dashboard } from './views/Dashboard'
 import { Browser } from './views/Browser'
 import { Search } from './views/Search'
+import { Activity } from './views/Activity'
 import { Graph } from './views/Graph'
 import { Health } from './views/Health'
 import { Scopes } from './views/Scopes'
@@ -15,6 +16,7 @@ import {
   IconOverview,
   IconBrowse,
   IconSearch,
+  IconActivity,
   IconGraph,
   IconHealth,
   IconScopes,
@@ -47,6 +49,7 @@ const NAV: {
   { path: '/', label: 'Overview', title: 'Overview', Icon: IconOverview, component: Dashboard },
   { path: '/browse', label: 'Browse', title: 'Memory browser', Icon: IconBrowse, component: Browser },
   { path: '/search', label: 'Search', title: 'Recall', Icon: IconSearch, component: Search },
+  { path: '/activity', label: 'Activity', title: 'Recent activity', Icon: IconActivity, component: Activity },
   { path: '/graph', label: 'Graph', title: 'Relationship graph', Icon: IconGraph, component: Graph },
   { path: '/scopes', label: 'Scopes', title: 'Namespace scopes & links', Icon: IconScopes, component: Scopes },
   { path: '/keys', label: 'Keys', title: 'API keys', Icon: IconKey, component: Keys },
@@ -103,6 +106,16 @@ function Shell() {
           </button>
         </header>
         <div class="content">
+          {/* A non-fatal advisory from the server — e.g. the home namespace it
+              overrode because this API key is bound to a home of its own. The
+              request succeeded, just not quite as asked, and the operator would
+              otherwise be left wondering why they are seeing a different
+              namespace's memories than they requested. */}
+          {serverWarning.value && (
+            <div class="banner warn" role="status">
+              {serverWarning.value}
+            </div>
+          )}
           <Router>
             {NAV.map(({ path: to, component }) => (
               <Route key={to} path={to} component={component} />

--- a/ui/src/components/LevelFilter.tsx
+++ b/ui/src/components/LevelFilter.tsx
@@ -1,0 +1,33 @@
+import { LEVELS, type Level } from '../types'
+
+interface Props {
+  selected: Level[]
+  onChange: (levels: Level[]) => void
+}
+
+// LevelFilter toggles derivation level — explicit (the user said it) vs deduced
+// (the model distilled it). Empty selection = both.
+export function LevelFilter({ selected, onChange }: Props) {
+  const toggle = (l: Level) => {
+    onChange(selected.includes(l) ? selected.filter((x) => x !== l) : [...selected, l])
+  }
+  return (
+    <div class="tier-filter" role="group" aria-label="Filter by level">
+      {LEVELS.map((l) => {
+        const on = selected.length === 0 || selected.includes(l)
+        return (
+          <button
+            key={l}
+            type="button"
+            class={`tier-toggle ${on ? 'on' : ''}`}
+            aria-pressed={on}
+            aria-label={`${l} memories${on ? '' : ' (hidden)'}`}
+            onClick={() => toggle(l)}
+          >
+            <span class={`chip level ${l}`}>{l}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/ui/src/components/MemoryTypeFilter.tsx
+++ b/ui/src/components/MemoryTypeFilter.tsx
@@ -1,0 +1,35 @@
+import { MEMORY_TYPES, type MemoryType } from '../types'
+import { MemoryTypeBadge } from './MemoryTypeBadge'
+
+interface Props {
+  selected: string[]
+  onChange: (types: string[]) => void
+}
+
+// MemoryTypeFilter is a row of toggleable memory-type badges, matching
+// TierFilter. Empty selection = all types (including untyped memories, which no
+// selection ever matches).
+export function MemoryTypeFilter({ selected, onChange }: Props) {
+  const toggle = (t: MemoryType) => {
+    onChange(selected.includes(t) ? selected.filter((x) => x !== t) : [...selected, t])
+  }
+  return (
+    <div class="tier-filter" role="group" aria-label="Filter by memory type">
+      {MEMORY_TYPES.map((t) => {
+        const on = selected.length === 0 || selected.includes(t)
+        return (
+          <button
+            key={t}
+            type="button"
+            class={`tier-toggle ${on ? 'on' : ''}`}
+            aria-pressed={on}
+            aria-label={`${t} memories${on ? '' : ' (hidden)'}`}
+            onClick={() => toggle(t)}
+          >
+            <MemoryTypeBadge type={t} />
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/ui/src/components/NamespaceFilter.tsx
+++ b/ui/src/components/NamespaceFilter.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'preact/hooks'
+import { api } from '../api'
+import { useAsync } from '../hooks'
+
+interface Props {
+  selected: string[]
+  onChange: (namespaces: string[]) => void
+}
+
+// NamespaceFilter narrows an "All projects" listing to a subset of namespaces
+// without touching the global namespace picker — the picker switches which
+// project you're working in, this only narrows what the aggregate shows.
+// Rendered only in All-projects mode (the caller gates it); a scoped listing is
+// already restricted by the namespace header.
+export function NamespaceFilter({ selected, onChange }: Props) {
+  const [open, setOpen] = useState(false)
+  const { data } = useAsync(() => api.namespaces(), [])
+  const names = data ?? []
+
+  const toggle = (n: string) => {
+    onChange(selected.includes(n) ? selected.filter((x) => x !== n) : [...selected, n])
+  }
+
+  const label =
+    selected.length === 0
+      ? 'All projects'
+      : selected.length === 1
+        ? selected[0]
+        : `${selected.length} projects`
+
+  return (
+    <div class="ns-filter">
+      <button
+        type="button"
+        class={`chip ${selected.length ? 'on' : ''}`}
+        aria-expanded={open}
+        aria-label="Filter by project"
+        onClick={() => setOpen(!open)}
+      >
+        {label} ▾
+      </button>
+      {open && (
+        <div class="ns-filter-menu panel" role="group" aria-label="Projects">
+          {names.length === 0 && <span class="muted">No projects</span>}
+          {names.map((n) => (
+            <label key={n} class="ns-filter-item">
+              <input
+                type="checkbox"
+                checked={selected.includes(n)}
+                onChange={() => toggle(n)}
+              />
+              <span class="mono">{n}</span>
+            </label>
+          ))}
+          {selected.length > 0 && (
+            <button type="button" class="chip" onClick={() => onChange([])}>
+              Clear
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/components/RecencyFilter.tsx
+++ b/ui/src/components/RecencyFilter.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'preact/hooks'
+
+type Field = 'created' | 'accessed'
+
+const WINDOWS: { label: string; hours: number }[] = [
+  { label: 'Any time', hours: 0 },
+  { label: 'Last 24h', hours: 24 },
+  { label: 'Last 7d', hours: 24 * 7 },
+  { label: 'Last 30d', hours: 24 * 30 },
+]
+
+interface Props {
+  // onChange emits ISO instants for the created_after / accessed_after params;
+  // undefined means no constraint.
+  onChange: (createdAfter?: string, accessedAfter?: string) => void
+}
+
+// RecencyFilter narrows a listing to memories created (or last used) within a
+// window. The cutoff is computed here and sent to the server rather than
+// filtering the response, because the listing is capped under a sort: sorted by
+// importance, a recent-but-unimportant memory falls outside the capped page, so
+// a client-side window filter would quietly under-report.
+export function RecencyFilter({ onChange }: Props) {
+  const [field, setField] = useState<Field>('created')
+  const [hours, setHours] = useState(0)
+
+  const emit = (f: Field, h: number) => {
+    const iso = h > 0 ? new Date(Date.now() - h * 3600_000).toISOString() : undefined
+    onChange(f === 'created' ? iso : undefined, f === 'accessed' ? iso : undefined)
+  }
+
+  return (
+    <div class="recency-filter" role="group" aria-label="Filter by recency">
+      <select
+        class="chip"
+        value={field}
+        aria-label="Recency field"
+        onChange={(e) => {
+          const f = (e.target as HTMLSelectElement).value as Field
+          setField(f)
+          emit(f, hours)
+        }}
+      >
+        <option value="created">Created</option>
+        <option value="accessed">Last used</option>
+      </select>
+      <select
+        class="chip"
+        value={String(hours)}
+        aria-label="Recency window"
+        onChange={(e) => {
+          const h = Number((e.target as HTMLSelectElement).value)
+          setHours(h)
+          emit(field, h)
+        }}
+      >
+        {WINDOWS.map((w) => (
+          <option key={w.hours} value={String(w.hours)}>
+            {w.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/ui/src/components/SortControl.tsx
+++ b/ui/src/components/SortControl.tsx
@@ -1,0 +1,39 @@
+import { SORT_KEYS, type SortKey, type SortOrder } from '../types'
+
+interface Props {
+  sort: SortKey
+  order: SortOrder
+  onChange: (sort: SortKey, order: SortOrder) => void
+}
+
+// SortControl picks the server-side sort for a listing: a key select plus a
+// direction toggle. Sorting happens on the server because the listing is capped
+// — reordering the capped page in the browser would sort the wrong rows.
+export function SortControl({ sort, order, onChange }: Props) {
+  const label = SORT_KEYS.find((s) => s.key === sort)?.label ?? sort
+  return (
+    <div class="sort-control" role="group" aria-label="Sort">
+      <select
+        class="chip"
+        value={sort}
+        aria-label="Sort by"
+        onChange={(e) => onChange((e.target as HTMLSelectElement).value as SortKey, order)}
+      >
+        {SORT_KEYS.map((s) => (
+          <option key={s.key} value={s.key}>
+            {s.label}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        class="chip sort-dir"
+        aria-label={`${label}, ${order === 'desc' ? 'descending' : 'ascending'}`}
+        title={order === 'desc' ? 'Descending' : 'Ascending'}
+        onClick={() => onChange(sort, order === 'desc' ? 'asc' : 'desc')}
+      >
+        {order === 'desc' ? '↓' : '↑'}
+      </button>
+    </div>
+  )
+}

--- a/ui/src/icons.tsx
+++ b/ui/src/icons.tsx
@@ -35,6 +35,11 @@ export const IconGraph = base([
   <path d="m8.2 8.4 3 6.5M15.8 7.6 14 14.7M8.4 6.6 15.5 6" opacity="0.7" />,
 ])
 export const IconHealth = base([<path d="M3 12h4l2 6 4-14 2 8h6" />])
+// A clock with a replay arc: the activity feed is what was used, and when.
+export const IconActivity = base([
+  <circle cx="12" cy="12" r="8" />,
+  <path d="M12 7.5V12l3 1.8" />,
+])
 export const IconSettings = base([
   <path d="M4 6h10M18 6h2M4 12h2M10 12h10M4 18h7M15 18h5" />,
   <circle cx="16" cy="6" r="2" />,

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -57,6 +57,13 @@ export function refresh() {
   refreshNonce.value++
 }
 
+// The server's last non-fatal advisory (the X-Memini-Warning response header) —
+// e.g. a home namespace header it overrode because the API key is bound to a
+// home of its own. Set on every response, so it clears itself once the
+// condition goes away. The shell renders it as a banner: the request succeeded,
+// but not quite as asked, and that is worth seeing.
+export const serverWarning = signal('')
+
 // Persist settings and reflect the theme on <html> whenever they change.
 effect(() => {
   const data: Persisted = {

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1415,3 +1415,189 @@ pre.json {
     grid-template-columns: 1fr;
   }
 }
+
+/* ---- Activity feed --------------------------------------------------- */
+
+/* Event-kind pill. Reads share the semantic hue, writes the procedural one, and
+   the destructive kinds borrow the working tier's warm accent, so a glance at
+   the feed separates "was read" from "was changed". */
+.evkind {
+  --kc: var(--muted);
+  border-color: color-mix(in oklab, var(--kc) 45%, transparent);
+  color: color-mix(in oklab, var(--kc) 78%, var(--text));
+  background: color-mix(in oklab, var(--kc) 13%, transparent);
+}
+.evkind.recall,
+.evkind.briefing,
+.evkind.get {
+  --kc: var(--tier-episodic);
+}
+.evkind.remember,
+.evkind.update {
+  --kc: var(--tier-semantic);
+}
+.evkind.forget,
+.evkind.supersede {
+  --kc: var(--tier-procedural);
+}
+
+.chip.warn {
+  border-color: color-mix(in oklab, var(--tier-procedural) 50%, transparent);
+  color: color-mix(in oklab, var(--tier-procedural) 80%, var(--text));
+}
+.chip.on {
+  border-color: var(--line-strong);
+  color: var(--text);
+}
+.muted {
+  color: var(--muted);
+}
+
+.act-list {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+}
+.act-event {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--line);
+}
+.act-event:last-child {
+  border-bottom: none;
+}
+.act-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.act-head .grow {
+  flex: 1;
+}
+.act-query {
+  font-weight: 500;
+  color: var(--text);
+}
+.act-what {
+  color: var(--text);
+}
+
+/* Served memories, indented under their event: rank, tier, summary, score. */
+.act-mems {
+  display: flex;
+  flex-direction: column;
+  margin-top: 8px;
+  margin-left: 10px;
+  border-left: 1px solid var(--line);
+}
+.act-mem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 5px 10px;
+  background: none;
+  border: none;
+  border-radius: var(--r-sm);
+  text-align: left;
+  cursor: pointer;
+  color: var(--text-dim);
+  font-size: 13px;
+}
+.act-mem:hover {
+  background: var(--surface-2);
+}
+.act-rank {
+  min-width: 26px;
+  font-size: 11px;
+  color: var(--muted);
+}
+.act-summary {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.act-more {
+  display: flex;
+  justify-content: center;
+  margin-top: 12px;
+}
+.act-more .chip {
+  cursor: pointer;
+  padding: 6px 14px;
+}
+
+/* ---- Browse: sort + extra filters ------------------------------------ */
+
+.sort-control,
+.recency-filter,
+.ns-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  position: relative;
+}
+.sort-control select,
+.recency-filter select {
+  cursor: pointer;
+  appearance: none;
+}
+.sort-dir {
+  cursor: pointer;
+  padding: 2px 7px;
+}
+.ns-filter > .chip {
+  cursor: pointer;
+}
+.ns-filter-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px;
+  min-width: 200px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.ns-filter-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+/* Derivation-level chip: explicit (stated) vs deduced (distilled). */
+.chip.level {
+  --lc: var(--tier-episodic);
+  border-color: color-mix(in oklab, var(--lc) 45%, transparent);
+  color: color-mix(in oklab, var(--lc) 78%, var(--text));
+  background: color-mix(in oklab, var(--lc) 13%, transparent);
+}
+.chip.level.deduced {
+  --lc: var(--tier-working);
+}
+
+/* Activity text filter: a chip-shaped search box, sized to fit a short phrase. */
+.act-search {
+  min-width: 220px;
+  padding: 4px 10px;
+  font-family: var(--font-ui);
+  color: var(--text);
+}
+.act-search::placeholder {
+  color: var(--muted);
+}
+
+/* Server advisory banner: the request worked, but not quite as asked. Shares
+   .banner's layout with .banner.err above; only the palette differs — amber
+   rather than ember, since this is an FYI, not a failure. */
+.banner.warn {
+  border-color: color-mix(in oklab, var(--tier-semantic) 55%, transparent);
+  background: color-mix(in oklab, var(--tier-semantic) 12%, transparent);
+  color: color-mix(in oklab, var(--tier-semantic) 82%, var(--text));
+}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -2,13 +2,55 @@
 // (openapi-typescript -> src/api-schema.gen.ts). Don't hand-edit shapes here;
 // change the spec and regenerate, so the UI can't drift from the server.
 
-import type { components } from './api-schema.gen'
+import type { components, operations } from './api-schema.gen'
 
 type Schemas = components['schemas']
+type Operations = operations
 
 export type Tier = Schemas['Tier']
 
 export const TIERS: Tier[] = ['working', 'episodic', 'semantic', 'procedural']
+
+export type Level = Schemas['Level']
+
+export const LEVELS: Level[] = ['explicit', 'deduced']
+
+// The memory types the service stamps onto metadata.memory_type
+// (service.promote/classify). Not a spec enum — it's a metadata value — so this
+// list is the UI's own, matching MemoryTypeBadge's.
+export const MEMORY_TYPES = ['decision', 'preference', 'problem'] as const
+export type MemoryType = (typeof MEMORY_TYPES)[number]
+
+// Sort keys accepted by GET /v1/memories?sort=, from the generated operation.
+export type SortKey = NonNullable<
+  NonNullable<Operations['listMemories']['parameters']['query']>['sort']
+>
+export type SortOrder = NonNullable<
+  NonNullable<Operations['listMemories']['parameters']['query']>['order']
+>
+
+export const SORT_KEYS: { key: SortKey; label: string }[] = [
+  { key: 'created_at', label: 'Created' },
+  { key: 'updated_at', label: 'Updated' },
+  { key: 'last_accessed_at', label: 'Last used' },
+  { key: 'access_count', label: 'Recall count' },
+  { key: 'importance', label: 'Importance' },
+]
+
+export type EventKind = Schemas['EventKind']
+export type ActivityEvent = Schemas['ActivityEvent']
+export type ActivityMemory = Schemas['ActivityMemory']
+export type ActivityResponse = Schemas['ActivityResponse']
+
+export const EVENT_KINDS: EventKind[] = [
+  'recall',
+  'briefing',
+  'get',
+  'remember',
+  'update',
+  'forget',
+  'supersede',
+]
 
 export type Memory = Schemas['Memory']
 export type Scored = Schemas['ScoredMemory']

--- a/ui/src/views/Activity.tsx
+++ b/ui/src/views/Activity.tsx
@@ -1,0 +1,268 @@
+import { useCallback, useEffect, useState } from 'preact/hooks'
+import { api, ApiError, isAllProjects } from '../api'
+import { namespace, refreshNonce } from '../store'
+import { EVENT_KINDS, type ActivityEvent, type EventKind, type Memory, type Tier } from '../types'
+import { MemoryDrawer } from '../components/MemoryDrawer'
+import { TierBadge } from '../components/TierBadge'
+import { TierFilter } from '../components/TierFilter'
+import { NamespaceFilter } from '../components/NamespaceFilter'
+import { Loading, ErrorBanner, Empty } from '../components/States'
+import { relTime, fmtDate } from '../util'
+
+const KINDS_KEY = 'memini.activity.kinds'
+const PAGE = 40
+
+// Hidden kinds persist: a briefing fires on every session start, so the feed is
+// mostly briefings unless you say otherwise — and having to say so on every
+// visit would be its own annoyance.
+function loadHiddenKinds(): EventKind[] {
+  try {
+    const raw = localStorage.getItem(KINDS_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((k): k is EventKind => EVENT_KINDS.includes(k as EventKind))
+  } catch {
+    return []
+  }
+}
+
+// headline renders the one-line "what happened" for an event.
+function headline(ev: ActivityEvent): string {
+  const n = ev.memories?.length ?? 0
+  switch (ev.kind) {
+    case 'recall':
+      return n === 0 ? 'found nothing' : `served ${n} ${n === 1 ? 'memory' : 'memories'}`
+    case 'briefing':
+      return `session briefing · ${n} ${n === 1 ? 'memory' : 'memories'}`
+    case 'get':
+      return 'opened'
+    case 'remember':
+      return 'remembered'
+    case 'update':
+      return 'updated'
+    case 'forget':
+      return 'forgot'
+    case 'supersede':
+      return 'superseded'
+    default:
+      return ev.kind
+  }
+}
+
+const WINDOWS: { label: string; hours: number }[] = [
+  { label: 'Any time', hours: 0 },
+  { label: 'Last hour', hours: 1 },
+  { label: 'Last 24h', hours: 24 },
+  { label: 'Last 7d', hours: 24 * 7 },
+  { label: 'Last 30d', hours: 24 * 30 },
+]
+
+export function Activity() {
+  const [hidden, setHidden] = useState<EventKind[]>(loadHiddenKinds)
+  const [tiers, setTiers] = useState<Tier[]>([])
+  const [text, setText] = useState('')
+  const [hours, setHours] = useState(0)
+  const [namespaces, setNamespaces] = useState<string[]>([])
+  const [events, setEvents] = useState<ActivityEvent[]>([])
+  const [cursor, setCursor] = useState<string | undefined>()
+  const [hasMore, setHasMore] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [open, setOpen] = useState<Memory | null>(null)
+
+  const kinds = EVENT_KINDS.filter((k) => !hidden.includes(k))
+  const kindsKey = kinds.join(',')
+  const tiersKey = tiers.join(',')
+  const nsKey = namespaces.join(',')
+
+  // Every filter goes to the server rather than narrowing the response, so a
+  // page of N events really is N events and "load more" stays meaningful.
+  // `since` is recomputed per fetch: pinning the instant into state would make
+  // "last hour" mean the hour before you picked it, drifting as you sit there.
+  const load = useCallback(
+    async (before?: string) => {
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await api.activity({
+          kinds,
+          tiers,
+          text: text.trim() || undefined,
+          since: hours > 0 ? new Date(Date.now() - hours * 3600_000).toISOString() : undefined,
+          namespaces,
+          limit: PAGE,
+          before,
+        })
+        const page = res.events ?? []
+        setEvents((prev) => (before ? [...prev, ...page] : page))
+        setCursor(res.next_cursor)
+        setHasMore(Boolean(res.has_more))
+      } catch (e) {
+        setError(e instanceof ApiError ? e.message : String(e))
+        if (!before) setEvents([])
+      } finally {
+        setLoading(false)
+      }
+    },
+    [kindsKey, tiersKey, text, hours, nsKey],
+  )
+
+  // Reset to the first page whenever the scope or any filter changes. The text
+  // box is debounced so a fetch doesn't fire on every keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => void load(), text ? 250 : 0)
+    return () => clearTimeout(t)
+  }, [namespace.value, kindsKey, tiersKey, text, hours, nsKey, refreshNonce.value])
+
+  const toggleKind = (k: EventKind) => {
+    const next = hidden.includes(k) ? hidden.filter((x) => x !== k) : [...hidden, k]
+    setHidden(next)
+    try {
+      localStorage.setItem(KINDS_KEY, JSON.stringify(next))
+    } catch {
+      // A private-mode browser with no storage still filters, just not durably.
+    }
+  }
+
+  const openMemory = async (id: string, ns: string) => {
+    try {
+      setOpen(await api.get(id, ns))
+    } catch {
+      // The memory is gone (a forget event, most likely). The row still renders
+      // from its snapshot; there is simply nothing to open.
+    }
+  }
+
+  const showNs = isAllProjects()
+
+  return (
+    <>
+      <div class="view activity">
+        <div class="toolbar">
+          <div class="tier-filter" role="group" aria-label="Filter by event kind">
+            {EVENT_KINDS.map((k) => {
+              const on = !hidden.includes(k)
+              return (
+                <button
+                  key={k}
+                  type="button"
+                  class={`tier-toggle ${on ? 'on' : ''}`}
+                  aria-pressed={on}
+                  aria-label={`${k} events${on ? '' : ' (hidden)'}`}
+                  onClick={() => toggleKind(k)}
+                >
+                  <span class={`chip evkind ${k}`}>{k}</span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+        <div class="toolbar">
+          {/* Tier here means "events that touched a memory of this tier" — the
+              whole event comes back, so its counts stay honest. */}
+          <TierFilter selected={tiers} onChange={setTiers} />
+          <input
+            class="chip act-search"
+            type="search"
+            placeholder="Filter by query or memory…"
+            aria-label="Filter activity by text"
+            value={text}
+            onInput={(e) => setText((e.target as HTMLInputElement).value)}
+          />
+          <select
+            class="chip"
+            aria-label="Time window"
+            value={String(hours)}
+            onChange={(e) => setHours(Number((e.target as HTMLSelectElement).value))}
+          >
+            {WINDOWS.map((w) => (
+              <option key={w.hours} value={String(w.hours)}>
+                {w.label}
+              </option>
+            ))}
+          </select>
+          {showNs && <NamespaceFilter selected={namespaces} onChange={setNamespaces} />}
+          <span class="grow" />
+          <span class="chip mono">{events.length} shown</span>
+        </div>
+
+        {error && <ErrorBanner message={error} />}
+        {loading && events.length === 0 ? (
+          <Loading />
+        ) : events.length === 0 ? (
+          <Empty title="No activity yet" />
+        ) : (
+          <div class="panel act-list">
+            {events.map((ev) => (
+              <div key={ev.op_id} class="act-event">
+                <div class="act-head">
+                  <span class={`chip evkind ${ev.kind}`}>{ev.kind}</span>
+                  {ev.query ? (
+                    <span class="act-query">“{ev.query}”</span>
+                  ) : (
+                    <span class="act-what">{headline(ev)}</span>
+                  )}
+                  {ev.query && <span class="muted">{headline(ev)}</span>}
+                  {typeof ev.detail?.degraded === 'string' && (
+                    <span class="chip warn" title="Recall fell back to keyword-only search">
+                      degraded: {ev.detail.degraded}
+                    </span>
+                  )}
+                  {showNs && <span class="chip mono">{ev.namespace}</span>}
+                  <span class="grow" />
+                  <span class="muted" title={fmtDate(ev.time)}>
+                    {relTime(ev.time)}
+                  </span>
+                </div>
+
+                {(ev.memories?.length ?? 0) > 0 && (
+                  <div class="act-mems">
+                    {ev.memories?.map((m) => (
+                      <button
+                        key={m.id}
+                        type="button"
+                        class="act-mem"
+                        onClick={() => openMemory(m.id, m.namespace)}
+                      >
+                        {m.rank ? <span class="act-rank mono">#{m.rank}</span> : <span class="act-rank" />}
+                        <TierBadge tier={m.tier} />
+                        <span class="act-summary">{m.summary}</span>
+                        {m.section && <span class="chip">{m.section}</span>}
+                        {/* The score is the "why": how well this memory matched
+                            the query it was served for. */}
+                        {typeof m.score === 'number' && (
+                          <span class="chip mono" title="Relevance score for this query">
+                            {m.score.toFixed(2)}
+                          </span>
+                        )}
+                        {showNs && m.namespace !== ev.namespace && (
+                          <span class="chip mono">{m.namespace}</span>
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {hasMore && (
+          <div class="act-more">
+            <button
+              type="button"
+              class="chip"
+              disabled={loading}
+              onClick={() => void load(cursor)}
+            >
+              {loading ? 'Loading…' : 'Load more'}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {open && <MemoryDrawer memory={open} onClose={() => setOpen(null)} />}
+    </>
+  )
+}

--- a/ui/src/views/Browser.tsx
+++ b/ui/src/views/Browser.tsx
@@ -2,28 +2,62 @@ import { useState } from 'preact/hooks'
 import { api, isAllProjects } from '../api'
 import { namespace, refreshNonce } from '../store'
 import { useAsync } from '../hooks'
-import type { Memory, Tier } from '../types'
+import type { Level, Memory, SortKey, SortOrder, Tier } from '../types'
 import { MemoryCard } from '../components/MemoryCard'
 import { MemoryDrawer } from '../components/MemoryDrawer'
 import { TierFilter } from '../components/TierFilter'
 import { MetaFilter } from '../components/MetaFilter'
+import { MemoryTypeFilter } from '../components/MemoryTypeFilter'
+import { LevelFilter } from '../components/LevelFilter'
+import { RecencyFilter } from '../components/RecencyFilter'
+import { NamespaceFilter } from '../components/NamespaceFilter'
+import { SortControl } from '../components/SortControl'
 import { Loading, ErrorBanner, Empty } from '../components/States'
 
 export function Browser() {
   const [tiers, setTiers] = useState<Tier[]>([])
+  const [levels, setLevels] = useState<Level[]>([])
+  const [memoryTypes, setMemoryTypes] = useState<string[]>([])
   const [tags, setTags] = useState<string[]>([])
   const [metadata, setMetadata] = useState<Record<string, string>>({})
+  const [createdAfter, setCreatedAfter] = useState<string | undefined>()
+  const [accessedAfter, setAccessedAfter] = useState<string | undefined>()
+  const [namespaces, setNamespaces] = useState<string[]>([])
+  const [sort, setSort] = useState<SortKey>('created_at')
+  const [order, setOrder] = useState<SortOrder>('desc')
   const [includeExpired, setExpired] = useState(false)
   const [includeSuperseded, setSuperseded] = useState(false)
   const [open, setOpen] = useState<Memory | null>(null)
 
   const { data, error, loading } = useAsync(
-    () => api.list({ tiers, tags, metadata, includeExpired, includeSuperseded, limit: 500 }),
+    () =>
+      api.list({
+        tiers,
+        levels,
+        memoryTypes,
+        tags,
+        metadata,
+        createdAfter,
+        accessedAfter,
+        namespaces,
+        sort,
+        order,
+        includeExpired,
+        includeSuperseded,
+        limit: 500,
+      }),
     [
       namespace.value,
       tiers.join(','),
+      levels.join(','),
+      memoryTypes.join(','),
       tags.join(','),
       JSON.stringify(metadata),
+      createdAfter,
+      accessedAfter,
+      namespaces.join(','),
+      sort,
+      order,
       includeExpired,
       includeSuperseded,
       refreshNonce.value,
@@ -39,10 +73,29 @@ export function Browser() {
       <div class={`view browse ${sparse ? 'sparse' : ''}`}>
         <div class="toolbar">
           <TierFilter selected={tiers} onChange={setTiers} />
+          <MemoryTypeFilter selected={memoryTypes} onChange={setMemoryTypes} />
+          <LevelFilter selected={levels} onChange={setLevels} />
+        </div>
+        <div class="toolbar">
           <MetaFilter
             onChange={(t, m) => {
               setTags(t)
               setMetadata(m)
+            }}
+          />
+          <RecencyFilter
+            onChange={(c, a) => {
+              setCreatedAfter(c)
+              setAccessedAfter(a)
+            }}
+          />
+          {showNs && <NamespaceFilter selected={namespaces} onChange={setNamespaces} />}
+          <SortControl
+            sort={sort}
+            order={order}
+            onChange={(s, o) => {
+              setSort(s)
+              setOrder(o)
             }}
           />
           <span class="grow" />


### PR DESCRIPTION
## Record what memory was served, and why

Ask memini "what did you use recently, and why?" and today it can't really answer. Usage is two counters on the memory row, `access_count` and `last_accessed_at`, bumped by `Reinforce` on the recall path. That tells you a memory was used. It doesn't tell you which question it answered, where it ranked, or how well it scored, and all of that exists at serve time: `Recall` computes fused and reranked scores, hands them to the caller, and throws them away. `store.Scored` carries a single float, and by the time results reach `reinforceResults` only the IDs survive.

The gaps are worse than "lossy". `memory_get` and `memory_briefing` don't reinforce at all, so `last_accessed_at` doesn't mean "last used", it means "last recalled". A memory served in every session briefing for a month looks untouched.

This PR adds a real activity log, an Activity page to read it, and (since you can't explore a feed you can't filter) filters on both that page and the browser.

### The log

A new `memory_events` table in both drivers, behind an optional `EventLogStore` capability interface. That follows the `LinkStore` / `APIKeyStore` precedent: the service and REST layer type-assert and degrade, so a driver without it just skips logging and `/v1/activity` answers 501.

One row per (operation, memory). Rows from one logical operation share an `op_id` and are inserted as a single batch, which is the load-bearing detail. A batch shares a `created_at` and gets contiguous ids, so `ORDER BY created_at DESC, id DESC` keeps an operation's rows adjacent. That adjacency is what lets the reader regroup a flat page of rows back into whole events by walking consecutive rows, with no join table and no second query.

One consequence worth knowing: within a group the rows come back in reverse rank order, because the id tiebreak runs backwards. `groupEvents` re-sorts by rank. There's a conformance case pinning it, and it caught me the first time I wrote the test.

Each row denormalizes a snapshot of the memory (namespace, tier, summary). That's deliberate on two counts. The feed renders in one query with no N+1 fetch per row, and a `forget` event stays readable after the memory it describes no longer exists. A recall that matched nothing gets a sentinel row too, because "this query found nothing" is exactly the sort of thing you open an activity feed to discover.

Writes are async and best-effort, off the request path, using the same `context.WithoutCancel` plus bounded-timeout shape as `reinforceResults`. A wedged log can slow nothing and fail nothing. `MEMINI_ACTIVITY_LOG=false` turns it off, and `MEMINI_ACTIVITY_RETENTION` (30d) and `MEMINI_ACTIVITY_MAX_ROWS` (100k) bound it, pruned by the existing decay sweeper.

### Logging is not reinforcing

This is the one design decision I'd argue about if someone proposed the alternative. It would have been easy to make briefings and gets bump `access_count` while we're in there, since they are reads after all.

They must not. `Reinforce` isn't a usage counter, it's a relevance signal. It slides TTLs forward and gates episodic to durable promotion (`promoteMinAccess`) and durable ranking. A briefing fires on every session start over the same top-N whether or not anything in it was relevant. Reinforcing that would inflate `access_count` uniformly across exactly the memories that already rank highest, and quietly corrupt promotion. `memory_get` is addressing a memory by ID, often the admin UI's own drawer, which says nothing about relevance either.

So both are logged but never reinforced. The activity log answers "when and how was this used" without touching the signal that decides what gets promoted. `TestBriefingAndGetLogButDoNotReinforce` pins it, because this is the kind of invariant someone helpful "fixes" in six months.

### The Activity page

Newest-first feed, grouped by operation, at `/activity`. A recall renders as its query plus the memories it served, each with rank and score, which is the "why". A briefing shows which section each memory came from. Forget and supersede show what was removed. Kind chips hide the noisy kinds (briefings dominate otherwise) and the selection persists, because re-hiding them on every visit is its own small misery.

Against a live instance it reads like this:

```
recall   "which database do we use"   served 1 memory     just now
           #1  semantic  the production database is postgres 16   1.00
recall   "zzz nonexistent kangaroo"   found nothing       1m ago
briefing  session briefing · 2 memories                   1m ago
           #1  semantic  the production database is postgres 16   facts
```

### Filters, and one honest bit of SQL

Browse had tier/tag/metadata filters and no sorting anywhere in the stack. Neither driver's `List` had an `ORDER BY`, so a single-namespace listing came back in insertion order while the "All projects" view sorted by `CreatedAt` in Go. There's now a real `sort` / `order` param (created, updated, last-used, recall-count, importance) mapped through a whitelist switch to an `ORDER BY` in both drivers, with an id tiebreak so a capped listing is deterministic, and the all-namespaces merge uses a Go comparator kept in lockstep with the SQL. Default is `created_at desc`, which is both sane and a bug fix.

Browse also gains memory-type (repeatable, OR semantics, because `meta=k=v` ANDs one value per key and can't express a multi-select), level (the REST layer already accepted it, the UI just never sent it), a recency window, and namespace narrowing in All-projects mode. The Activity feed gets kind, tier, free text, time window, and namespace.

Everything is server-side, which matters more than it sounds. The listing is capped at 500 under a sort, so a client-side recency filter would be correct only when sorting by that same time field and would quietly under-report otherwise. Same for narrowing an aggregate: filtering the response can starve a namespace whose rows fell outside the global cap.

The interesting case is tier and text on the activity feed. An event is a group of rows, so filtering rows would make a recall that served five memories render as "served 2 memories" under `tier=semantic`, which is a lie about what happened. Those two filters select whole operations instead, via `op_id IN (SELECT op_id FROM memory_events WHERE ...)`, and return the matching event intact. A conformance case and a REST case both assert that a tier-filtered recall still reports every memory it served.

### The home-header override now says something

#95 landed per-key home namespaces, where a bound key's home wins over a conflicting `X-Memini-Home` header and the disagreement is "logged if it disagrees". In practice that log was at debug level, so the override was invisible: you set a home, got a different one, and nothing told you why.

It now logs at warn and returns an `X-Memini-Warning` response header, which the admin UI renders as a banner:

> `home namespace "someone/elses/home" from X-Memini-Home ignored: API key "bound-bot" is bound to home "acme/home", which wins`

Still never a 400, since a shared client config that always sets the header is not a caller error, and no warning at all when the header agrees with the binding or the key is unbound. A warning that fires when nothing was overridden is noise, and noise gets ignored.

### Verification

Store conformance covers the new capability and filters for both drivers: sort ordering per key, limit-takes-the-top-N, memory-type OR, recency bounds, event round trip, op-adjacency, keyset cursor, prune by age and by cap, and that LIKE wildcards in a text filter stay literal instead of matching everything. Service and REST tests cover the log-versus-reinforce split, remember versus update, the forget snapshot outliving its memory, pagination, 400s on unknown sort/kind/tier values, and the home warning firing only on a real conflict.

Beyond the suite I drove a real server end to end (writes, recalls, briefings, forget, every filter, pagination) and confirmed the pages render and the filters actually reach the server rather than being applied in the browser.

### Notes for review

- No MCP tool for the activity log here. REST is what the UI needs, and a `memory_activity` tool is a clean follow-up if it's wanted.
- Opening a memory from the Activity page issues a `get`, which logs a `get` event. Self-noise, hidden by the kind chips. An opt-out header would fix it properly if it grates.
- Postgres shares the conformance suite but I ran the sqlite driver locally. The pg suite needs Docker (`mise run test-integration`).
