### PR TITLE
Give REST an update-in-place route, and stop re-embedding content that did not change

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -547,6 +547,35 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/Memory" }
         "404": { $ref: "#/components/responses/Error" }
+    patch:
+      operationId: updateMemory
+      tags: [memory]
+      summary: Update a memory in place
+      description: >
+        Changes only the fields present in the body; anything omitted carries
+        over from the stored record. metadata merges into the existing metadata
+        key-by-key and an explicit null deletes that key — POST /v1/memories
+        with an id replaces metadata wholesale instead.
+
+
+        The write-time lifecycle still runs (validation, secret redaction,
+        content sanitization), so this is not a bare field write. Content is
+        re-embedded only when it actually changes, so a tags- or metadata-only
+        update costs no embedder call.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/UpdateMemoryRequest" }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Memory" }
+        "400": { $ref: "#/components/responses/Error" }
+        "404": { $ref: "#/components/responses/Error" }
+        "500": { $ref: "#/components/responses/Error" }
     delete:
       operationId: forgetMemory
       tags: [memory]
@@ -1069,7 +1098,12 @@ components:
             (the default) — it only raises to semantic/procedural.
         summary: { type: string }
         tags: { type: array, items: { type: string } }
-        metadata: { type: object, additionalProperties: true }
+        metadata:
+          type: object
+          additionalProperties: true
+          description: >
+            Replaces the stored metadata wholesale when this write carries an id
+            (an upsert). Use PATCH /v1/memories/{id} to merge key-by-key instead.
         importance: { type: number, format: double, minimum: 0, maximum: 1 }
         level:
           allOf:
@@ -1115,6 +1149,52 @@ components:
             request namespace "acme/phoenix/api"), and the write lands there
             instead. Ignored for non-durable writes: an episodic/working memory
             always stays in the request namespace regardless of visibility.
