### PR TITLE
fix(ui): align namespace tree labels with their depth in the selector

### DIFF
--- a/ui/src/components/NamespaceSelect.tsx
+++ b/ui/src/components/NamespaceSelect.tsx
@@ -157,8 +157,13 @@ function NsRow({
         ) : (
           // A synthetic path-prefix node (e.g. "acme/phoenix" when only
           // "acme/phoenix/api" holds memories) — a group label, not a
-          // selectable namespace.
-          <span class="opt opt-group">{label}</span>
+          // selectable namespace. It keeps the empty check slot so its label
+          // lands on the same x as a leaf's at the same depth; without it the
+          // group's label sits 22px left and nesting reads wrong.
+          <span class="opt opt-group">
+            <span class="ck" aria-hidden="true" />
+            {label}
+          </span>
         )}
       </div>
       {hasChildren &&

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1279,6 +1279,9 @@ pre.json {
 }
 .menu .opt .ck {
   width: 14px;
+  /* A fixed gutter, like .tree-chevron/.tree-spacer: without this a long label
+     shrinks the slot and drags its row's text out of line with the others. */
+  flex: none;
 }
 
 /* Indented namespace tree inside the menu popover (NamespaceSelect). Each


### PR DESCRIPTION
## What

The namespace switcher in the top bar indented labels erratically — a node one level deeper could render **left** of a shallower one:

## Root cause

`nsTree` and the `paddingLeft: depth * 16` on `.tree-row` are both correct — which is why the chevron column always stepped properly, and why this looked so scrambled against it.

The break is an asymmetry between `NsRow`'s two label branches:

| Row kind | Markup | Label starts at |
|---|---|---|
| Leaf (holds memories) | `<button class="opt">` + 14px `.ck` slot + label | `depth·16 + 54px` |
| Synthetic path-prefix group | `<span class="opt opt-group">{label}</span>` — no `.ck` | `depth·16 + 32px` |

The 22px difference is the `.ck` slot (14px) plus `.menu .opt`'s `gap: 8px`. Since **22 > the 16px indent step**, a group one level deeper overtakes a shallower leaf. And because leaf-vs-group depends on whether that exact namespace holds memories — not on depth — the offset lands on seemingly arbitrary rows.

It shows up wherever a namespace exists only as an ancestor: with `atvik/tyrfing/jon/dev` present but no `atvik/tyrfing/jon`, the synthetic `jon` node is the one that renders wrong.

## Fix

1. Give the group span the same empty `.ck` slot, so both branches share identical leading structure.
2. Pin `.ck` with `flex: none`, the way its sibling gutters `.tree-chevron` and `.tree-spacer` already are. Without it a label of ~21+ chars shrank the slot to 12.5px and pulled that row 1–2px out of line — same defect, smaller scale.

No behavior change; groups remain non-selectable.

## Verification

`pnpm typecheck` passes. Measured against a live 38-row tree (via the browser, reading real `/v1/namespaces` data):

- **Before:** every leaf sat at chevron+54, every group at chevron+32. `jon` (depth 2) rendered at x=1085, 6px **left** of `tyrfing` (depth 1) at x=1091.
- **After:** labels at the same depth share an x, every level steps exactly 16px, and every check slot measures exactly 14px — regardless of leaf/group or label length.