+    UpdateMemoryRequest:
+      type: object
+      description: >
+        A partial edit: every property is optional and anything omitted keeps
+        its stored value. Sending an explicit value writes it, so summary: ""
+        clears the summary rather than being ignored.
+      properties:
+        content: { type: string }
+        summary: { type: string }
+        tier:
+          allOf:
+            - $ref: "#/components/schemas/Tier"
+          description: Move the memory to this tier. Omit to keep the stored tier.
+        level:
+          allOf:
+            - $ref: "#/components/schemas/Level"
+          description: Relabel derivation provenance. Omit to keep the stored level.
+        tags:
+          type: array
+          items: { type: string }
+          description: >
+            Replaces the stored tag set wholesale. Omit to keep it; send an
+            empty array to clear it.
+        metadata:
+          type: object
+          additionalProperties: true
+          description: >
+            Merges into the stored metadata key-by-key: listed keys are added or
+            overwritten, unlisted keys are untouched, and a key sent with a null
+            value is deleted. POST /v1/memories with an id replaces metadata
+            wholesale instead.
+        importance:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 1
+          description: >
+            Omit to keep the stored importance. Note that 0 is currently
+            indistinguishable from omitted and keeps the stored value.
+        confidence:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 1
+          description: >
+            Omit to keep the stored confidence; ignored for short-term tiers.
     SupersedeRequest:
       type: object
       required: [by]

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -176,7 +176,7 @@ Update fields of an existing memory by ID (partial: only provided fields change;
 | `confidence` | number |  | 0..1; omit to keep |
 | `content` | string |  | replacement content; omit to keep |
 | `importance` | number |  | 0..1; omit to keep |
-| `metadata` | object |  | merged into existing metadata key-by-key |
+| `metadata` | object |  | merged into existing metadata key-by-key; a null value deletes that key |
 | `namespace` | string |  | namespace; defaults to the server namespace |
 | `summary` | string |  | replacement summary; omit to keep |
 | `tags` | string[] |  | replacement tag set; omit to keep |

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -25,6 +25,7 @@ The core read and write surface. `POST /v1/search` is the REST equivalent of the
 | `POST /v1/memories` | Remember (store) a memory |
 | `DELETE /v1/memories/{id}` | Forget (delete) a memory |
 | `GET /v1/memories/{id}` | Fetch a memory by ID |
+| `PATCH /v1/memories/{id}` | Update a memory in place |
 | `GET /v1/memories/{id}/history` | The full version chain (supersession lineage) of a memory |
 | `POST /v1/memories/{id}/reassign` | Move a single memory to a different namespace |
 | `POST /v1/memories/{id}/supersede` | Tombstone a memory, recording it was replaced by `by`. |

--- a/internal/api/mcp/mcp.go
+++ b/internal/api/mcp/mcp.go
@@ -1131,76 +1131,39 @@ func (t *tools) history(ctx context.Context, _ *mcpsdk.CallToolRequest, in idArg
 
 type updateArgs struct {
 	ID         string         `json:"id" jsonschema:"the memory ID to update (from memory_recall/memory_list)"`
-	Content    string         `json:"content,omitempty" jsonschema:"replacement content; omit to keep"`
-	Summary    string         `json:"summary,omitempty" jsonschema:"replacement summary; omit to keep"`
-	Tier       string         `json:"tier,omitempty" jsonschema:"move to this tier; omit to keep"`
+	Content    *string        `json:"content,omitempty" jsonschema:"replacement content; omit to keep"`
+	Summary    *string        `json:"summary,omitempty" jsonschema:"replacement summary; omit to keep"`
+	Tier       *string        `json:"tier,omitempty" jsonschema:"move to this tier; omit to keep"`
 	Tags       []string       `json:"tags,omitempty" jsonschema:"replacement tag set; omit to keep"`
-	Metadata   map[string]any `json:"metadata,omitempty" jsonschema:"merged into existing metadata key-by-key"`
+	Metadata   map[string]any `json:"metadata,omitempty" jsonschema:"merged into existing metadata key-by-key; a null value deletes that key"`
 	Importance *float64       `json:"importance,omitempty" jsonschema:"0..1; omit to keep"`
 	Confidence *float64       `json:"confidence,omitempty" jsonschema:"0..1; omit to keep"`
 	Namespace  string         `json:"namespace,omitempty" jsonschema:"namespace; defaults to the server namespace"`
 }
 
-// update composes svc.Get + svc.Remember with the current ID (the documented
-// upsert path): it re-embeds content and re-runs the write-time lifecycle
-// (corroborate/contradict), so an update is not a bare field patch. Only
-// fields explicitly provided in in are changed; everything else carries over
-// from the current record. Metadata merges key-by-key rather than replacing
-// wholesale, so a caller enriching one key never has to resend the rest.
+// update edits an existing memory in place via service.Update, which REST's
+// PATCH /v1/memories/{id} shares: only fields explicitly provided are changed,
+// metadata merges key-by-key (a null value deletes that key), and the write-time
+// lifecycle still runs, so an update is not a bare field patch. Content is
+// re-embedded only when it actually changes.
 func (t *tools) update(ctx context.Context, _ *mcpsdk.CallToolRequest, in updateArgs) (*mcpsdk.CallToolResult, memoryItem, error) {
 	ns, err := t.ns(in.Namespace)
 	if err != nil {
 		return nil, memoryItem{}, err
 	}
-	cur, err := t.svc.Get(ctx, ns, in.ID)
+	upd := service.UpdateInput{
+		Namespace: ns, ID: in.ID, Home: t.defaultHome, Author: t.defaultAuthor,
+		Content: in.Content, Summary: in.Summary, Tags: in.Tags, Metadata: in.Metadata,
+		Importance: in.Importance, Confidence: in.Confidence,
+	}
+	if in.Tier != nil {
+		upd.Tier = new(memory.Tier(*in.Tier))
+	}
+	m, err := t.svc.Update(ctx, upd)
 	if err != nil {
+		// notFoundErr passes anything else through untouched; it only enriches
+		// the ErrNotFound case with where a valid ID comes from.
 		return nil, memoryItem{}, notFoundErr(in.ID, ns, err)
-	}
-	upd := service.RememberInput{
-		Namespace: ns, Home: t.defaultHome, Author: t.defaultAuthor, ID: cur.ID,
-		Content: cur.Content, Summary: cur.Summary, Tier: cur.Tier,
-		Tags: cur.Tags, Metadata: cur.Metadata, Importance: cur.Importance, Confidence: cur.Confidence,
-		Level: cur.Level, ValidFrom: cur.ValidFrom, ValidTo: cur.ValidTo,
-	}
-	if in.Content != "" {
-		upd.Content = in.Content
-	}
-	if in.Summary != "" {
-		upd.Summary = in.Summary
-	}
-	if in.Tier != "" {
-		tr := memory.Tier(in.Tier)
-		if !tr.Valid() {
-			return nil, memoryItem{}, fmt.Errorf("invalid tier %q: want working|episodic|semantic|procedural", in.Tier)
-		}
-		upd.Tier = tr
-	}
-	if in.Tags != nil {
-		upd.Tags = in.Tags
-	}
-	for k, v := range in.Metadata {
-		if upd.Metadata == nil {
-			upd.Metadata = map[string]any{}
-		}
-		upd.Metadata[k] = v
-	}
-	if in.Importance != nil {
-		upd.Importance = *in.Importance
-	}
-	if in.Confidence != nil {
-		upd.Confidence = in.Confidence
-	}
-	m, err := t.svc.Remember(ctx, upd)
-	if err != nil {
-		return nil, memoryItem{}, err
-	}
-	// The episodic value gate returns (nil, nil) when it drops a low-signal
-	// write. For memory_remember that is a stored=false result, but here the
-	// caller asked to change an existing memory and nothing changed — surface
-	// it as an error rather than dereferencing nil or claiming success.
-	if m == nil {
-		return nil, memoryItem{}, fmt.Errorf("update dropped: the new content is below the episodic value gate " +
-			"(too short/low-signal); provide more substantive content or set a durable tier")
 	}
 	return nil, toMemoryItem(m), nil
 }

--- a/internal/api/rest/api.gen.go
+++ b/internal/api/rest/api.gen.go
@@ -1061,7 +1061,9 @@ type RememberRequest struct {
 	Importance *float64 `json:"importance,omitempty"`
 
 	// Level Label the derivation provenance (explicit vs deduced) at write time. Omit to leave unset (default, legacy rows, auto-tagged by service).
-	Level    *Level                  `json:"level,omitempty"`
+	Level *Level `json:"level,omitempty"`
+
+	// Metadata Replaces the stored metadata wholesale when this write carries an id (an upsert). Use PATCH /v1/memories/{id} to merge key-by-key instead.
 	Metadata *map[string]interface{} `json:"metadata,omitempty"`
 	Summary  *string                 `json:"summary,omitempty"`
 	Tags     *[]string               `json:"tags,omitempty"`
@@ -1312,6 +1314,29 @@ type UpdateApiKeyRequest struct {
 	Settings *ClientSettings `json:"settings,omitempty"`
 }
 
+// UpdateMemoryRequest A partial edit: every property is optional and anything omitted keeps its stored value. Sending an explicit value writes it, so summary: "" clears the summary rather than being ignored.
+type UpdateMemoryRequest struct {
+	// Confidence Omit to keep the stored confidence; ignored for short-term tiers.
+	Confidence *float64 `json:"confidence,omitempty"`
+	Content    *string  `json:"content,omitempty"`
+
+	// Importance Omit to keep the stored importance. Note that 0 is currently indistinguishable from omitted and keeps the stored value.
+	Importance *float64 `json:"importance,omitempty"`
+
+	// Level Relabel derivation provenance. Omit to keep the stored level.
+	Level *Level `json:"level,omitempty"`
+
+	// Metadata Merges into the stored metadata key-by-key: listed keys are added or overwritten, unlisted keys are untouched, and a key sent with a null value is deleted. POST /v1/memories with an id replaces metadata wholesale instead.
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	Summary  *string                 `json:"summary,omitempty"`
+
+	// Tags Replaces the stored tag set wholesale. Omit to keep it; send an empty array to clear it.
+	Tags *[]string `json:"tags,omitempty"`
+
+	// Tier Move the memory to this tier. Omit to keep the stored tier.
+	Tier *Tier `json:"tier,omitempty"`
+}
+
 // Namespace defines model for Namespace.
 type Namespace = string
 
@@ -1490,6 +1515,12 @@ type GetMemoryParams struct {
 	XMeminiNamespace *Namespace `json:"X-Memini-Namespace,omitempty"`
 }
 
+// UpdateMemoryParams defines parameters for UpdateMemory.
+type UpdateMemoryParams struct {
+	// XMeminiNamespace Namespace for this request; falls back to the server default.
+	XMeminiNamespace *Namespace `json:"X-Memini-Namespace,omitempty"`
+}
+
 // GetMemoryHistoryParams defines parameters for GetMemoryHistory.
 type GetMemoryHistoryParams struct {
 	// XMeminiNamespace Namespace for this request; falls back to the server default.
@@ -1622,6 +1653,9 @@ type PutLinkJSONRequestBody PutLinkJSONBody
 // RememberMemoryJSONRequestBody defines body for RememberMemory for application/json ContentType.
 type RememberMemoryJSONRequestBody = RememberRequest
 
+// UpdateMemoryJSONRequestBody defines body for UpdateMemory for application/json ContentType.
+type UpdateMemoryJSONRequestBody = UpdateMemoryRequest
+
 // ReassignMemoryJSONRequestBody defines body for ReassignMemory for application/json ContentType.
 type ReassignMemoryJSONRequestBody ReassignMemoryJSONBody
 
@@ -1705,6 +1739,9 @@ type ServerInterface interface {
 	// Fetch a memory by ID
 	// (GET /v1/memories/{id})
 	GetMemory(w http.ResponseWriter, r *http.Request, id string, params GetMemoryParams)
+	// Update a memory in place
+	// (PATCH /v1/memories/{id})
+	UpdateMemory(w http.ResponseWriter, r *http.Request, id string, params UpdateMemoryParams)
 	// The full version chain (supersession lineage) of a memory
 	// (GET /v1/memories/{id}/history)
 	GetMemoryHistory(w http.ResponseWriter, r *http.Request, id string, params GetMemoryHistoryParams)
@@ -1870,6 +1907,12 @@ func (_ Unimplemented) ForgetMemory(w http.ResponseWriter, r *http.Request, id s
 // Fetch a memory by ID
 // (GET /v1/memories/{id})
 func (_ Unimplemented) GetMemory(w http.ResponseWriter, r *http.Request, id string, params GetMemoryParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Update a memory in place
+// (PATCH /v1/memories/{id})
+func (_ Unimplemented) UpdateMemory(w http.ResponseWriter, r *http.Request, id string, params UpdateMemoryParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -3053,6 +3096,62 @@ func (siw *ServerInterfaceWrapper) GetMemory(w http.ResponseWriter, r *http.Requ
 	handler.ServeHTTP(w, r)
 }
 
+// UpdateMemory operation middleware
+func (siw *ServerInterfaceWrapper) UpdateMemory(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params UpdateMemoryParams
+
+	headers := r.Header
+
+	// ------------- Optional header parameter "X-Memini-Namespace" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Memini-Namespace")]; found {
+		var XMeminiNamespace Namespace
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Memini-Namespace", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Memini-Namespace", valueList[0], &XMeminiNamespace, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Memini-Namespace", Err: err})
+			return
+		}
+
+		params.XMeminiNamespace = &XMeminiNamespace
+
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateMemory(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetMemoryHistory operation middleware
 func (siw *ServerInterfaceWrapper) GetMemoryHistory(w http.ResponseWriter, r *http.Request) {
 
@@ -3980,6 +4079,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/memories/{id}", wrapper.GetMemory)
+	})
+	r.Group(func(r chi.Router) {
+		r.Patch(options.BaseURL+"/v1/memories/{id}", wrapper.UpdateMemory)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/memories/{id}/history", wrapper.GetMemoryHistory)

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -304,6 +304,54 @@ func (h *Server) GetMemory(w http.ResponseWriter, r *http.Request, boundID strin
 	httputil.JSON(w, http.StatusOK, apiMemory(m))
 }
 
+// UpdateMemory implements PATCH /v1/memories/{id}. It shares service.Update
+// with the MCP memory_update tool, so both surfaces apply the same omit-to-keep
+// and metadata-merge semantics. Contrast RememberMemory, where an id in the body
+// upserts by replacing the whole record.
+func (h *Server) UpdateMemory(w http.ResponseWriter, r *http.Request, boundID string, _ UpdateMemoryParams) {
+	id, ok := unescapeID(boundID)
+	if !ok {
+		httputil.Error(w, http.StatusNotFound, "memory not found")
+		return
+	}
+	var req UpdateMemoryRequest
+	if !decode(w, r, &req) {
+		return
+	}
+	in := service.UpdateInput{
+		Namespace:  namespaceFromContext(r.Context()),
+		Home:       homeFromContext(r.Context()),
+		ID:         id,
+		Content:    req.Content,
+		Summary:    req.Summary,
+		Importance: req.Importance,
+		Confidence: req.Confidence,
+		Tags:       deref(req.Tags),
+		Metadata:   deref(req.Metadata),
+	}
+	// Attribution mirrors RememberMemory: a named key stamps its name, the
+	// admin key stamps none.
+	if p, ok := principalFromContext(r.Context()); ok {
+		in.Author = p.Name
+	}
+	if req.Tier != nil {
+		in.Tier = new(memory.Tier(*req.Tier))
+	}
+	if req.Level != nil {
+		in.Level = new(memory.Level(*req.Level))
+	}
+	m, err := h.svc.Update(r.Context(), in)
+	if errors.Is(err, store.ErrNotFound) {
+		httputil.Error(w, http.StatusNotFound, "memory not found")
+		return
+	}
+	if err != nil {
+		writeError(w, r, statusFor(err), err)
+		return
+	}
+	httputil.JSON(w, http.StatusOK, apiMemory(m))
+}
+
 // GetMemoryHistory implements GET /v1/memories/{id}/history.
 func (h *Server) GetMemoryHistory(w http.ResponseWriter, r *http.Request, boundID string, _ GetMemoryHistoryParams) {
 	id, ok := unescapeID(boundID)

--- a/internal/api/rest/shared_test.go
+++ b/internal/api/rest/shared_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -73,6 +74,100 @@ func TestSharedMemoryAcrossSurfaces(t *testing.T) {
 	}
 	if len(out.Results) == 0 || out.Results[0].Content != "the deploy key lives in vault at secret/ci/deploy" {
 		t.Fatalf("agent B did not recall agent A's memory: %+v", out.Results)
+	}
+}
+
+// TestUpdateSemanticsMatchAcrossSurfaces pins the point of sharing
+// service.Update: an identical partial edit sent as a REST PATCH and as an MCP
+// memory_update must produce the identical row. Both surfaces used to be free to
+// drift — the omit-to-keep rules and the metadata merge lived only in the MCP
+// handler, and REST's nearest equivalent (POST with an id) replaces wholesale.
+func TestUpdateSemanticsMatchAcrossSurfaces(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlitevec.Open(ctx, filepath.Join(t.TempDir(), "parity.db"), dims)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	svc := service.New(st, embedtest.New(dims))
+	const ns = "parity-project"
+
+	seed := func(t *testing.T) *memory.Memory {
+		t.Helper()
+		m, err := svc.Remember(ctx, service.RememberInput{
+			Namespace: ns, Content: "the deploy key lives in vault at secret/ci/deploy",
+			Summary: "deploy key location", Tier: memory.TierSemantic, Tags: []string{"ops"},
+			Metadata: map[string]any{"source": "handbook", "reviewed": "no"},
+		})
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		return m
+	}
+
+	// The same partial edit, expressed for each surface: change one metadata
+	// key, retag, and leave content/summary/tier to carry over.
+	viaREST := seed(t)
+	r := chi.NewRouter()
+	rest.New(svc, rest.AuthConfig{NamespaceHeader: nsHdr, DefaultNamespace: "default"}).Mount(r)
+	rec := do(t, r, http.MethodPatch, "/v1/memories/"+viaREST.ID, ns, "", map[string]any{
+		"tags": []string{"ops", "vault"}, "metadata": map[string]any{"reviewed": "yes"},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("REST patch: want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+
+	viaMCP := seed(t)
+	srv := meminimcp.NewServer(svc, ns, "", "", "none")
+	clientT, serverT := mcpsdk.NewInMemoryTransports()
+	if _, err := srv.Connect(ctx, serverT, nil); err != nil {
+		t.Fatalf("mcp server connect: %v", err)
+	}
+	cs, err := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "agent", Version: "0"}, nil).Connect(ctx, clientT, nil)
+	if err != nil {
+		t.Fatalf("mcp client connect: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+	if _, err := cs.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name: "memory_update",
+		Arguments: map[string]any{
+			"id": viaMCP.ID, "tags": []string{"ops", "vault"},
+			"metadata": map[string]any{"reviewed": "yes"},
+		},
+	}); err != nil {
+		t.Fatalf("mcp update: %v", err)
+	}
+
+	// Compare what actually landed in the store, not what each surface echoed.
+	gotREST, err := st.Get(ctx, ns, viaREST.ID)
+	if err != nil {
+		t.Fatalf("get rest row: %v", err)
+	}
+	gotMCP, err := st.Get(ctx, ns, viaMCP.ID)
+	if err != nil {
+		t.Fatalf("get mcp row: %v", err)
+	}
+
+	if gotREST.Content != gotMCP.Content {
+		t.Fatalf("content diverged: REST %q vs MCP %q", gotREST.Content, gotMCP.Content)
+	}
+	if gotREST.Summary != gotMCP.Summary {
+		t.Fatalf("summary diverged: REST %q vs MCP %q", gotREST.Summary, gotMCP.Summary)
+	}
+	if gotREST.Tier != gotMCP.Tier {
+		t.Fatalf("tier diverged: REST %q vs MCP %q", gotREST.Tier, gotMCP.Tier)
+	}
+	if !slices.Equal(gotREST.Tags, gotMCP.Tags) {
+		t.Fatalf("tags diverged: REST %v vs MCP %v", gotREST.Tags, gotMCP.Tags)
+	}
+	for _, k := range []string{"source", "reviewed"} {
+		if gotREST.Metadata[k] != gotMCP.Metadata[k] {
+			t.Fatalf("metadata[%q] diverged: REST %v vs MCP %v", k, gotREST.Metadata[k], gotMCP.Metadata[k])
+		}
+	}
+	// And the merge actually happened on both: the untouched key survived.
+	if gotREST.Metadata["source"] != "handbook" {
+		t.Fatalf("metadata[source] = %v on both surfaces, want the merge to preserve it", gotREST.Metadata["source"])
 	}
 }
 

--- a/internal/api/rest/update_test.go
+++ b/internal/api/rest/update_test.go
@@ -1,0 +1,164 @@
+package rest_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// updateNS is the namespace every PATCH test seeds into. Kept as one constant so
+// the seed helper and the request paths cannot drift apart.
+const updateNS = "alice"
+
+// apiMemoryBody is the subset of the Memory response these tests assert on.
+type apiMemoryBody struct {
+	ID       string         `json:"id"`
+	Content  string         `json:"content"`
+	Summary  string         `json:"summary"`
+	Tier     string         `json:"tier"`
+	Tags     []string       `json:"tags"`
+	Metadata map[string]any `json:"metadata"`
+}
+
+// seedMemory stores one memory over REST and returns its id.
+func seedMemory(t *testing.T, h http.Handler, body map[string]any) string {
+	t.Helper()
+	rec := do(t, h, http.MethodPost, "/v1/memories", updateNS, apiKey, body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("seed remember: want 201, got %d (%s)", rec.Code, rec.Body)
+	}
+	var out apiMemoryBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode seed: %v", err)
+	}
+	return out.ID
+}
+
+func decodeMemory(t *testing.T, body []byte) apiMemoryBody {
+	t.Helper()
+	var out apiMemoryBody
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode memory: %v", err)
+	}
+	return out
+}
+
+// patchMemory issues a PATCH against a seeded id.
+func patchMemory(t *testing.T, h http.Handler, id string, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	return do(t, h, http.MethodPatch, "/v1/memories/"+id, updateNS, apiKey, body)
+}
+
+// TestPatchMemoryPartialUpdate: the fields the body omits must survive.
+func TestPatchMemoryPartialUpdate(t *testing.T) {
+	h := newServer(t)
+	id := seedMemory(t, h, map[string]any{
+		"content": "the deploy runbook lives in the ops wiki", "summary": "runbook location",
+		"tier": "semantic", "tags": []string{"ops"},
+	})
+
+	rec := patchMemory(t, h, id, map[string]any{"tags": []string{"ops", "runbook"}})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch: want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+	got := decodeMemory(t, rec.Body.Bytes())
+	if got.Content != "the deploy runbook lives in the ops wiki" {
+		t.Fatalf("Content = %q, want the stored content kept", got.Content)
+	}
+	if got.Summary != "runbook location" {
+		t.Fatalf("Summary = %q, want the stored summary kept", got.Summary)
+	}
+	if len(got.Tags) != 2 {
+		t.Fatalf("Tags = %v, want the update applied", got.Tags)
+	}
+}
+
+// TestPatchMemoryMergesMetadata pins the divergence from POST-with-an-id: PATCH
+// merges key-by-key where the upsert replaces wholesale. Getting this backwards
+// silently destroys metadata for anyone scripting partial edits.
+func TestPatchMemoryMergesMetadata(t *testing.T) {
+	h := newServer(t)
+	id := seedMemory(t, h, map[string]any{
+		"content": "the deploy runbook lives in the ops wiki", "tier": "semantic",
+		"metadata": map[string]any{"source": "handbook", "reviewed": "no"},
+	})
+
+	rec := patchMemory(t, h, id, map[string]any{"metadata": map[string]any{"reviewed": "yes"}})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch: want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+	got := decodeMemory(t, rec.Body.Bytes())
+	if got.Metadata["source"] != "handbook" {
+		t.Fatalf("Metadata[source] = %v, want preserved by the merge (a wholesale replace would drop it)",
+			got.Metadata["source"])
+	}
+	if got.Metadata["reviewed"] != "yes" {
+		t.Fatalf("Metadata[reviewed] = %v, want overwritten", got.Metadata["reviewed"])
+	}
+}
+
+// TestPatchMemoryNullMetadataValueDeletesKey covers the RFC 7386 delete.
+func TestPatchMemoryNullMetadataValueDeletesKey(t *testing.T) {
+	h := newServer(t)
+	id := seedMemory(t, h, map[string]any{
+		"content": "the deploy runbook lives in the ops wiki", "tier": "semantic",
+		"metadata": map[string]any{"source": "handbook", "reviewed": "no"},
+	})
+
+	rec := patchMemory(t, h, id, map[string]any{"metadata": map[string]any{"reviewed": nil}})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch: want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+	got := decodeMemory(t, rec.Body.Bytes())
+	if _, ok := got.Metadata["reviewed"]; ok {
+		t.Fatalf("Metadata[reviewed] = %v, want deleted by an explicit null", got.Metadata["reviewed"])
+	}
+	if got.Metadata["source"] != "handbook" {
+		t.Fatalf("Metadata[source] = %v, want the other keys untouched", got.Metadata["source"])
+	}
+}
+
+// TestPatchMemoryUnknownID must be a 404, not a 500.
+func TestPatchMemoryUnknownID(t *testing.T) {
+	h := newServer(t)
+	rec := patchMemory(t, h, "does-not-exist", map[string]any{"summary": "irrelevant"})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("patch unknown id: want 404, got %d (%s)", rec.Code, rec.Body)
+	}
+}
+
+// TestPatchMemoryBadTierIsBadRequest is the regression guard on error CLASS.
+// service.Update must return ErrInvalidInput for a bad tier: statusFor maps that
+// to 400 and anything unrecognized to 500, so a bare fmt.Errorf would report a
+// caller's typo as a server fault. Verified by mutation: swapping invalidInputf
+// for fmt.Errorf turns this into a 500.
+func TestPatchMemoryBadTierIsBadRequest(t *testing.T) {
+	h := newServer(t)
+	id := seedMemory(t, h, map[string]any{
+		"content": "the deploy runbook lives in the ops wiki", "tier": "semantic",
+	})
+
+	rec := patchMemory(t, h, id, map[string]any{"tier": "nonsense"})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("patch with a bad tier: want 400, got %d (%s)", rec.Code, rec.Body)
+	}
+}
+
+// TestPatchMemoryClearsSummary: an explicit empty string is a write, not an
+// omission — the behaviour the old ""-sentinel form could not express.
+func TestPatchMemoryClearsSummary(t *testing.T) {
+	h := newServer(t)
+	id := seedMemory(t, h, map[string]any{
+		"content": "the deploy runbook lives in the ops wiki", "summary": "runbook location",
+		"tier": "semantic",
+	})
+
+	rec := patchMemory(t, h, id, map[string]any{"summary": ""})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch: want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+	if got := decodeMemory(t, rec.Body.Bytes()); got.Summary != "" {
+		t.Fatalf("Summary = %q, want cleared by an explicit empty string", got.Summary)
+	}
+}

--- a/internal/service/remember_reuse_test.go
+++ b/internal/service/remember_reuse_test.go
@@ -1,0 +1,153 @@
+package service_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/eleboucher/memini/internal/embed/embedtest"
+	"github.com/eleboucher/memini/internal/memory"
+	"github.com/eleboucher/memini/internal/service"
+)
+
+// TestRememberUpdateReusesVectorWhenContentUnchanged pins the point of the
+// reuse path: an update that touches only metadata/tags/importance costs no
+// embedder call.
+//
+// The Recall assertion is not incidental. Reusing existing.Embedding (always
+// empty — Get omits vectors) would hand Upsert a zero-length vector, which it
+// reads as "drop the vector", silently evicting the row from semantic recall.
+// That bug spends zero embedder calls too, so a count-only test would pass
+// while the memory quietly stopped being findable.
+func TestRememberUpdateReusesVectorWhenContentUnchanged(t *testing.T) {
+	ctx := context.Background()
+	st := openTestStore(t)
+	rec := &recordingEmbedder{Embedder: embedtest.New(dims)}
+	svc := service.New(st, rec, service.WithSyncReinforce())
+
+	const content = "the deploy runbook lives in the ops wiki"
+	created, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "alice", Content: content, Tier: memory.TierSemantic,
+		Tags: []string{"ops"},
+	})
+	if err != nil {
+		t.Fatalf("seed remember: %v", err)
+	}
+	seedCalls := len(rec.texts)
+
+	updated, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "alice", ID: created.ID, Content: content, Tier: memory.TierSemantic,
+		Tags: []string{"ops", "runbook"}, Metadata: map[string]any{"reviewed": "yes"},
+	})
+	if err != nil {
+		t.Fatalf("metadata-only update: %v", err)
+	}
+
+	if len(rec.texts) != seedCalls {
+		t.Fatalf("embedder called %d extra time(s) for a content-unchanged update, want 0 (texts: %v)",
+			len(rec.texts)-seedCalls, rec.texts[seedCalls:])
+	}
+	if len(updated.Embedding) == 0 {
+		t.Fatal("Embedding empty after a reused-vector update, want the stored vector carried forward")
+	}
+	if !slices.Contains(updated.Tags, "runbook") {
+		t.Fatalf("Tags = %v, want the update applied", updated.Tags)
+	}
+
+	// The vector must still be in the index, not merely on the returned struct.
+	hits, err := svc.Recall(ctx, service.RecallInput{Namespace: "alice", Query: content, Limit: 5})
+	if err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	var found bool
+	for _, h := range hits {
+		if h.Memory.ID == created.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("memory %s is no longer recallable after a metadata-only update — its vector was dropped", created.ID)
+	}
+}
+
+// TestRememberUpdateReEmbedsVectorlessRow is the guard on the reuse condition.
+// A row left vectorless by a degraded write has content that matches the update
+// byte-for-byte but nothing to reuse, so it must still embed for real — this is
+// the documented recovery path (memory_update once the embedder is back).
+//
+// Written as reuse-on-content-match alone, without the has-a-vector check, this
+// fails: the row would keep its empty vector and stay degraded forever. The two
+// existing pending_embed tests both change content, so neither reaches this
+// branch.
+func TestRememberUpdateReEmbedsVectorlessRow(t *testing.T) {
+	ctx := context.Background()
+	st := openTestStore(t)
+
+	const content = "the office wifi password is on the whiteboard"
+	degraded := service.New(st, errEmbedder{dims: dims}, service.WithSyncReinforce(),
+		service.WithWriteEmbedTimeout(time.Second))
+	created, err := degraded.Remember(ctx, service.RememberInput{
+		Namespace: "alice", Content: content, Tier: memory.TierSemantic,
+	})
+	if err != nil {
+		t.Fatalf("seed degraded remember: %v", err)
+	}
+	if created.Metadata["pending_embed"] != "true" {
+		t.Fatalf("seed Metadata[pending_embed] = %v, want \"true\"", created.Metadata["pending_embed"])
+	}
+
+	// Same content, healthy embedder, metadata-only edit.
+	rec := &recordingEmbedder{Embedder: embedtest.New(dims)}
+	healthy := service.New(st, rec, service.WithSyncReinforce())
+	updated, err := healthy.Remember(ctx, service.RememberInput{
+		Namespace: "alice", ID: created.ID, Content: content, Tier: memory.TierSemantic,
+		Metadata: created.Metadata,
+	})
+	if err != nil {
+		t.Fatalf("recovery update: %v", err)
+	}
+
+	if len(rec.texts) != 1 {
+		t.Fatalf("embedder calls = %d, want 1: a vectorless row has nothing to reuse and must re-embed", len(rec.texts))
+	}
+	if _, ok := updated.Metadata["pending_embed"]; ok {
+		t.Fatal("Metadata[pending_embed] still set, want cleared once the row gained a vector")
+	}
+	if len(updated.Embedding) == 0 {
+		t.Fatal("Embedding empty, want a vector after the recovery re-embed")
+	}
+}
+
+// TestRememberUpdateReEmbedsWhenContentChanges is the negative control: a real
+// content edit must still pay exactly one embedder call, or the reuse condition
+// is too eager and the stored vector would point at replaced content.
+func TestRememberUpdateReEmbedsWhenContentChanges(t *testing.T) {
+	ctx := context.Background()
+	st := openTestStore(t)
+	rec := &recordingEmbedder{Embedder: embedtest.New(dims)}
+	svc := service.New(st, rec, service.WithSyncReinforce())
+
+	created, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "alice", Content: "the deploy runbook lives in the ops wiki", Tier: memory.TierSemantic,
+	})
+	if err != nil {
+		t.Fatalf("seed remember: %v", err)
+	}
+	seedCalls := len(rec.texts)
+
+	const replacement = "the deploy runbook moved to the platform handbook"
+	if _, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "alice", ID: created.ID, Content: replacement, Tier: memory.TierSemantic,
+	}); err != nil {
+		t.Fatalf("content update: %v", err)
+	}
+
+	if got := len(rec.texts) - seedCalls; got != 1 {
+		t.Fatalf("embedder calls for a content change = %d, want 1", got)
+	}
+	if last := rec.texts[len(rec.texts)-1]; last != replacement {
+		t.Fatalf("embedded %q, want the replacement content %q", last, replacement)
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -976,7 +976,50 @@ func validateRememberInput(in RememberInput) (RememberInput, memory.Tier, error)
 	return in, tier, nil
 }
 
-// embedForRemember embeds fresh write content. When writeEmbedTimeout is set
+// reusableVector returns the stored vector when this write is an update that
+// leaves content byte-identical, so a tags-, metadata- or importance-only edit
+// costs no embedder call. ok is false when the caller must embed for real.
+//
+// in.Content is compared after scrubInput/sanitizeContent have rewritten it, so
+// it is the exact string embedForRemember would send to the embedder — equality
+// with the stored content makes the reused vector identical to the one a
+// re-embed would produce, not merely close. (Writes get no queryPrefix; that is
+// recall-only.)
+//
+// The vector is read back through the store rather than off existing.Embedding,
+// which is always empty: Get omits the vector from every read path (see
+// memory.Memory.Embedding). Reusing that empty slice would hand Upsert a
+// zero-length embedding, which it reads as "drop the vector" — silently
+// evicting the memory from semantic recall on every metadata edit.
+//
+// A vectorless row (degraded write, pending_embed) has nothing to reuse and
+// falls through to a real embed: that is the documented recovery path, and
+// GetEmbedding reporting (nil, nil) rather than an error is what keeps it
+// distinct from a missing row. A GetEmbedding error also falls through — a
+// redundant embed is strictly better than failing a write that would otherwise
+// succeed.
+func (s *Service) reusableVector(ctx context.Context, in *RememberInput, existing *memory.Memory) ([]float32, bool) {
+	if existing == nil || existing.Content != in.Content {
+		return nil, false
+	}
+	vec, err := s.store.GetEmbedding(ctx, in.Namespace, in.ID)
+	if err != nil {
+		slog.WarnContext(ctx, "remember: reading the stored vector failed, re-embedding instead",
+			"namespace", in.Namespace, "id", in.ID, "err", err)
+		return nil, false
+	}
+	if len(vec) == 0 {
+		return nil, false
+	}
+	// The row carries a valid vector for exactly this content, so it is not
+	// degraded — mirror the embed success path and clear any stale flag.
+	delete(in.Metadata, "pending_embed")
+	return vec, true
+}
+
+// embedForRemember embeds fresh write content, or reuses the stored vector when
+// an update leaves content unchanged (see reusableVector). When
+// writeEmbedTimeout is set
 // (> 0), the embed is bounded and a timeout or error degrades the write: it
 // returns a nil vector (the caller stores the memory keyword-searchable only)
 // and stamps in.Metadata["pending_embed"] = "true" so a background backfill
@@ -985,7 +1028,10 @@ func validateRememberInput(in RememberInput) (RememberInput, memory.Tier, error)
 // fail-fast default. in.Metadata is mutated in place (allocated if nil),
 // mirroring stampClassifiedTier/scrubInput: callers that share a Metadata map
 // across writes will see the flag too.
-func (s *Service) embedForRemember(ctx context.Context, in *RememberInput) ([]float32, error) {
+func (s *Service) embedForRemember(ctx context.Context, in *RememberInput, existing *memory.Memory) ([]float32, error) {
+	if vec, ok := s.reusableVector(ctx, in, existing); ok {
+		return vec, nil
+	}
 	if s.writeEmbedTimeout <= 0 {
 		vec, err := embed.EmbedOne(ctx, s.embedder, in.Content)
 		if err != nil {
@@ -1070,19 +1116,11 @@ func (s *Service) Remember(ctx context.Context, in RememberInput) (*memory.Memor
 		return existing, nil
 	}
 
-	vec, err := s.embedForRemember(ctx, &in)
-	if err != nil {
-		s.metrics.RememberResult("error", string(tier))
-		return nil, err
-	}
-
-	now := s.now()
-	id := in.ID
-	if id == "" {
-		id = s.newID()
-	}
 	// An update by ID preserves the existing row's validity start and confidence;
-	// load it so the upsert below doesn't reset them.
+	// load it so the upsert below doesn't reset them. This runs before the embed
+	// because embedForRemember reuses the loaded row's stored vector when the
+	// update leaves content unchanged (see reusableVector). A create skips it
+	// entirely — in.ID is empty — so the fresh-write path pays nothing.
 	var existing *memory.Memory
 	if in.ID != "" {
 		ex, gerr := s.store.Get(ctx, in.Namespace, in.ID)
@@ -1094,6 +1132,18 @@ func (s *Service) Remember(ctx context.Context, in RememberInput) (*memory.Memor
 			s.metrics.RememberResult("error", string(tier))
 			return nil, fmt.Errorf("remember: load existing: %w", gerr)
 		}
+	}
+
+	vec, err := s.embedForRemember(ctx, &in, existing)
+	if err != nil {
+		s.metrics.RememberResult("error", string(tier))
+		return nil, err
+	}
+
+	now := s.now()
+	id := in.ID
+	if id == "" {
+		id = s.newID()
 	}
 	m := &memory.Memory{
 		ID:             id,

--- a/internal/service/update.go
+++ b/internal/service/update.go
@@ -1,0 +1,133 @@
+package service
+
+import (
+	"context"
+	"maps"
+
+	"github.com/eleboucher/memini/internal/memory"
+)
+
+// UpdateInput describes a partial edit to an existing memory. Every field is
+// optional: a nil pointer (or nil slice/map) keeps whatever the stored record
+// holds, so a caller enriching one field never has to resend the rest.
+//
+// The pointers are deliberate. An earlier ""-sentinel form could not tell "omit
+// to keep" from "set this to empty", which made a summary impossible to clear.
+// A non-nil pointer to the zero value is an explicit write of that value.
+type UpdateInput struct {
+	Namespace string
+	ID        string
+	// Home is the caller's personal namespace, and Author the named API key
+	// behind the edit — both forwarded to RememberInput. See its docs.
+	Home   string
+	Author string
+
+	Content *string
+	Summary *string
+	Tier    *memory.Tier
+	Level   *memory.Level
+	// Known limitation: an explicit 0 is silently ignored and the stored
+	// importance kept, because resolveImportance uses a `!= 0` sentinel on
+	// RememberInput.Importance (a float64, not a pointer). Fixing it means
+	// pointer-izing that field across every write path. Do not document an
+	// update surface as being able to set importance to 0.
+	Importance *float64
+	Confidence *float64
+
+	// Tags replaces the stored set wholesale: nil keeps it, a non-nil empty
+	// slice clears it. Not a *[]string — nil-vs-empty already carries both
+	// meanings, and it is the shape both surfaces decode into natively.
+	Tags []string
+
+	// Metadata merges into the stored metadata key-by-key rather than replacing
+	// it (RFC 7386 style): nil leaves metadata untouched, and an explicit nil
+	// value deletes that key. This is the one place Update deliberately differs
+	// from RememberInput.Metadata, which replaces wholesale — see mergeMetadata.
+	Metadata map[string]any
+}
+
+// Update applies a partial edit to an existing memory and returns the stored
+// result. Returns store.ErrNotFound when id is absent, and ErrInvalidInput when
+// the edit is rejected.
+//
+// It composes Get + Remember with the current ID (the documented upsert path)
+// rather than writing fields directly, so an edit still runs the full write
+// lifecycle: validation, secret redaction, and content sanitization all apply to
+// updated content exactly as they would to a fresh write. Content is re-embedded
+// only when it actually changes (see reusableVector), so a tags- or
+// metadata-only edit costs no embedder call. Remember's dedup, consolidation and
+// corroborate/contradict routing are fresh-write-only and never fire here.
+func (s *Service) Update(ctx context.Context, in UpdateInput) (*memory.Memory, error) {
+	cur, err := s.Get(ctx, in.Namespace, in.ID)
+	if err != nil {
+		return nil, err
+	}
+	// Seed every field from the stored record so anything the caller omitted
+	// carries over untouched.
+	upd := RememberInput{
+		Namespace: in.Namespace, Home: in.Home, Author: in.Author, ID: cur.ID,
+		Content: cur.Content, Summary: cur.Summary, Tier: cur.Tier,
+		Tags: cur.Tags, Metadata: mergeMetadata(cur.Metadata, in.Metadata),
+		Importance: cur.Importance, Confidence: cur.Confidence,
+		Level: cur.Level, ValidFrom: cur.ValidFrom, ValidTo: cur.ValidTo,
+	}
+	if in.Content != nil {
+		upd.Content = *in.Content
+	}
+	if in.Summary != nil {
+		upd.Summary = *in.Summary
+	}
+	if in.Tier != nil {
+		if !in.Tier.Valid() {
+			return nil, invalidInputf("invalid tier %q: want working|episodic|semantic|procedural", *in.Tier)
+		}
+		upd.Tier = *in.Tier
+	}
+	if in.Level != nil {
+		if !in.Level.Valid() {
+			return nil, invalidInputf("invalid level %q: want explicit|deduced", *in.Level)
+		}
+		upd.Level = *in.Level
+	}
+	if in.Tags != nil {
+		upd.Tags = in.Tags
+	}
+	if in.Importance != nil {
+		upd.Importance = *in.Importance
+	}
+	if in.Confidence != nil {
+		upd.Confidence = in.Confidence
+	}
+
+	m, err := s.Remember(ctx, upd)
+	if err != nil {
+		return nil, err
+	}
+	// The episodic value gate returns (nil, nil) when it drops a low-signal
+	// write. For a fresh Remember that is a stored=false result, but here the
+	// caller asked to change an existing memory and nothing changed — surface it
+	// as an error rather than dereferencing nil or claiming success.
+	if m == nil {
+		return nil, invalidInputf("update dropped: the new content is below the episodic value gate " +
+			"(too short/low-signal); provide more substantive content or set a durable tier")
+	}
+	return m, nil
+}
+
+// mergeMetadata overlays patch onto cur key-by-key, deleting any key whose patch
+// value is nil. It always allocates: Remember mutates the Metadata map it is
+// given (stampClassifiedTier, scrubInput and embedForRemember all write to it),
+// so handing it the map that came off the stored record would let a write scribble
+// on its own input.
+func mergeMetadata(cur, patch map[string]any) map[string]any {
+	out := make(map[string]any, len(cur)+len(patch))
+	maps.Copy(out, cur)
+	for k, v := range patch {
+		if v == nil {
+			delete(out, k)
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/internal/service/update_test.go
+++ b/internal/service/update_test.go
@@ -1,0 +1,214 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/eleboucher/memini/internal/embed/embedtest"
+	"github.com/eleboucher/memini/internal/memory"
+	"github.com/eleboucher/memini/internal/service"
+	"github.com/eleboucher/memini/internal/store"
+)
+
+// seedForUpdate stores one fully-populated memory to edit.
+func seedForUpdate(t *testing.T, svc *service.Service) *memory.Memory {
+	t.Helper()
+	m, err := svc.Remember(context.Background(), service.RememberInput{
+		Namespace: "alice",
+		Content:   "the deploy runbook lives in the ops wiki",
+		Summary:   "runbook location",
+		Tier:      memory.TierSemantic,
+		Tags:      []string{"ops"},
+		Metadata:  map[string]any{"source": "handbook", "reviewed": "no"},
+	})
+	if err != nil {
+		t.Fatalf("seed remember: %v", err)
+	}
+	return m
+}
+
+func newUpdateService(t *testing.T) *service.Service {
+	t.Helper()
+	return service.New(openTestStore(t), embedtest.New(dims), service.WithSyncReinforce())
+}
+
+// TestUpdateOmittedFieldsAreKept is the core omit-to-keep contract: a caller
+// changing one field must not have to resend the others to avoid losing them.
+func TestUpdateOmittedFieldsAreKept(t *testing.T) {
+	ctx := context.Background()
+	svc := newUpdateService(t)
+	seed := seedForUpdate(t, svc)
+
+	got, err := svc.Update(ctx, service.UpdateInput{
+		Namespace: "alice", ID: seed.ID, Tags: []string{"ops", "runbook"},
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if got.Content != seed.Content {
+		t.Fatalf("Content = %q, want the stored content kept", got.Content)
+	}
+	if got.Summary != seed.Summary {
+		t.Fatalf("Summary = %q, want the stored summary kept", got.Summary)
+	}
+	if got.Tier != seed.Tier {
+		t.Fatalf("Tier = %q, want the stored tier kept", got.Tier)
+	}
+	if got.Metadata["source"] != "handbook" {
+		t.Fatalf("Metadata[source] = %v, want the stored metadata kept", got.Metadata["source"])
+	}
+	if !slices.Equal(got.Tags, []string{"ops", "runbook"}) {
+		t.Fatalf("Tags = %v, want the update applied", got.Tags)
+	}
+}
+
+// TestUpdateClearsSummaryWithExplicitEmpty pins the behaviour the ""-sentinel
+// form could not express: an explicit empty value is a write, not an omission.
+// Before pointers, summary: "" was indistinguishable from "field absent" and was
+// silently ignored, so a summary could never be cleared.
+func TestUpdateClearsSummaryWithExplicitEmpty(t *testing.T) {
+	ctx := context.Background()
+	svc := newUpdateService(t)
+	seed := seedForUpdate(t, svc)
+
+	got, err := svc.Update(ctx, service.UpdateInput{
+		Namespace: "alice", ID: seed.ID, Summary: new(""),
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if got.Summary != "" {
+		t.Fatalf("Summary = %q, want cleared by an explicit empty string", got.Summary)
+	}
+}
+
+// TestUpdateMergesMetadataKeyByKey: enriching one key must not drop the others,
+// which is what a wholesale replace (POST /v1/memories with an id) would do.
+func TestUpdateMergesMetadataKeyByKey(t *testing.T) {
+	ctx := context.Background()
+	svc := newUpdateService(t)
+	seed := seedForUpdate(t, svc)
+
+	got, err := svc.Update(ctx, service.UpdateInput{
+		Namespace: "alice", ID: seed.ID,
+		Metadata: map[string]any{"reviewed": "yes", "owner": "platform"},
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if got.Metadata["source"] != "handbook" {
+		t.Fatalf("Metadata[source] = %v, want an untouched key preserved by the merge", got.Metadata["source"])
+	}
+	if got.Metadata["reviewed"] != "yes" {
+		t.Fatalf("Metadata[reviewed] = %v, want overwritten", got.Metadata["reviewed"])
+	}
+	if got.Metadata["owner"] != "platform" {
+		t.Fatalf("Metadata[owner] = %v, want added", got.Metadata["owner"])
+	}
+}
+
+// TestUpdateNilMetadataValueDeletesKey: a nil value is a delete, which is
+// otherwise impossible — the only alternative is a wholesale re-POST of every
+// other key, which is both racy and lossy.
+func TestUpdateNilMetadataValueDeletesKey(t *testing.T) {
+	ctx := context.Background()
+	svc := newUpdateService(t)
+	seed := seedForUpdate(t, svc)
+
+	got, err := svc.Update(ctx, service.UpdateInput{
+		Namespace: "alice", ID: seed.ID,
+		Metadata: map[string]any{"reviewed": nil},
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if _, ok := got.Metadata["reviewed"]; ok {
+		t.Fatalf("Metadata[reviewed] = %v, want deleted by an explicit nil value", got.Metadata["reviewed"])
+	}
+	if got.Metadata["source"] != "handbook" {
+		t.Fatalf("Metadata[source] = %v, want the other keys untouched", got.Metadata["source"])
+	}
+}
+
+// TestUpdateInvalidTierIsInvalidInput pins the error CLASS, not its text: the
+// REST layer maps ErrInvalidInput to 400 and anything unrecognized to 500, so a
+// bare fmt.Errorf here would surface a caller's typo as a server error.
+func TestUpdateInvalidTierIsInvalidInput(t *testing.T) {
+	ctx := context.Background()
+	svc := newUpdateService(t)
+	seed := seedForUpdate(t, svc)
+
+	_, err := svc.Update(ctx, service.UpdateInput{
+		Namespace: "alice", ID: seed.ID, Tier: new(memory.Tier("nonsense")),
+	})
+	if !errors.Is(err, service.ErrInvalidInput) {
+		t.Fatalf("err = %v, want ErrInvalidInput so the REST layer renders 400 rather than 500", err)
+	}
+}
+
+// TestUpdateMissingIDIsNotFound: the sentinel must survive the Get+Remember
+// composition so each surface can render its own 404.
+func TestUpdateMissingIDIsNotFound(t *testing.T) {
+	ctx := context.Background()
+	svc := newUpdateService(t)
+
+	_, err := svc.Update(ctx, service.UpdateInput{Namespace: "alice", ID: "does-not-exist"})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("err = %v, want store.ErrNotFound", err)
+	}
+}
+
+// TestUpdateAppliesContentAndTier covers the ordinary explicit-write path.
+func TestUpdateAppliesContentAndTier(t *testing.T) {
+	ctx := context.Background()
+	svc := newUpdateService(t)
+	seed := seedForUpdate(t, svc)
+
+	const replacement = "the deploy runbook moved to the platform handbook"
+	got, err := svc.Update(ctx, service.UpdateInput{
+		Namespace: "alice", ID: seed.ID,
+		Content: new(replacement), Tier: new(memory.TierProcedural),
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if got.Content != replacement {
+		t.Fatalf("Content = %q, want %q", got.Content, replacement)
+	}
+	if got.Tier != memory.TierProcedural {
+		t.Fatalf("Tier = %q, want procedural", got.Tier)
+	}
+	if got.ID != seed.ID {
+		t.Fatalf("ID = %q, want the edit to stay in place on %q", got.ID, seed.ID)
+	}
+}
+
+// TestUpdateDoesNotMutateStoredMetadataMap guards the fresh-map allocation in
+// mergeMetadata. Remember writes into the Metadata map it is handed
+// (stampClassifiedTier / scrubInput / embedForRemember), so reusing the map that
+// came off the stored record would let one write scribble on another's data.
+func TestUpdateDoesNotMutateStoredMetadataMap(t *testing.T) {
+	ctx := context.Background()
+	svc := newUpdateService(t)
+	seed := seedForUpdate(t, svc)
+
+	before := make(map[string]any, len(seed.Metadata))
+	maps.Copy(before, seed.Metadata)
+	if _, err := svc.Update(ctx, service.UpdateInput{
+		Namespace: "alice", ID: seed.ID, Metadata: map[string]any{"owner": "platform"},
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	for k, want := range before {
+		if seed.Metadata[k] != want {
+			t.Fatalf("the seed's Metadata[%q] changed to %v (want %v) — Update mutated a caller's map",
+				k, seed.Metadata[k], want)
+		}
+	}
+	if _, ok := seed.Metadata["owner"]; ok {
+		t.Fatal("Update leaked its merge into the caller's metadata map")
+	}
+}

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -345,6 +345,27 @@ func (s *Store) Get(ctx context.Context, namespace, id string) (*memory.Memory, 
 	return m, err
 }
 
+// GetEmbedding returns the stored vector for a memory, or nil when the row is
+// vectorless (embedding IS NULL — a degraded write awaiting backfill). Scanning
+// into a *pgvector.Vector rather than a value is what keeps those two cases
+// apart: pgx leaves the pointer nil for SQL NULL, where a value scan would
+// error.
+func (s *Store) GetEmbedding(ctx context.Context, namespace, id string) ([]float32, error) {
+	var emb *pgvector.Vector
+	err := s.pool.QueryRow(ctx,
+		`SELECT embedding FROM memories WHERE id=$1 AND namespace=$2`, id, namespace).Scan(&emb)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("postgres: get embedding %q: %w", id, err)
+	}
+	if emb == nil {
+		return nil, nil
+	}
+	return emb.Slice(), nil
+}
+
 // PredecessorIDs returns the IDs of memories in the namespace superseded by id.
 func (s *Store) PredecessorIDs(ctx context.Context, namespace, id string) ([]string, error) {
 	rows, err := s.pool.Query(ctx,

--- a/internal/store/sqlitevec/helpers.go
+++ b/internal/store/sqlitevec/helpers.go
@@ -1,7 +1,9 @@
 package sqlitevec
 
 import (
+	"bytes"
 	"database/sql"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -332,6 +334,22 @@ func boolToInt(b bool) int {
 		return 1
 	}
 	return 0
+}
+
+// deserializeFloat32 decodes a vec0 embedding blob back into a vector. The
+// bindings ship SerializeFloat32 but no inverse, and the blob is exactly
+// little-endian packed float32, so this mirrors it. A length that isn't a
+// multiple of 4 is not a blob this store wrote — surface it rather than
+// returning a silently truncated vector.
+func deserializeFloat32(b []byte) ([]float32, error) {
+	if len(b)%4 != 0 {
+		return nil, fmt.Errorf("sqlitevec: embedding blob is %d bytes, not a multiple of 4", len(b))
+	}
+	vec := make([]float32, len(b)/4)
+	if err := binary.Read(bytes.NewReader(b), binary.LittleEndian, vec); err != nil {
+		return nil, fmt.Errorf("sqlitevec: deserialize embedding: %w", err)
+	}
+	return vec, nil
 }
 
 func distanceToScore(d float64) float64 { return 1 / (1 + d) }

--- a/internal/store/sqlitevec/store.go
+++ b/internal/store/sqlitevec/store.go
@@ -517,6 +517,29 @@ func (s *Store) Get(ctx context.Context, namespace, id string) (*memory.Memory, 
 	return m, err
 }
 
+// GetEmbedding returns the stored vector for a memory, or nil when the row is
+// vectorless. The lookup is a LEFT JOIN for the same reason Reassign's is: a
+// vectorless memory has no vec_memories row at all, and an inner join would
+// report it as ErrNotFound — indistinguishable from a memory that doesn't
+// exist, which the caller must tell apart (one falls back to embedding, the
+// other is an error).
+func (s *Store) GetEmbedding(ctx context.Context, namespace, id string) ([]float32, error) {
+	var emb []byte
+	err := s.db.QueryRowContext(ctx,
+		`SELECT v.embedding FROM memories m LEFT JOIN vec_memories v ON v.rowid = m.rowid
+		 WHERE m.id = ? AND m.namespace = ?`, id, namespace).Scan(&emb)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("sqlitevec: get embedding %q: %w", id, err)
+	}
+	if emb == nil {
+		return nil, nil
+	}
+	return deserializeFloat32(emb)
+}
+
 // PredecessorIDs returns the IDs of memories in the namespace superseded by id.
 func (s *Store) PredecessorIDs(ctx context.Context, namespace, id string) ([]string, error) {
 	rows, err := s.db.QueryContext(ctx,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -123,6 +123,19 @@ type Store interface {
 	// Get returns a memory by ID, or ErrNotFound.
 	Get(ctx context.Context, namespace, id string) (*memory.Memory, error)
 
+	// GetEmbedding returns the stored vector for a memory, for a write that must
+	// preserve a vector it is not recomputing (see service.Remember's reuse of
+	// the stored vector when an update leaves content unchanged). Returns
+	// (nil, nil) when the row exists but is vectorless — a degraded write
+	// awaiting backfill — and ErrNotFound when the memory is absent.
+	//
+	// Kept off Get deliberately: a vector is dims*4 bytes and Get/List/search run
+	// on every read path, so Memory.Embedding is left empty there (see
+	// memory.Memory.Embedding). That makes a Get-then-Upsert round trip lossy for
+	// the vector, which is why a write that skips embedding must read it back
+	// through here rather than off the Memory it just loaded.
+	GetEmbedding(ctx context.Context, namespace, id string) ([]float32, error)
+
 	// PredecessorIDs returns the IDs of memories in the namespace whose
 	// SupersededBy points at id — the versions id replaced. Empty when none.
 	// Used to walk a memory's supersession lineage backwards.

--- a/internal/store/storetest/conformance.go
+++ b/internal/store/storetest/conformance.go
@@ -51,6 +51,7 @@ func Run(t *testing.T, st store.Store, dims int) {
 	t.Run("GetByFingerprint", func(t *testing.T) { testGetByFingerprint(t, st, dims) })
 	t.Run("LevelFilter", func(t *testing.T) { testLevelFilter(t, st, dims) })
 	t.Run("VectorlessRow", func(t *testing.T) { testVectorlessRow(t, st, dims) })
+	t.Run("GetEmbedding", func(t *testing.T) { testGetEmbedding(t, st, dims) })
 	t.Run("NamespaceLinks", func(t *testing.T) { testNamespaceLinks(t, st, dims) })
 	t.Run("NamespaceActivity", func(t *testing.T) { testNamespaceActivity(t, st, dims) })
 	t.Run("APIKeys", func(t *testing.T) { testAPIKeys(t, st, dims) })
@@ -584,6 +585,53 @@ func testNamespaceActivity(t *testing.T, st store.Store, dims int) {
 // vector must make it vector-searchable; re-upserting a vectored row without a
 // vector must remove the now-stale vector-index entry, not just leave it
 // unreachable through the new write.
+// testGetEmbedding pins the three-way contract callers depend on to tell "reuse
+// this vector" from "go embed": a stored vector round-trips exactly, a
+// vectorless row reports (nil, nil) rather than an error, and a missing memory
+// is ErrNotFound. Conflating the middle case with either neighbour is what
+// makes a skip-the-embed write either lose the vector or fail closed.
+func testGetEmbedding(t *testing.T, st store.Store, dims int) {
+	ctx := context.Background()
+	ns := t.Name()
+
+	// (a) a stored vector round-trips byte-for-byte.
+	want := vec(dims, 0.25, -0.5, 0.75)
+	mustUpsert(t, st, mem(ns, "vectored", "content with a vector", want))
+	got, err := st.GetEmbedding(ctx, ns, id(ns, "vectored"))
+	if err != nil {
+		t.Fatalf("get embedding: %v", err)
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("embedding round-trip mismatch:\n got %v\nwant %v", got, want)
+	}
+
+	// (b) a vectorless row is (nil, nil) — present, but nothing to reuse.
+	mustUpsert(t, st, mem(ns, "vectorless", "content with no vector", nil))
+	got, err = st.GetEmbedding(ctx, ns, id(ns, "vectorless"))
+	if err != nil {
+		t.Fatalf("get embedding on a vectorless row: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("vectorless row should report a nil embedding, got %v", got)
+	}
+
+	// (c) a missing memory is ErrNotFound, distinct from (b).
+	if _, err := st.GetEmbedding(ctx, ns, id(ns, "absent")); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("get embedding on a missing memory: want ErrNotFound, got %v", err)
+	}
+
+	// (d) a row that loses its vector reports (nil, nil) again — the degraded
+	// re-upsert path, which must not keep serving the old vector.
+	mustUpsert(t, st, mem(ns, "vectored", "content with a vector", nil))
+	got, err = st.GetEmbedding(ctx, ns, id(ns, "vectored"))
+	if err != nil {
+		t.Fatalf("get embedding after dropping the vector: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("embedding should be gone after a vectorless re-upsert, got %v", got)
+	}
+}
+
 func testVectorlessRow(t *testing.T, st store.Store, dims int) {
 	ctx := context.Background()
 	ns := t.Name()

--- a/ui/src/api-schema.gen.ts
+++ b/ui/src/api-schema.gen.ts
@@ -310,7 +310,13 @@ export interface paths {
         delete: operations["forgetMemory"];
         options?: never;
         head?: never;
-        patch?: never;
+        /**
+         * Update a memory in place
+         * @description Changes only the fields present in the body; anything omitted carries over from the stored record. metadata merges into the existing metadata key-by-key and an explicit null deletes that key — POST /v1/memories with an id replaces metadata wholesale instead.
+         *
+         *     The write-time lifecycle still runs (validation, secret redaction, content sanitization), so this is not a bare field write. Content is re-embedded only when it actually changes, so a tags- or metadata-only update costs no embedder call.
+         */
+        patch: operations["updateMemory"];
         trace?: never;
     };
     "/v1/memories/{id}/history": {
@@ -614,6 +620,7 @@ export interface components {
             tier?: components["schemas"]["Tier"];
             summary?: string;
             tags?: string[];
+            /** @description Replaces the stored metadata wholesale when this write carries an id (an upsert). Use PATCH /v1/memories/{id} to merge key-by-key instead. */
             metadata?: {
                 [key: string]: unknown;
             };
@@ -642,6 +649,31 @@ export interface components {
             confidence?: number;
             /** @description Write-side namespace scoping. Omit or "project" (default) writes to the request namespace itself. "personal" writes to the caller's home namespace (X-Memini-Home header / MEMINI_HOME on the client) instead — an error if no home namespace is configured. Any other value must name an ancestor of the request namespace, either its full path or an unambiguous last path segment (e.g. "acme" for request namespace "acme/phoenix/api"), and the write lands there instead. Ignored for non-durable writes: an episodic/working memory always stays in the request namespace regardless of visibility. */
             visibility?: string;
+        };
+        /** @description A partial edit: every property is optional and anything omitted keeps its stored value. Sending an explicit value writes it, so summary: "" clears the summary rather than being ignored. */
+        UpdateMemoryRequest: {
+            content?: string;
+            summary?: string;
+            /** @description Move the memory to this tier. Omit to keep the stored tier. */
+            tier?: components["schemas"]["Tier"];
+            /** @description Relabel derivation provenance. Omit to keep the stored level. */
+            level?: components["schemas"]["Level"];
+            /** @description Replaces the stored tag set wholesale. Omit to keep it; send an empty array to clear it. */
+            tags?: string[];
+            /** @description Merges into the stored metadata key-by-key: listed keys are added or overwritten, unlisted keys are untouched, and a key sent with a null value is deleted. POST /v1/memories with an id replaces metadata wholesale instead. */
+            metadata?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Format: double
+             * @description Omit to keep the stored importance. Note that 0 is currently indistinguishable from omitted and keeps the stored value.
+             */
+            importance?: number;
+            /**
+             * Format: double
+             * @description Omit to keep the stored confidence; ignored for short-term tiers.
+             */
+            confidence?: number;
         };
         SupersedeRequest: {
             /** @description ID of the memory that replaces the target. */
@@ -1938,6 +1970,38 @@ export interface operations {
                 content?: never;
             };
             404: components["responses"]["Error"];
+        };
+    };
+    updateMemory: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description Namespace for this request; falls back to the server default. */
+                "X-Memini-Namespace"?: components["parameters"]["Namespace"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateMemoryRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Memory"];
+                };
+            };
+            400: components["responses"]["Error"];
+            404: components["responses"]["Error"];
+            500: components["responses"]["Error"];
         };
     };
     getMemoryHistory: {


### PR DESCRIPTION
## Why

This started as a claim made mid-task, while scripting an edit across 88 memories:

> PATCH/PUT are both 405, there's no REST update-in-place route (only GET/DELETE on {id}, POST only on the collection which is create/upsert and would force a re-embed). The correct in-place tool is MCP memory_update (proven, no re-embed).

The 405s are real. Almost nothing else in that is.

There *is* a REST update-in-place route: `POST /v1/memories` binds an optional body `id` and upserts, which `RememberInput.ID` and the spec both say plainly. And `memory_update` was never re-embed-free. It is `svc.Get`, overlay fields, `svc.Remember` with the same ID, which is the identical service call `POST` with an `id` lands on. There is no `service.Update` at all. Both re-embedded, unconditionally, so the 88 memories would have cost 88 embedder calls either way.

The conclusion was wrong and the instinct was right, for an unstated reason. `memory_update` really is the correct tool, because of its merge semantics, not its embedding behaviour: `POST` with an `id` is a whole-record replace that drops every metadata key the caller did not resend. 88 partial POSTs would have silently destroyed data. The 405 prevented that by accident.

So two real gaps, and they are the same gap seen from two sides. **The re-embed is genuinely wasteful**: a tags-only edit pays a full embedder call on byte-identical content, and `Remember` embeds *before* it loads the existing row, so it could not have compared them even in principle. **And the surfaces have drifted**: every partial-update rule lives in the MCP handler, REST has no equivalent, and the route it pushes callers toward is the one that loses their data.

## What changed, by commit

**feat(store): add GetEmbedding so a write can preserve a vector it is not recomputing.** The obvious implementation of "reuse the vector when content did not change" is a silent data-loss bug, and this is the finding that shaped the whole change. `existing.Embedding` is *always* empty: `Memory.Embedding` is documented as "required when writing to the store and omitted from API responses", `memoryColumns` has no embedding column, and Postgres says so on `List`. `Upsert` then reads an empty `Embedding` as "drop the vector". So `Get` a memory, hand it back with the embedding untouched, and the row silently leaves the vector index. `Upsert`'s contract is right and stays, because a degraded update *must* drop the vector rather than leave a stale one pointing at replaced content, so a write that wants to keep a vector it is not recomputing has to read it back explicitly. This is the same trap #49 hit in the chunk backfill, from the other direction: that one had to stop writing the vector, this one has to start reading it.

**perf(service): reuse the stored vector when an update leaves content unchanged.** The existing-row load moves above the embed and the embed becomes conditional. Content is compared after `scrubInput` and `sanitizeContent` have rewritten it, so it is the exact string the embedder would have received, which makes the reused vector identical to a recomputed one rather than close to it. A create skips the load entirely (`in.ID` is empty), so the fresh-write path pays nothing and `POST` with an `id` gets the saving for free. The has-a-vector check is load-bearing rather than defensive: a row left vectorless by a degraded write has matching content and nothing to reuse, and it is exactly the documented recovery path, so it must still embed for real.

**refactor(service): extract Update, the partial-edit path both surfaces share.** `Get` plus `Remember` with the current ID, so an edit still runs validation, redaction and sanitization exactly as a fresh write does, and dedup/consolidation/contradiction routing stay fresh-write-only. Fields become pointers, because the `""` sentinel could not distinguish "omit to keep" from "set to empty" and a summary could never be cleared. Three things it fixes rather than carries over, since sharing them with REST would have made them worse: tier validation and the value-gate drop now return `ErrInvalidInput`, because `statusFor` maps anything unrecognized to **500** and the bare `fmt.Errorf` would have reported a caller's typo as a server fault; and `mergeMetadata` allocates, because `Remember` mutates the map it is handed and was being given the one off the stored record.

**refactor(mcp): repoint memory_update onto service.Update.** The handler becomes a translation layer. The wire schema is unchanged: `*float64` already rendered as a plain number, so `*string` renders as a plain string, and the only regenerated `mcp-tools.md` diff is the metadata description. `TestUpdateToolContentOnly` passes unmodified, which is the check that the extraction preserved the semantics rather than approximated them.

**feat(api): add PATCH /v1/memories/{id}.** Spec-first, so the route is generated. The generated request type is all optional pointers, mapping onto `UpdateInput` one to one, and keeping `"metadata": null` (no change) distinct from `{"metadata": {"k": null}}` (delete `k`) for free.

## Behaviour changes worth a changelog line

All three are on inputs that are meaningless today, which is what makes them worth taking.

- `{"summary": ""}` cleared nothing and now clears the summary. This is the bug the pointers fix.
- `{"content": ""}` was a silent no-op and now errors. Silently ignoring a caller who sent empty content was the worst of the three options.
- `{"metadata": {"k": null}}` stored a null and now deletes the key.

## Deliberate trade-offs, so you know they are not oversights

- **The skip lives in `Remember`, not in `Update`, and that is the load-bearing call.** Putting it in `Update` would compare pre-scrub content, correct only because `redact.Secrets` and `sanitize.Clean` happen to be idempotent on already-processed text, which is fragile reasoning to bake into a correctness check. It would also have missed the `POST`-upsert win. The alternative of passing a reusable vector through `RememberInput` was rejected outright: it puts a raw `[]float32` on the most-used struct in the service, where any caller can pass a vector that does not match its content.
- **`GetEmbedding` is required on the interface, not optional.** Reading back a vector is core to a vector store, `internal/store` has no out-of-tree implementers, and getting it wrong loses data silently, so the conformance suite should enforce it on every driver. `EmbedModelStore` is optional because recording a model name is genuinely driver-specific; this is not.
- **`(nil, nil)` for a vectorless row is the whole point of the method.** The caller must tell "nothing to reuse, go embed" apart from "no such memory". sqlitevec gets there with a LEFT JOIN for exactly the reason `Reassign`'s is one, and Postgres scans into a `*pgvector.Vector` so NULL lands as nil instead of failing the scan.
- **A `GetEmbedding` error falls through to embedding rather than failing the write.** A redundant embed beats failing a write that would otherwise succeed.
- **`importance: 0` stays broken, and is documented rather than fixed.** `resolveImportance` uses a `!= 0` sentinel on a `float64`, so an explicit zero is ignored today via `memory_update` too. Making it honest means pointer-izing `RememberInput.Importance` across `rest.go`, `promote.go`, `consolidate.go`, the importer and maintenance, which is its own change. The PATCH docs do not claim it works.
- **PATCH merges metadata, POST with an `id` replaces it.** Keeping both is deliberate: replace is what an upsert means. The divergence is documented on both, pointing at each other, in the spec and in the Go docs, because it is the detail most likely to be assumed rather than read.
- **A null metadata value deletes the key**, following RFC 7386. There is currently no way to delete a metadata key at all; the only alternative is a wholesale re-POST of every other key, which is both racy and lossy.
- **`Update` reads the row twice** (`s.Get`, then `Remember`'s own load). That is true today via the MCP path as well, so it is not a regression, and collapsing it means teaching `Remember` to accept a preloaded row. Left alone.
- **`s.Get`, not `s.store.Get`.** `s.Get` logs the activity event the MCP path has always emitted. Switching would have dropped it silently.

## Verification

Full unit suite and `golangci-lint` clean. The full integration suite passes against a real vchord Postgres, including the new conformance case on both drivers.

The tests that matter here were checked by mutation, because three of them assert things a passing test can trivially fake:

- Reusing `existing.Embedding` (the naive implementation) fails the reuse test.
- Dropping the has-a-vector check strands degraded rows, and fails the recovery test.
- Swapping `invalidInputf` for `fmt.Errorf` turns the PATCH bad-tier case into a **500**, which also confirms the generated binder does *not* validate the tier enum, so that guard is load-bearing rather than belt-and-braces.

The reuse test asserts the memory is **still returned by `Recall`**, not merely that the embedder went uncalled. The vector-wipe bug spends zero embedder calls too, so a count-only assertion passes straight through it while the corpus rots.

Worth noting what the existing suite could not do: `TestRememberUpdatePreservesPendingEmbed` and `TestRememberUpdateRecoveryClearsPendingEmbed` both change content, so both bypass the new branch entirely. They pass, and they prove nothing about it. That is why the recovery case had to be written rather than assumed.
