### PR TITLE
Make degraded writes visible: pending-embed status on stats, doctor, healthz, and the UI

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1477,6 +1477,7 @@ components:
           expired,
           superseded,
           low_confidence_durable,
+          pending_embed,
           total_accesses,
           avg_importance,
         ]
@@ -1495,6 +1496,9 @@ components:
         low_confidence_durable:
           type: integer
           description: Live durable memories whose decayed confidence is below the demote floor — reclaimable, uncorroborated debris.
+        pending_embed:
+          type: integer
+          description: Live memories saved without a vector because the embedder was unreachable at write time; the backfill loop re-embeds and unflags them, so a persistently nonzero value means the embedder is still down.
         total_accesses: { type: integer }
         avg_importance: { type: number, format: double }
         last_write_at: { type: string, format: date-time, nullable: true }

--- a/cmd/memini/depstatus.go
+++ b/cmd/memini/depstatus.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/eleboucher/memini/internal/embed"
 	"github.com/eleboucher/memini/internal/llm"
+	"github.com/eleboucher/memini/internal/rerank"
 	"github.com/eleboucher/memini/internal/server"
 )
 
@@ -56,6 +57,20 @@ func (r recordingLLM) Distill(ctx context.Context, in llm.DistillInput) ([]llm.F
 	facts, err := r.Client.Distill(ctx, in)
 	r.deps.Record("llm", err)
 	return facts, err
+}
+
+// recordingReranker wraps a rerank.Reranker the same way recordingEmbedder
+// wraps an embed.Embedder: every recall-path Rerank outcome feeds the
+// dep-status tracker under the "reranker" key.
+type recordingReranker struct {
+	rerank.Reranker
+	deps *server.DepTracker
+}
+
+func (r recordingReranker) Rerank(ctx context.Context, query string, candidates []rerank.Candidate) ([]string, error) {
+	ids, err := r.Reranker.Rerank(ctx, query, candidates)
+	r.deps.Record("reranker", err)
+	return ids, err
 }
 
 // probeEmbedder performs a one-shot tiny embed at startup so an unreachable

--- a/cmd/memini/doctor.go
+++ b/cmd/memini/doctor.go
@@ -321,7 +321,15 @@ type nsStat struct {
 	classified   int // durable writes tiered by the marker classifier (tier_classified=marker)
 	promoted     int // durable facts produced by promotion (promoted_from set)
 	corroborated int // durable memories whose confidence grew past the fresh seed
+	pendingEmbed int // vectorless degraded writes (pending_embed="true") awaiting backfill
 }
+
+// pendingEmbedTrue is the Metadata["pending_embed"] sentinel marking a
+// vectorless degraded write awaiting embed backfill. It mirrors
+// internal/service's package-private pendingEmbedValue (unimportable from
+// cmd/memini) and is a named constant only to keep goconst quiet — matching the
+// tiersAll/labelUnset precedent, not exported semantics.
+const pendingEmbedTrue = "true"
 
 func namespaceStats(ctx context.Context, st store.Store) ([]nsStat, error) {
 	names, err := st.ListNamespaces(ctx)
@@ -355,6 +363,9 @@ func namespaceStats(ctx context.Context, st store.Store) ([]nsStat, error) {
 				}
 				if _, ok := m.Metadata["promoted_from"]; ok {
 					s.promoted++
+				}
+				if v, _ := m.Metadata["pending_embed"].(string); v == pendingEmbedTrue {
+					s.pendingEmbed++
 				}
 			}
 			if m.Tier.Term() == memory.LongTerm && m.Confidence != nil &&
@@ -411,13 +422,14 @@ func printStoreStats(out io.Writer, stats []nsStat, pluginNS string) int {
 // promoter produced, and durable memories whose confidence has grown past the
 // fresh seed (re-observed via corroboration or exact restatement).
 func printWritePathSignals(out io.Writer, stats []nsStat) {
-	var classified, promoted, corroborated int
+	var classified, promoted, corroborated, pendingEmbed int
 	for _, s := range stats {
 		classified += s.classified
 		promoted += s.promoted
 		corroborated += s.corroborated
+		pendingEmbed += s.pendingEmbed
 	}
-	if classified == 0 && promoted == 0 && corroborated == 0 {
+	if classified == 0 && promoted == 0 && corroborated == 0 && pendingEmbed == 0 {
 		return
 	}
 	fmt.Fprintln(out, "Write-path signals:")                                                       //nolint:errcheck
@@ -425,6 +437,7 @@ func printWritePathSignals(out io.Writer, stats []nsStat) {
 	fmt.Fprintf(out, "  promotion-produced facts:          %d\n", promoted)                        //nolint:errcheck
 	fmt.Fprintf(out, "  corroborated durable memories:     %d (confidence above the %.2f seed)\n", //nolint:errcheck
 		corroborated, memory.ConfidenceSeedFresh)
+	fmt.Fprintf(out, "  pending embed (vectorless, awaiting backfill):  %d\n", pendingEmbed) //nolint:errcheck
 }
 
 // nsStat is the per-namespace summary doctor reports.

--- a/cmd/memini/doctor.go
+++ b/cmd/memini/doctor.go
@@ -321,7 +321,7 @@ type nsStat struct {
 	classified   int // durable writes tiered by the marker classifier (tier_classified=marker)
 	promoted     int // durable facts produced by promotion (promoted_from set)
 	corroborated int // durable memories whose confidence grew past the fresh seed
-	pendingEmbed int // vectorless degraded writes (pending_embed="true") awaiting backfill
+	pendingEmbed int // live vectorless degraded writes (pending_embed="true") awaiting backfill
 }
 
 // pendingEmbedTrue is the Metadata["pending_embed"] sentinel marking a
@@ -364,7 +364,12 @@ func namespaceStats(ctx context.Context, st store.Store) ([]nsStat, error) {
 				if _, ok := m.Metadata["promoted_from"]; ok {
 					s.promoted++
 				}
-				if v, _ := m.Metadata["pending_embed"].(string); v == pendingEmbedTrue {
+				// Live rows only: /v1/stats counts the pending-embed backlog
+				// over live memories and the backfill never lists superseded or
+				// expired rows, so counting them here would report a backlog
+				// nothing will ever drain.
+				if v, _ := m.Metadata["pending_embed"].(string); v == pendingEmbedTrue &&
+					m.SupersededBy == nil && !m.Expired(now) {
 					s.pendingEmbed++
 				}
 			}

--- a/cmd/memini/doctor.go
+++ b/cmd/memini/doctor.go
@@ -324,13 +324,6 @@ type nsStat struct {
 	pendingEmbed int // live vectorless degraded writes (pending_embed="true") awaiting backfill
 }
 
-// pendingEmbedTrue is the Metadata["pending_embed"] sentinel marking a
-// vectorless degraded write awaiting embed backfill. It mirrors
-// internal/service's package-private pendingEmbedValue (unimportable from
-// cmd/memini) and is a named constant only to keep goconst quiet — matching the
-// tiersAll/labelUnset precedent, not exported semantics.
-const pendingEmbedTrue = "true"
-
 func namespaceStats(ctx context.Context, st store.Store) ([]nsStat, error) {
 	names, err := st.ListNamespaces(ctx)
 	if err != nil {
@@ -368,8 +361,7 @@ func namespaceStats(ctx context.Context, st store.Store) ([]nsStat, error) {
 				// over live memories and the backfill never lists superseded or
 				// expired rows, so counting them here would report a backlog
 				// nothing will ever drain.
-				if v, _ := m.Metadata["pending_embed"].(string); v == pendingEmbedTrue &&
-					m.SupersededBy == nil && !m.Expired(now) {
+				if m.PendingEmbed() && m.SupersededBy == nil && !m.Expired(now) {
 					s.pendingEmbed++
 				}
 			}

--- a/cmd/memini/doctor_test.go
+++ b/cmd/memini/doctor_test.go
@@ -164,6 +164,14 @@ func TestPrintWritePathSignals(t *testing.T) {
 		}
 	}
 
+	// The pending-embed backlog is the only nonzero signal: the section must
+	// still print (isolates the `&& pendingEmbed == 0` guard term).
+	buf.Reset()
+	printWritePathSignals(&buf, []nsStat{{namespace: "x", pendingEmbed: 1}})
+	if got := buf.String(); !strings.Contains(got, "pending embed (vectorless, awaiting backfill):  1") {
+		t.Fatalf("pending-embed-only signals should print the section, got:\n%s", got)
+	}
+
 	buf.Reset()
 	printWritePathSignals(&buf, []nsStat{{namespace: "a"}})
 	if buf.Len() != 0 {

--- a/cmd/memini/doctor_test.go
+++ b/cmd/memini/doctor_test.go
@@ -154,11 +154,11 @@ func TestDoctorFixBackfillsLegacyConfidence(t *testing.T) {
 func TestPrintWritePathSignals(t *testing.T) {
 	var buf strings.Builder
 	printWritePathSignals(&buf, []nsStat{
-		{namespace: "a", classified: 2, promoted: 1, corroborated: 3},
-		{namespace: "b", classified: 1},
+		{namespace: "a", classified: 2, promoted: 1, corroborated: 3, pendingEmbed: 2},
+		{namespace: "b", classified: 1, pendingEmbed: 1},
 	})
 	out := buf.String()
-	for _, want := range []string{"marker-classified durable writes:  3", "promotion-produced facts:          1", "corroborated durable memories:     3"} {
+	for _, want := range []string{"marker-classified durable writes:  3", "promotion-produced facts:          1", "corroborated durable memories:     3", "pending embed (vectorless, awaiting backfill):  3"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("output missing %q:\n%s", want, out)
 		}
@@ -168,6 +168,45 @@ func TestPrintWritePathSignals(t *testing.T) {
 	printWritePathSignals(&buf, []nsStat{{namespace: "a"}})
 	if buf.Len() != 0 {
 		t.Fatalf("all-zero signals should print nothing, got:\n%s", buf.String())
+	}
+}
+
+// TestNamespaceStatsPendingEmbed: a memory carrying pending_embed="true"
+// metadata is counted toward the namespace's pendingEmbed backlog; a memory
+// without the flag is not.
+func TestNamespaceStatsPendingEmbed(t *testing.T) {
+	st := openTestStore(t)
+	now := time.Now().UTC()
+	flagged := &memory.Memory{
+		ID: "acme/vectorless", Namespace: "acme", Tier: memory.TierEpisodic,
+		Content: "degraded write awaiting backfill", CreatedAt: now, UpdatedAt: now, LastAccessedAt: now,
+		Embedding: []float32{1, 0, 0, 0},
+		Metadata:  map[string]any{"pending_embed": "true"},
+	}
+	if err := st.Upsert(context.Background(), flagged); err != nil {
+		t.Fatalf("upsert flagged: %v", err)
+	}
+	plain := &memory.Memory{
+		ID: "acme/embedded", Namespace: "acme", Tier: memory.TierEpisodic,
+		Content: "ordinary write", CreatedAt: now, UpdatedAt: now, LastAccessedAt: now,
+		Embedding: []float32{0, 1, 0, 0},
+	}
+	if err := st.Upsert(context.Background(), plain); err != nil {
+		t.Fatalf("upsert plain: %v", err)
+	}
+
+	stats := statsFor(t, st)
+	total, ok := 0, false
+	for _, s := range stats {
+		if s.namespace == "acme" {
+			total, ok = s.pendingEmbed, true
+		}
+	}
+	if !ok {
+		t.Fatalf("namespace acme missing from stats: %+v", stats)
+	}
+	if total != 1 {
+		t.Fatalf("pendingEmbed = %d, want 1 (only the flagged memory counts)", total)
 	}
 }
 

--- a/cmd/memini/doctor_test.go
+++ b/cmd/memini/doctor_test.go
@@ -179,9 +179,11 @@ func TestPrintWritePathSignals(t *testing.T) {
 	}
 }
 
-// TestNamespaceStatsPendingEmbed: a memory carrying pending_embed="true"
+// TestNamespaceStatsPendingEmbed: a live memory carrying pending_embed="true"
 // metadata is counted toward the namespace's pendingEmbed backlog; a memory
-// without the flag is not.
+// without the flag is not, and neither is a flagged row that is no longer live
+// (superseded or expired) — /v1/stats and the backfill both ignore those, so
+// doctor must not report a backlog nothing will drain.
 func TestNamespaceStatsPendingEmbed(t *testing.T) {
 	st := openTestStore(t)
 	now := time.Now().UTC()
@@ -202,6 +204,28 @@ func TestNamespaceStatsPendingEmbed(t *testing.T) {
 	if err := st.Upsert(context.Background(), plain); err != nil {
 		t.Fatalf("upsert plain: %v", err)
 	}
+	replacement := "acme/embedded"
+	superseded := &memory.Memory{
+		ID: "acme/superseded-vectorless", Namespace: "acme", Tier: memory.TierEpisodic,
+		Content: "flagged but tombstoned", CreatedAt: now, UpdatedAt: now, LastAccessedAt: now,
+		Embedding:    []float32{0, 0, 1, 0},
+		Metadata:     map[string]any{"pending_embed": "true"},
+		SupersededBy: &replacement,
+	}
+	if err := st.Upsert(context.Background(), superseded); err != nil {
+		t.Fatalf("upsert superseded: %v", err)
+	}
+	past := now.Add(-time.Hour)
+	expired := &memory.Memory{
+		ID: "acme/expired-vectorless", Namespace: "acme", Tier: memory.TierEpisodic,
+		Content: "flagged but past its TTL", CreatedAt: now, UpdatedAt: now, LastAccessedAt: now,
+		Embedding: []float32{0, 0, 0, 1},
+		Metadata:  map[string]any{"pending_embed": "true"},
+		ExpiresAt: &past,
+	}
+	if err := st.Upsert(context.Background(), expired); err != nil {
+		t.Fatalf("upsert expired: %v", err)
+	}
 
 	stats := statsFor(t, st)
 	total, ok := 0, false
@@ -214,7 +238,7 @@ func TestNamespaceStatsPendingEmbed(t *testing.T) {
 		t.Fatalf("namespace acme missing from stats: %+v", stats)
 	}
 	if total != 1 {
-		t.Fatalf("pendingEmbed = %d, want 1 (only the flagged memory counts)", total)
+		t.Fatalf("pendingEmbed = %d, want 1 (only the live flagged memory counts)", total)
 	}
 }
 

--- a/cmd/memini/root.go
+++ b/cmd/memini/root.go
@@ -139,6 +139,7 @@ func newServer(
 	srv.SetReady(func(ctx context.Context) error { return st.Ping(ctx) })
 	srv.SetDeps(deps)
 	srv.SetLLMConfigured(cfg.LLMEnabled())
+	srv.SetRerankConfigured(cfg.RerankEnabled())
 
 	// keyStore is nil for a backing store that predates APIKeyStore (a driver
 	// that hasn't run the api_keys migration); both the REST and MCP surfaces
@@ -309,6 +310,9 @@ func buildServiceStack(
 			return nil, nil, nil, nil, nil, err
 		}
 		if reranker != nil {
+			// Outermost wrap: every recall-path Rerank call feeds the dependency
+			// tracker that verbose healthz reads under the "reranker" key.
+			reranker = recordingReranker{Reranker: reranker, deps: deps}
 			svcOpts = append(svcOpts,
 				service.WithReranker(reranker, name),
 				service.WithRerankTimeout(cfg.RerankTimeout),

--- a/internal/api/mcp/mcp.go
+++ b/internal/api/mcp/mcp.go
@@ -672,8 +672,8 @@ func (t *tools) remember(ctx context.Context, _ *mcpsdk.CallToolRequest, in reme
 			Tier:           string(hint.Tier),
 		}
 	}
-	if pending, ok := m.Metadata["pending_embed"].(string); ok && pending == "true" {
-		res.Degraded = "pending_embed"
+	if m.PendingEmbed() {
+		res.Degraded = memory.PendingEmbedKey
 		res.Note = "embeddings unavailable; stored keyword-searchable only, vector will be backfilled automatically"
 	}
 	return nil, res, nil

--- a/internal/api/rest/api.gen.go
+++ b/internal/api/rest/api.gen.go
@@ -1278,7 +1278,10 @@ type Stats struct {
 	// LowConfidenceDurable Live durable memories whose decayed confidence is below the demote floor — reclaimable, uncorroborated debris.
 	LowConfidenceDurable int    `json:"low_confidence_durable"`
 	Namespace            string `json:"namespace"`
-	Superseded           int    `json:"superseded"`
+
+	// PendingEmbed Live memories saved without a vector because the embedder was unreachable at write time; the backfill loop re-embeds and unflags them, so a persistently nonzero value means the embedder is still down.
+	PendingEmbed int `json:"pending_embed"`
+	Superseded   int `json:"superseded"`
 
 	// Total Live memories (excludes expired/superseded)
 	Total         int `json:"total"`

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -909,6 +909,7 @@ func (h *Server) GetStats(w http.ResponseWriter, r *http.Request, params GetStat
 		Expired:              s.Expired,
 		Superseded:           s.Superseded,
 		LowConfidenceDurable: s.LowConfidenceDurable,
+		PendingEmbed:         s.PendingEmbed,
 		TotalAccesses:        s.TotalAccesses,
 		AvgImportance:        s.AvgImportance,
 		LastWriteAt:          s.LastWriteAt,

--- a/internal/memory/types.go
+++ b/internal/memory/types.go
@@ -150,6 +150,22 @@ func (m *Memory) Expired(now time.Time) bool {
 	return m.ExpiresAt != nil && !m.ExpiresAt.After(now)
 }
 
+// PendingEmbedKey/PendingEmbedValue are the metadata flag a degraded write
+// carries when it was stored vectorless because the embedder was unreachable;
+// the backfill loop re-embeds flagged rows and deletes the key on success.
+const (
+	PendingEmbedKey   = "pending_embed"
+	PendingEmbedValue = "true"
+)
+
+// PendingEmbed reports whether this memory is still awaiting its embedding
+// (stored vectorless by a degraded write; keyword-retrieval only until the
+// backfill clears the flag).
+func (m *Memory) PendingEmbed() bool {
+	v, _ := m.Metadata[PendingEmbedKey].(string)
+	return v == PendingEmbedValue
+}
+
 // retentionHalfLife is the time since last access at which the recency factor
 // of a memory's retention score halves.
 const retentionHalfLife = 7 * 24 * time.Hour

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -23,12 +23,14 @@ type depBlock struct {
 	LastSuccess string `json:"last_success,omitempty"`
 }
 
-// llmDepBlock adds Configured ahead of the shared depBlock fields. OK must
-// NOT be omitempty: false is the zero value, so omitempty would drop the
-// "ok" key exactly when the LLM is configured but down — the one signal
-// this block exists to report. An unconfigured LLM renders ok:false too;
-// consumers gate on configured first.
-type llmDepBlock struct {
+// optionalDepBlock adds Configured ahead of the shared depBlock fields. It
+// backs both the "llm" and "reranker" blocks — dependencies that are only
+// present when configured. OK must NOT be omitempty: false is the zero value,
+// so omitempty would drop the "ok" key exactly when the dependency is
+// configured but down — the one signal this block exists to report. An
+// unconfigured dependency renders ok:false too; consumers gate on configured
+// first.
+type optionalDepBlock struct {
 	Configured  bool   `json:"configured"`
 	OK          bool   `json:"ok"`
 	LastError   string `json:"last_error,omitempty"`
@@ -39,9 +41,10 @@ type verboseHealth struct {
 	Status  string `json:"status"`
 	Version string `json:"version"`
 	Deps    struct {
-		Store    depBlock    `json:"store"`
-		Embedder depBlock    `json:"embedder"`
-		LLM      llmDepBlock `json:"llm"`
+		Store    depBlock         `json:"store"`
+		Embedder depBlock         `json:"embedder"`
+		LLM      optionalDepBlock `json:"llm"`
+		Reranker optionalDepBlock `json:"reranker"`
 	} `json:"deps"`
 }
 
@@ -85,6 +88,14 @@ func (s *Server) verboseHealthz(ctx context.Context) verboseHealth {
 		resp.Deps.LLM.OK = b.OK
 		resp.Deps.LLM.LastError = b.LastError
 		resp.Deps.LLM.LastSuccess = b.LastSuccess
+	}
+
+	resp.Deps.Reranker.Configured = s.rerankConfigured.Load()
+	if resp.Deps.Reranker.Configured {
+		b := s.depBlockFor("reranker")
+		resp.Deps.Reranker.OK = b.OK
+		resp.Deps.Reranker.LastError = b.LastError
+		resp.Deps.Reranker.LastSuccess = b.LastSuccess
 	}
 	return resp
 }

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -104,18 +104,21 @@ func (s *Server) verboseHealthz(ctx context.Context) verboseHealth {
 // rather than tracking it: the store is a single local check (no network
 // round trip worth avoiding), so there's nothing a tracker would add over
 // asking it right now, and this stays consistent with /readyz by
-// construction instead of needing to be kept in sync with it.
+// construction instead of needing to be kept in sync with it. A healthy
+// probe stamps LastSuccess with the current time (rendered exactly like
+// depBlockFor's tracker timestamps): the block must be self-describing —
+// without it a consumer can't tell ok-freshly-probed from ok-never-called.
 func (s *Server) storeDepBlock(ctx context.Context) depBlock {
 	fn := s.ready.Load()
 	if fn == nil {
-		return depBlock{OK: true}
+		return depBlock{OK: true, LastSuccess: time.Now().UTC().Format(time.RFC3339)}
 	}
 	pingCtx, cancel := context.WithTimeout(ctx, storePingTimeout)
 	defer cancel()
 	if err := (*fn)(pingCtx); err != nil {
 		return depBlock{OK: false, LastError: err.Error()}
 	}
-	return depBlock{OK: true}
+	return depBlock{OK: true, LastSuccess: time.Now().UTC().Format(time.RFC3339)}
 }
 
 // depBlockFor renders dep's tracker snapshot. A dep with no recorded events

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -79,8 +79,9 @@ type verboseHealthBody struct {
 	Status string `json:"status"`
 	Deps   struct {
 		Store struct {
-			OK        bool   `json:"ok"`
-			LastError string `json:"last_error"`
+			OK          bool   `json:"ok"`
+			LastError   string `json:"last_error"`
+			LastSuccess string `json:"last_success"`
 		} `json:"store"`
 		Embedder struct {
 			OK          bool   `json:"ok"`
@@ -322,8 +323,31 @@ func TestHealthzVerboseNoDepsTrackerInstalled(t *testing.T) {
 	if !body.Deps.Store.OK || !body.Deps.Embedder.OK {
 		t.Errorf("deps = %+v, want ok defaults with no tracker installed", body.Deps)
 	}
+	if body.Deps.Store.LastSuccess == "" {
+		t.Errorf("store.last_success empty, want the probe timestamp (RFC3339)")
+	}
 	if body.Deps.LLM.Configured {
 		t.Errorf("llm.configured = true, want false")
+	}
+}
+
+func TestHealthzVerboseStoreHealthy(t *testing.T) {
+	// A healthy on-demand store ping must stamp last_success: the block has to
+	// be self-describing, and consumers can't tell ok-freshly-probed from
+	// ok-never-called without it.
+	srv := newTestServer(t)
+	srv.SetReady(func(context.Context) error { return nil })
+
+	_, body := getVerboseHealth(t, srv)
+
+	if !body.Deps.Store.OK {
+		t.Fatalf("store.ok = false, want true")
+	}
+	if body.Deps.Store.LastSuccess == "" {
+		t.Fatalf("store.last_success empty, want the probe timestamp (RFC3339)")
+	}
+	if _, err := time.Parse(time.RFC3339, body.Deps.Store.LastSuccess); err != nil {
+		t.Errorf("store.last_success = %q, not RFC3339: %v", body.Deps.Store.LastSuccess, err)
 	}
 }
 

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -93,6 +93,12 @@ type verboseHealthBody struct {
 			LastError   string `json:"last_error"`
 			LastSuccess string `json:"last_success"`
 		} `json:"llm"`
+		Reranker struct {
+			Configured  bool   `json:"configured"`
+			OK          bool   `json:"ok"`
+			LastError   string `json:"last_error"`
+			LastSuccess string `json:"last_success"`
+		} `json:"reranker"`
 	} `json:"deps"`
 }
 
@@ -214,6 +220,51 @@ func TestHealthzVerboseLLMConfigured(t *testing.T) {
 	}
 	if body.Deps.LLM.LastSuccess == "" {
 		t.Errorf("llm.last_success empty, want an RFC3339 timestamp")
+	}
+}
+
+func TestHealthzVerboseRerankerNotConfigured(t *testing.T) {
+	srv := newTestServer(t)
+	srv.SetDeps(server.NewDepTracker())
+
+	_, body := getVerboseHealth(t, srv)
+	if body.Deps.Reranker.Configured {
+		t.Errorf("reranker.configured = true, want false")
+	}
+}
+
+func TestHealthzVerboseRerankerConfigured(t *testing.T) {
+	srv := newTestServer(t)
+	deps := server.NewDepTracker()
+	deps.Record("reranker", nil)
+	srv.SetDeps(deps)
+	srv.SetRerankConfigured(true)
+
+	_, body := getVerboseHealth(t, srv)
+	if !body.Deps.Reranker.Configured {
+		t.Errorf("reranker.configured = false, want true")
+	}
+	if !body.Deps.Reranker.OK {
+		t.Errorf("reranker.ok = false, want true")
+	}
+	if body.Deps.Reranker.LastSuccess == "" {
+		t.Errorf("reranker.last_success empty, want an RFC3339 timestamp")
+	}
+}
+
+func TestHealthzVerboseRerankerDown(t *testing.T) {
+	srv := newTestServer(t)
+	deps := server.NewDepTracker()
+	deps.Record("reranker", errors.New("rerank backend unreachable"))
+	srv.SetDeps(deps)
+	srv.SetRerankConfigured(true)
+
+	_, body := getVerboseHealth(t, srv)
+	if body.Deps.Reranker.OK {
+		t.Errorf("reranker.ok = true, want false")
+	}
+	if body.Deps.Reranker.LastError == "" {
+		t.Errorf("reranker.last_error empty, want the recorded error")
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -38,11 +38,13 @@ type Server struct {
 	uiHandler http.Handler
 
 	ready atomic.Pointer[ReadinessFunc]
-	// deps and llmConfigured back the verbose healthz dependency blocks; both
-	// are set once at startup (see SetDeps/SetLLMConfigured) but use atomics
-	// for the same late-binding reason as ready.
-	deps          atomic.Pointer[DepTracker]
-	llmConfigured atomic.Bool
+	// deps, llmConfigured and rerankConfigured back the verbose healthz
+	// dependency blocks; all are set once at startup (see
+	// SetDeps/SetLLMConfigured/SetRerankConfigured) but use atomics for the
+	// same late-binding reason as ready.
+	deps             atomic.Pointer[DepTracker]
+	llmConfigured    atomic.Bool
+	rerankConfigured atomic.Bool
 }
 
 // Options configures the server without importing the config package.
@@ -154,6 +156,10 @@ func (s *Server) SetDeps(t *DepTracker) { s.deps.Store(t) }
 // SetLLMConfigured records whether the LLM pipeline is configured, for the
 // "llm.configured" field in verbose healthz.
 func (s *Server) SetLLMConfigured(v bool) { s.llmConfigured.Store(v) }
+
+// SetRerankConfigured records whether recall reranking is configured, for the
+// verbose healthz reranker block.
+func (s *Server) SetRerankConfigured(v bool) { s.rerankConfigured.Store(v) }
 
 // Run starts the HTTP server and blocks until ctx is cancelled, then performs
 // a graceful shutdown bounded by the configured timeout.

--- a/internal/service/embed_backfill.go
+++ b/internal/service/embed_backfill.go
@@ -16,6 +16,11 @@ import (
 // one tick into an unbounded, slow-draining scan.
 const backfillBatch = 100
 
+// pendingEmbedValue is the metadata value stamped under the "pending_embed"
+// key to mark a write stored vectorless (embed budget exceeded or the embedder
+// errored) and awaiting the backfill loop.
+const pendingEmbedValue = "true"
+
 // RunEmbedBackfill periodically re-embeds memories that were stored vectorless
 // (metadata pending_embed="true", stamped by embedForRemember when the
 // write-time embed budget was exceeded or the embedder errored) until ctx is
@@ -65,7 +70,7 @@ func (s *Service) BackfillEmbeddings(ctx context.Context) (int, error) {
 		return 0, err
 	}
 
-	filter := store.Filter{Metadata: map[string]string{"pending_embed": "true"}, Now: s.now()}
+	filter := store.Filter{Metadata: map[string]string{"pending_embed": pendingEmbedValue}, Now: s.now()}
 	var pending []*memory.Memory
 	for _, ns := range namespaces {
 		mems, err := s.store.List(ctx, ns, filter, 0)

--- a/internal/service/embed_backfill.go
+++ b/internal/service/embed_backfill.go
@@ -16,11 +16,6 @@ import (
 // one tick into an unbounded, slow-draining scan.
 const backfillBatch = 100
 
-// pendingEmbedValue is the metadata value stamped under the "pending_embed"
-// key to mark a write stored vectorless (embed budget exceeded or the embedder
-// errored) and awaiting the backfill loop.
-const pendingEmbedValue = "true"
-
 // RunEmbedBackfill periodically re-embeds memories that were stored vectorless
 // (metadata pending_embed="true", stamped by embedForRemember when the
 // write-time embed budget was exceeded or the embedder errored) until ctx is
@@ -70,7 +65,7 @@ func (s *Service) BackfillEmbeddings(ctx context.Context) (int, error) {
 		return 0, err
 	}
 
-	filter := store.Filter{Metadata: map[string]string{"pending_embed": pendingEmbedValue}, Now: s.now()}
+	filter := store.Filter{Metadata: map[string]string{memory.PendingEmbedKey: memory.PendingEmbedValue}, Now: s.now()}
 	var pending []*memory.Memory
 	for _, ns := range namespaces {
 		mems, err := s.store.List(ctx, ns, filter, 0)
@@ -121,7 +116,7 @@ func (s *Service) BackfillEmbeddings(ctx context.Context) (int, error) {
 			continue
 		}
 
-		delete(fresh.Metadata, "pending_embed")
+		delete(fresh.Metadata, memory.PendingEmbedKey)
 		fresh.Embedding = vec
 		fresh.UpdatedAt = s.now()
 		if err := s.store.Upsert(ctx, fresh); err != nil {

--- a/internal/service/query.go
+++ b/internal/service/query.go
@@ -139,10 +139,13 @@ type Stats struct {
 	Superseded   int                 `json:"superseded"`               // contradiction-tombstoned
 	// uncorroborated durable debris (confidence below the demote floor); unbounded
 	// by short-term caps, so a growing value signals reclaimable bloat
-	LowConfidenceDurable int        `json:"low_confidence_durable"`
-	TotalAccesses        int        `json:"total_accesses"`
-	AvgImportance        float64    `json:"avg_importance"`
-	LastWriteAt          *time.Time `json:"last_write_at,omitempty"`
+	LowConfidenceDurable int `json:"low_confidence_durable"`
+	// vectorless degraded writes (metadata pending_embed="true") awaiting the
+	// backfill loop; a persistently nonzero value means the embedder is down
+	PendingEmbed  int        `json:"pending_embed"`
+	TotalAccesses int        `json:"total_accesses"`
+	AvgImportance float64    `json:"avg_importance"`
+	LastWriteAt   *time.Time `json:"last_write_at,omitempty"`
 }
 
 // Stats computes a per-namespace overview by scanning all of its memories
@@ -173,6 +176,9 @@ func (s *Service) Stats(ctx context.Context, namespace string) (Stats, error) {
 			}
 			if m.Tier.Term() == memory.LongTerm && m.EffectiveConfidence(now) < memory.ConfidenceDemoteFloor {
 				st.LowConfidenceDurable++
+			}
+			if v, _ := m.Metadata["pending_embed"].(string); v == pendingEmbedValue {
+				st.PendingEmbed++
 			}
 			st.TotalAccesses += m.AccessCount
 			importanceSum += m.Importance
@@ -206,6 +212,7 @@ func (s *Service) StatsAll(ctx context.Context) (Stats, error) {
 		merged.Expired += st.Expired
 		merged.Superseded += st.Superseded
 		merged.LowConfidenceDurable += st.LowConfidenceDurable
+		merged.PendingEmbed += st.PendingEmbed
 		merged.TotalAccesses += st.TotalAccesses
 		// Weight by live total so the merged average isn't skewed by empty or
 		// tombstone-only namespaces.

--- a/internal/service/query.go
+++ b/internal/service/query.go
@@ -177,7 +177,7 @@ func (s *Service) Stats(ctx context.Context, namespace string) (Stats, error) {
 			if m.Tier.Term() == memory.LongTerm && m.EffectiveConfidence(now) < memory.ConfidenceDemoteFloor {
 				st.LowConfidenceDurable++
 			}
-			if v, _ := m.Metadata["pending_embed"].(string); v == pendingEmbedValue {
+			if m.PendingEmbed() {
 				st.PendingEmbed++
 			}
 			st.TotalAccesses += m.AccessCount

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -979,7 +979,7 @@ func validateRememberInput(in RememberInput) (RememberInput, memory.Tier, error)
 // embedForRemember embeds fresh write content. When writeEmbedTimeout is set
 // (> 0), the embed is bounded and a timeout or error degrades the write: it
 // returns a nil vector (the caller stores the memory keyword-searchable only)
-// and stamps in.Metadata["pending_embed"] = "true" so a background backfill
+// and stamps the memory.PendingEmbedKey metadata flag so a background backfill
 // can pick it up later, rather than failing the write. writeEmbedTimeout <= 0
 // keeps the embed unbounded and any error fatal — the pre-fallback,
 // fail-fast default. in.Metadata is mutated in place (allocated if nil),
@@ -991,7 +991,7 @@ func (s *Service) embedForRemember(ctx context.Context, in *RememberInput) ([]fl
 		if err != nil {
 			return nil, fmt.Errorf("remember: embed: %w", err)
 		}
-		delete(in.Metadata, "pending_embed")
+		delete(in.Metadata, memory.PendingEmbedKey)
 		return vec, nil
 	}
 	ectx, cancel := context.WithTimeout(ctx, s.writeEmbedTimeout)
@@ -1005,7 +1005,7 @@ func (s *Service) embedForRemember(ctx context.Context, in *RememberInput) ([]fl
 		// caller, inflate the backfill gauge, and cause a redundant
 		// re-embed next tick. delete on a nil map is a no-op, so this is
 		// safe even when in.Metadata was never set.
-		delete(in.Metadata, "pending_embed")
+		delete(in.Metadata, memory.PendingEmbedKey)
 		return vec, nil
 	}
 	reason := "embed_error"
@@ -1018,7 +1018,7 @@ func (s *Service) embedForRemember(ctx context.Context, in *RememberInput) ([]fl
 	if in.Metadata == nil {
 		in.Metadata = map[string]any{}
 	}
-	in.Metadata["pending_embed"] = pendingEmbedValue
+	in.Metadata[memory.PendingEmbedKey] = memory.PendingEmbedValue
 	return nil, nil
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1018,7 +1018,7 @@ func (s *Service) embedForRemember(ctx context.Context, in *RememberInput) ([]fl
 	if in.Metadata == nil {
 		in.Metadata = map[string]any{}
 	}
-	in.Metadata["pending_embed"] = "true"
+	in.Metadata["pending_embed"] = pendingEmbedValue
 	return nil, nil
 }
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -614,6 +614,34 @@ func TestStatsLowConfidenceDurable(t *testing.T) {
 	}
 }
 
+func TestStatsPendingEmbed(t *testing.T) {
+	// seedPendingEmbed (embed_backfill_test.go) writes memories through a failing
+	// embedder with a write-embed budget, so they land vectorless and flagged
+	// pending_embed="true" -- the same state a degraded write produces in
+	// production. It seeds into namespace "alice" and returns the ids.
+	st := openTestStore(t)
+	seedPendingEmbed(t, st, 2,
+		"the deploy key rotates every 90 days",
+		"the staging database lives in us-east-1")
+
+	// A healthy service on the same store: its write embeds cleanly and so must
+	// NOT be flagged pending, so it must not count.
+	svc := service.New(st, embedtest.New(dims), service.WithSyncReinforce())
+	if _, err := svc.Remember(context.Background(), service.RememberInput{
+		Namespace: "alice", Content: "healthy fact", Tier: memory.TierSemantic,
+	}); err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+
+	stats, err := svc.Stats(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.PendingEmbed != 2 {
+		t.Fatalf("pending_embed = %d, want 2", stats.PendingEmbed)
+	}
+}
+
 func TestRecallNamespaceIsolation(t *testing.T) {
 	svc := newService(t)
 	ctx := context.Background()
@@ -675,6 +703,11 @@ func TestListAndStatsAllNamespaces(t *testing.T) {
 	}
 	if stats.Total != 6 {
 		t.Fatalf("aggregate stats total = %d, want 6", stats.Total)
+	}
+	// No degraded writes were seeded (every write used the healthy embedtest
+	// embedder), so the merged pending_embed accumulator stays 0.
+	if stats.PendingEmbed != 0 {
+		t.Fatalf("aggregate stats pending_embed = %d, want 0", stats.PendingEmbed)
 	}
 }
 

--- a/ui/src/api-schema.gen.ts
+++ b/ui/src/api-schema.gen.ts
@@ -850,6 +850,8 @@ export interface components {
             superseded: number;
             /** @description Live durable memories whose decayed confidence is below the demote floor — reclaimable, uncorroborated debris. */
             low_confidence_durable: number;
+            /** @description Live memories saved without a vector because the embedder was unreachable at write time; the backfill loop re-embeds and unflags them, so a persistently nonzero value means the embedder is still down. */
+            pending_embed: number;
             total_accesses: number;
             /** Format: double */
             avg_importance: number;

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -32,6 +32,7 @@ import type {
   Stats,
   Tier,
   UpdateApiKeyBody,
+  VerboseHealth,
 } from './types'
 
 export class ApiError extends Error {
@@ -370,6 +371,10 @@ export const api = {
   // body; sending it in the URL keeps this a plain DELETE with no body.
   deleteLink: (dst: string, ns?: string) =>
     req<void>('DELETE', `/v1/links?dst=${encodeURIComponent(dst)}`, undefined, ns),
+
+  // Verbose liveness with dependency blocks. Out-of-spec infra endpoint; the
+  // req() bearer header satisfies the verbose gate when an API key is set.
+  health: () => req<VerboseHealth>('GET', '/healthz?verbose=1'),
 
   fsck: () => req<FsckReport>('POST', '/v1/fsck'),
 

--- a/ui/src/components/MemoryCard.tsx
+++ b/ui/src/components/MemoryCard.tsx
@@ -1,7 +1,16 @@
 import type { Memory } from '../types'
 import { TierBadge } from './TierBadge'
 import { MemoryTypeBadge } from './MemoryTypeBadge'
-import { fromLabel, isAutoTiered, memoryType, promotedFrom, relTime } from '../util'
+import {
+  CONFIDENCE_SEED,
+  fromLabel,
+  isAutoTiered,
+  isPendingEmbed,
+  isSeedImportance,
+  memoryType,
+  promotedFrom,
+  relTime,
+} from '../util'
 
 interface Props {
   memory: Memory
@@ -42,13 +51,25 @@ export function MemoryCard({ memory: m, score, onOpen, showNamespace, from, from
             promoted
           </span>
         )}
+        {isPendingEmbed(m) && (
+          <span class="chip pending" title="Saved while the embedder was unreachable — keyword search only until the backfill re-embeds it">
+            awaiting embed
+          </span>
+        )}
         <span class="grow" />
         {score !== undefined && <span class="mem-score">{score.toFixed(3)}</span>}
         {m.superseded_by && <span class="chip" title="Superseded by a newer memory">superseded</span>}
       </div>
       <div class="mem-body clamp">{m.summary || m.content}</div>
       <div class="mem-meta">
-        <span class="imp" title={`importance ${m.importance.toFixed(2)}`}>
+        <span
+          class="imp"
+          title={
+            isSeedImportance(m)
+              ? `importance ${m.importance.toFixed(2)} — the ${m.tier}-tier default`
+              : `importance ${m.importance.toFixed(2)}`
+          }
+        >
           imp
           <span class="imp-bar">
             <i style={{ width: `${Math.round(Math.min(1, Math.max(0, m.importance)) * 100)}%` }} />
@@ -57,7 +78,13 @@ export function MemoryCard({ memory: m, score, onOpen, showNamespace, from, from
         {m.confidence != null && (
           <span
             class="imp"
-            title={`confidence ${m.confidence.toFixed(2)} — grows each time the fact is re-observed`}
+            title={
+              m.confidence === CONFIDENCE_SEED
+                ? 'confidence 0.40 — seeded default, not yet corroborated'
+                : m.confidence > CONFIDENCE_SEED
+                  ? `confidence ${m.confidence.toFixed(2)} — corroborated (grown from the 0.40 seed)`
+                  : `confidence ${m.confidence.toFixed(2)} — grows each time the fact is re-observed`
+            }
           >
             conf
             <span class="imp-bar">

--- a/ui/src/components/MemoryCard.tsx
+++ b/ui/src/components/MemoryCard.tsx
@@ -3,6 +3,7 @@ import { TierBadge } from './TierBadge'
 import { MemoryTypeBadge } from './MemoryTypeBadge'
 import {
   CONFIDENCE_SEED,
+  confidenceState,
   fromLabel,
   isAutoTiered,
   isPendingEmbed,
@@ -28,6 +29,7 @@ interface Props {
 }
 
 export function MemoryCard({ memory: m, score, onOpen, showNamespace, from, fromNs }: Props) {
+  const conf = m.confidence != null ? confidenceState(m.confidence) : null
   return (
     <button type="button" class={`mem panel ${m.tier}`} onClick={() => onOpen(m)}>
       <div class="mem-head">
@@ -79,10 +81,10 @@ export function MemoryCard({ memory: m, score, onOpen, showNamespace, from, from
           <span
             class="imp"
             title={
-              m.confidence === CONFIDENCE_SEED
-                ? 'confidence 0.40 — seeded default, not yet corroborated'
-                : m.confidence > CONFIDENCE_SEED
-                  ? `confidence ${m.confidence.toFixed(2)} — corroborated (grown from the 0.40 seed)`
+              conf === 'seed'
+                ? `confidence ${CONFIDENCE_SEED.toFixed(2)} — seeded default, not yet corroborated`
+                : conf === 'corroborated'
+                  ? `confidence ${m.confidence.toFixed(2)} — corroborated (grown from the ${CONFIDENCE_SEED.toFixed(2)} seed)`
                   : `confidence ${m.confidence.toFixed(2)} — grows each time the fact is re-observed`
             }
           >

--- a/ui/src/components/MemoryDrawer.tsx
+++ b/ui/src/components/MemoryDrawer.tsx
@@ -5,7 +5,17 @@ import { api } from '../api'
 import { refresh } from '../store'
 import { TierBadge } from './TierBadge'
 import { MemoryTypeBadge } from './MemoryTypeBadge'
-import { fmtDate, fromLabel, isAutoTiered, memoryType, promotedFrom, relTime } from '../util'
+import {
+  CONFIDENCE_SEED,
+  fmtDate,
+  fromLabel,
+  isAutoTiered,
+  isPendingEmbed,
+  isSeedImportance,
+  memoryType,
+  promotedFrom,
+  relTime,
+} from '../util'
 import { IconClose, IconCopy, IconCheck, IconTrash } from '../icons'
 
 interface Props {
@@ -136,6 +146,11 @@ export function MemoryDrawer({ memory: m, onClose, wide, from, fromNs }: Props) 
               promoted
             </span>
           )}
+          {isPendingEmbed(m) && (
+            <span class="chip pending" title="Saved while the embedder was unreachable — keyword search only until the backfill re-embeds it">
+              awaiting embed
+            </span>
+          )}
           <span class="grow" />
           <button class="icon-btn" aria-label={copied ? 'Copied' : 'Copy ID'} onClick={copyId}>
             {copied ? <IconCheck /> : <IconCopy />}
@@ -196,13 +211,19 @@ export function MemoryDrawer({ memory: m, onClose, wide, from, fromNs }: Props) 
               </>
             )}
             <span class="key">importance</span>
-            <span class="val">{(m.importance ?? 0).toFixed(3)}</span>
+            <span
+              class="val"
+              title={isSeedImportance(m) ? `the ${m.tier}-tier default` : undefined}
+            >
+              {(m.importance ?? 0).toFixed(3)}
+              {isSeedImportance(m) ? ' · tier default' : ''}
+            </span>
             {m.confidence != null && (
               <>
                 <span class="key">confidence</span>
                 <span class="val" title="Seeded at 0.40; grows each time the fact is re-observed, decays when unused">
                   {m.confidence.toFixed(2)}
-                  {m.confidence > 0.4 ? ' · corroborated' : ''}
+                  {m.confidence > CONFIDENCE_SEED ? ' · corroborated' : m.confidence === CONFIDENCE_SEED ? ' · seed' : ''}
                 </span>
               </>
             )}

--- a/ui/src/components/MemoryDrawer.tsx
+++ b/ui/src/components/MemoryDrawer.tsx
@@ -7,6 +7,7 @@ import { TierBadge } from './TierBadge'
 import { MemoryTypeBadge } from './MemoryTypeBadge'
 import {
   CONFIDENCE_SEED,
+  confidenceState,
   fmtDate,
   fromLabel,
   isAutoTiered,
@@ -42,6 +43,8 @@ export function MemoryDrawer({ memory: m, onClose, wide, from, fromNs }: Props) 
 
   const drawerRef = useRef<HTMLElement>(null)
   const closeRef = useRef<HTMLButtonElement>(null)
+
+  const conf = m.confidence != null ? confidenceState(m.confidence) : null
 
   // Modal behavior: focus the drawer on open, trap Tab inside it, close on
   // Escape, and restore focus to whatever was focused before.
@@ -221,9 +224,12 @@ export function MemoryDrawer({ memory: m, onClose, wide, from, fromNs }: Props) 
             {m.confidence != null && (
               <>
                 <span class="key">confidence</span>
-                <span class="val" title="Seeded at 0.40; grows each time the fact is re-observed, decays when unused">
+                <span
+                  class="val"
+                  title={`Seeded at ${CONFIDENCE_SEED.toFixed(2)}; grows each time the fact is re-observed, decays when unused`}
+                >
                   {m.confidence.toFixed(2)}
-                  {m.confidence > CONFIDENCE_SEED ? ' · corroborated' : m.confidence === CONFIDENCE_SEED ? ' · seed' : ''}
+                  {conf === 'corroborated' ? ' · corroborated' : conf === 'seed' ? ' · seed' : ''}
                 </span>
               </>
             )}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1457,6 +1457,12 @@ pre.json {
   border-color: color-mix(in oklab, var(--tier-procedural) 50%, transparent);
   color: color-mix(in oklab, var(--tier-procedural) 80%, var(--text));
 }
+/* Degraded-write marker: amber (advisory), unlike .warn's ember (problem). */
+.chip.pending {
+  border-color: color-mix(in oklab, var(--tier-semantic) 55%, transparent);
+  background: color-mix(in oklab, var(--tier-semantic) 12%, transparent);
+  color: color-mix(in oklab, var(--tier-semantic) 82%, var(--text));
+}
 .chip.on {
   border-color: var(--line-strong);
   color: var(--text);

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -110,3 +110,29 @@ export type Pin = Schemas['Pin']
 export type PinListResponse = Schemas['PinListResponse']
 export type PinPutRequest = Schemas['PinPutRequest']
 export type PinDeleteRequest = Schemas['PinDeleteRequest']
+
+// ---- Verbose health (Task 7) --------------------------------------------
+
+// Hand-written: /healthz?verbose=1 is an infra endpoint whose 200 body has no
+// schema in api/openapi.yaml, so this shape is maintained by hand. Mirrors
+// internal/server/health.go (verboseHealth / depBlock / optionalDepBlock).
+export interface DepStatus {
+  ok: boolean
+  last_error?: string
+  last_success?: string
+}
+
+export interface OptionalDepStatus extends DepStatus {
+  configured: boolean
+}
+
+export interface VerboseHealth {
+  status: string
+  version: string
+  deps: {
+    store: DepStatus
+    embedder: DepStatus
+    llm: OptionalDepStatus
+    reranker: OptionalDepStatus
+  }
+}

--- a/ui/src/util.ts
+++ b/ui/src/util.ts
@@ -83,6 +83,14 @@ export function isSeedImportance(m: Memory): boolean {
 // CONFIDENCE_SEED mirrors memory.ConfidenceSeedFresh (internal/memory/types.go).
 export const CONFIDENCE_SEED = 0.4
 
+// confidenceState classifies a confidence value against the fresh seed:
+// 'seed' = exactly the untouched seed, 'corroborated' = grown past it,
+// 'other' = below it (decayed, contradicted, or explicitly set).
+export function confidenceState(conf: number): 'seed' | 'corroborated' | 'other' {
+  if (conf === CONFIDENCE_SEED) return 'seed'
+  return conf > CONFIDENCE_SEED ? 'corroborated' : 'other'
+}
+
 // relTime renders a compact, human relative timestamp ("3h", "2d", "just now").
 export function relTime(iso?: string): string {
   if (!iso) return '—'

--- a/ui/src/util.ts
+++ b/ui/src/util.ts
@@ -57,6 +57,32 @@ export function promotedFrom(m: Memory): string | undefined {
   return typeof src === 'string' && src ? src : undefined
 }
 
+// isPendingEmbed reports a degraded write: the memory was saved without a
+// vector (embedder unreachable) and is keyword-searchable only until the
+// backfill loop re-embeds it and clears the flag.
+export function isPendingEmbed(m: Memory): boolean {
+  return (m.metadata as Record<string, unknown> | undefined)?.pending_embed === 'true'
+}
+
+// Tier importance seeds — mirror seedImportance in internal/service/service.go;
+// keep in sync if the server seeds change.
+const IMPORTANCE_SEED: Record<Tier, number> = {
+  working: 0.1,
+  episodic: 0.3,
+  semantic: 0.6,
+  procedural: 0.6,
+}
+
+// isSeedImportance reports that a memory's importance equals its tier's
+// default seed (phrased in tooltips as "the <tier>-tier default", which stays
+// factual even if the value was set explicitly).
+export function isSeedImportance(m: Memory): boolean {
+  return m.importance === IMPORTANCE_SEED[m.tier]
+}
+
+// CONFIDENCE_SEED mirrors memory.ConfidenceSeedFresh (internal/memory/types.go).
+export const CONFIDENCE_SEED = 0.4
+
 // relTime renders a compact, human relative timestamp ("3h", "2d", "just now").
 export function relTime(iso?: string): string {
   if (!iso) return '—'

--- a/ui/src/views/Dashboard.tsx
+++ b/ui/src/views/Dashboard.tsx
@@ -47,6 +47,15 @@ export function Dashboard() {
             {stats.low_confidence_durable} low-confidence
           </div>
         </div>
+        {stats.pending_embed > 0 && (
+          <div class="panel stat">
+            <div class="k">Awaiting embedding</div>
+            <div class="v">
+              <span style={{ color: 'var(--tier-semantic)' }}>{num(stats.pending_embed)}</span>
+            </div>
+            <div class="sub">vectorless — keyword search only until the backfill re-embeds</div>
+          </div>
+        )}
       </div>
 
       <div class="panel panel-pad strata">

--- a/ui/src/views/Health.tsx
+++ b/ui/src/views/Health.tsx
@@ -8,16 +8,31 @@ import { Empty, ErrorBanner, Loading } from '../components/States'
 import { relTime } from '../util'
 import { IconRefresh, IconCheck } from '../icons'
 
-function depDot(d: DepStatus, configured = true): string {
-  if (!configured) return 'idle'
-  if (!d.ok) return 'bad'
-  return d.last_success ? 'ok' : 'idle' // ok-but-never-called reads as idle, not healthy
+// depState classifies one dep row of the healthz payload: 'unconfigured' (dep
+// not set up), 'down' (failing), 'ok' (healthy with a recorded success), or
+// 'quiet' (ok but never called — reads idle, not healthy). The status dot and
+// the detail text both derive from this one state.
+type DepState = 'unconfigured' | 'down' | 'ok' | 'quiet'
+
+function depState(d: DepStatus, configured: boolean): DepState {
+  if (!configured) return 'unconfigured'
+  if (!d.ok) return 'down'
+  return d.last_success ? 'ok' : 'quiet'
 }
 
-function depDetail(d: DepStatus, configured = true): string {
-  if (!configured) return 'not configured'
-  if (!d.ok) return d.last_error || 'failing'
-  return d.last_success ? `last success ${relTime(d.last_success)}` : 'no calls yet'
+const DEP_DOT: Record<DepState, string> = { unconfigured: 'idle', down: 'bad', ok: 'ok', quiet: 'idle' }
+
+function depDetail(state: DepState, d: DepStatus): string {
+  switch (state) {
+    case 'unconfigured':
+      return 'not configured'
+    case 'down':
+      return d.last_error || 'failing'
+    case 'ok':
+      return `last success ${relTime(d.last_success)}`
+    case 'quiet':
+      return 'no calls yet'
+  }
 }
 
 // Pipeline is a read-only dependency/backlog health panel. Unlike the mutating
@@ -49,13 +64,16 @@ function Pipeline() {
         <span class="hint">dependency health and embedding backlog — read-only</span>
       </div>
       <div class="kv" style={{ gridTemplateColumns: 'auto auto 1fr' }}>
-        {rows.map((r) => (
-          <Fragment key={r.name}>
-            <span class="key">{r.name}</span>
-            <span class={`status-dot ${depDot(r.dep, r.configured)}`} style={{ alignSelf: 'center' }} />
-            <span class="val">{depDetail(r.dep, r.configured)}</span>
-          </Fragment>
-        ))}
+        {rows.map((r) => {
+          const state = depState(r.dep, r.configured)
+          return (
+            <Fragment key={r.name}>
+              <span class="key">{r.name}</span>
+              <span class={`status-dot ${DEP_DOT[state]}`} style={{ alignSelf: 'center' }} />
+              <span class="val">{depDetail(state, r.dep)}</span>
+            </Fragment>
+          )
+        })}
         <span class="key">awaiting embed</span>
         <span
           class={`status-dot ${pending === null ? 'idle' : pending > 0 ? 'bad' : 'ok'}`}

--- a/ui/src/views/Health.tsx
+++ b/ui/src/views/Health.tsx
@@ -8,15 +8,21 @@ import { Empty, ErrorBanner, Loading } from '../components/States'
 import { relTime } from '../util'
 import { IconRefresh, IconCheck } from '../icons'
 
-function depDot(d: DepStatus, configured = true): string {
+// `live` deps (the store) are pinged on-demand by the server's storeDepBlock, so
+// `d.ok` already reflects a fresh probe and there is no last_success by design —
+// they read healthy straight off `d.ok`. Tracker-fed deps (embedder/llm/reranker)
+// carry no live probe, so ok-but-never-called stays idle until a real last_success.
+function depDot(d: DepStatus, configured = true, live = false): string {
   if (!configured) return 'idle'
   if (!d.ok) return 'bad'
+  if (live) return 'ok'
   return d.last_success ? 'ok' : 'idle' // ok-but-never-called reads as idle, not healthy
 }
 
-function depDetail(d: DepStatus, configured = true): string {
+function depDetail(d: DepStatus, configured = true, live = false): string {
   if (!configured) return 'not configured'
   if (!d.ok) return d.last_error || 'failing'
+  if (live) return 'responding' // pinged live for this response; no last_success to date from
   return d.last_success ? `last success ${relTime(d.last_success)}` : 'no calls yet'
 }
 
@@ -24,14 +30,19 @@ function depDetail(d: DepStatus, configured = true): string {
 // fsck/dedup tools below it, it auto-loads (and refreshes on the global nonce).
 function Pipeline() {
   const { data: health, error, loading } = useAsync(() => api.health(), [refreshNonce.value])
+  // Dropped error on purpose: dependency health is the priority signal here; the
+  // backlog row is best-effort, so if stats fails we fall back to "none" rather
+  // than failing the whole panel.
   const { data: stats } = useAsync(() => api.stats(), [namespace.value, refreshNonce.value])
 
   if (loading && !health) return <Loading />
   if (error) return <ErrorBanner message={error} />
   if (!health) return null
 
-  const rows = [
-    { name: 'store', dep: health.deps.store, configured: true },
+  const rows: { name: string; dep: DepStatus; configured: boolean; live?: boolean }[] = [
+    // store is a live on-demand ping (server storeDepBlock), not a tracker snapshot,
+    // so it never sets last_success — it must read off d.ok, hence live: true.
+    { name: 'store', dep: health.deps.store, configured: true, live: true },
     { name: 'embedder', dep: health.deps.embedder, configured: true },
     { name: 'llm', dep: health.deps.llm, configured: health.deps.llm.configured },
     { name: 'reranker', dep: health.deps.reranker, configured: health.deps.reranker.configured },
@@ -48,8 +59,8 @@ function Pipeline() {
         {rows.map((r) => (
           <Fragment key={r.name}>
             <span class="key">{r.name}</span>
-            <span class={`status-dot ${depDot(r.dep, r.configured)}`} style={{ alignSelf: 'center' }} />
-            <span class="val">{depDetail(r.dep, r.configured)}</span>
+            <span class={`status-dot ${depDot(r.dep, r.configured, r.live)}`} style={{ alignSelf: 'center' }} />
+            <span class="val">{depDetail(r.dep, r.configured, r.live)}</span>
           </Fragment>
         ))}
         <span class="key">awaiting embed</span>

--- a/ui/src/views/Health.tsx
+++ b/ui/src/views/Health.tsx
@@ -1,9 +1,68 @@
+import { Fragment } from 'preact'
 import { useState } from 'preact/hooks'
 import { api } from '../api'
-import { namespace, refresh } from '../store'
-import type { DedupReport, FsckReport } from '../types'
-import { Empty, ErrorBanner } from '../components/States'
+import { useAsync } from '../hooks'
+import { namespace, refresh, refreshNonce } from '../store'
+import type { DedupReport, DepStatus, FsckReport } from '../types'
+import { Empty, ErrorBanner, Loading } from '../components/States'
+import { relTime } from '../util'
 import { IconRefresh, IconCheck } from '../icons'
+
+function depDot(d: DepStatus, configured = true): string {
+  if (!configured) return 'idle'
+  if (!d.ok) return 'bad'
+  return d.last_success ? 'ok' : 'idle' // ok-but-never-called reads as idle, not healthy
+}
+
+function depDetail(d: DepStatus, configured = true): string {
+  if (!configured) return 'not configured'
+  if (!d.ok) return d.last_error || 'failing'
+  return d.last_success ? `last success ${relTime(d.last_success)}` : 'no calls yet'
+}
+
+// Pipeline is a read-only dependency/backlog health panel. Unlike the mutating
+// fsck/dedup tools below it, it auto-loads (and refreshes on the global nonce).
+function Pipeline() {
+  const { data: health, error, loading } = useAsync(() => api.health(), [refreshNonce.value])
+  const { data: stats } = useAsync(() => api.stats(), [namespace.value, refreshNonce.value])
+
+  if (loading && !health) return <Loading />
+  if (error) return <ErrorBanner message={error} />
+  if (!health) return null
+
+  const rows = [
+    { name: 'store', dep: health.deps.store, configured: true },
+    { name: 'embedder', dep: health.deps.embedder, configured: true },
+    { name: 'llm', dep: health.deps.llm, configured: health.deps.llm.configured },
+    { name: 'reranker', dep: health.deps.reranker, configured: health.deps.reranker.configured },
+  ]
+  const pending = stats?.pending_embed ?? 0
+
+  return (
+    <div class="panel panel-pad" style={{ marginBottom: '20px' }}>
+      <div class="section-h">
+        <h2>Pipeline</h2>
+        <span class="hint">dependency health and embedding backlog — read-only</span>
+      </div>
+      <div class="kv" style={{ gridTemplateColumns: 'auto auto 1fr' }}>
+        {rows.map((r) => (
+          <Fragment key={r.name}>
+            <span class="key">{r.name}</span>
+            <span class={`status-dot ${depDot(r.dep, r.configured)}`} style={{ alignSelf: 'center' }} />
+            <span class="val">{depDetail(r.dep, r.configured)}</span>
+          </Fragment>
+        ))}
+        <span class="key">awaiting embed</span>
+        <span class={`status-dot ${pending > 0 ? 'bad' : 'ok'}`} style={{ alignSelf: 'center' }} />
+        <span class="val">
+          {pending > 0
+            ? `${pending} vectorless ${pending === 1 ? 'memory' : 'memories'} — backfill retries while the embedder is down`
+            : 'none'}
+        </span>
+      </div>
+    </div>
+  )
+}
 
 // Health runs the server-side fsck consistency sweep: purge expired, enforce
 // the short-term cap, and audit for duplicate clusters. It mutates state, so
@@ -31,6 +90,8 @@ export function Health() {
 
   return (
     <div class="view">
+      <Pipeline />
+
       <div class="panel panel-pad" style={{ marginBottom: '20px' }}>
         <div class="section-h">
           <h2>fsck</h2>

--- a/ui/src/views/Health.tsx
+++ b/ui/src/views/Health.tsx
@@ -25,8 +25,9 @@ function depDetail(d: DepStatus, configured = true): string {
 function Pipeline() {
   const { data: health, error, loading } = useAsync(() => api.health(), [refreshNonce.value])
   // Dropped error on purpose: dependency health is the priority signal here; the
-  // backlog row is best-effort, so if stats fails we fall back to "none" rather
-  // than failing the whole panel.
+  // backlog row is best-effort tri-state, so if stats fails it reads as
+  // "unavailable" (idle) rather than failing the whole panel — never a
+  // false-healthy "none".
   const { data: stats } = useAsync(() => api.stats(), [namespace.value, refreshNonce.value])
 
   if (loading && !health) return <Loading />
@@ -39,7 +40,7 @@ function Pipeline() {
     { name: 'llm', dep: health.deps.llm, configured: health.deps.llm.configured },
     { name: 'reranker', dep: health.deps.reranker, configured: health.deps.reranker.configured },
   ]
-  const pending = stats?.pending_embed ?? 0
+  const pending = stats ? stats.pending_embed : null
 
   return (
     <div class="panel panel-pad" style={{ marginBottom: '20px' }}>
@@ -56,11 +57,16 @@ function Pipeline() {
           </Fragment>
         ))}
         <span class="key">awaiting embed</span>
-        <span class={`status-dot ${pending > 0 ? 'bad' : 'ok'}`} style={{ alignSelf: 'center' }} />
+        <span
+          class={`status-dot ${pending === null ? 'idle' : pending > 0 ? 'bad' : 'ok'}`}
+          style={{ alignSelf: 'center' }}
+        />
         <span class="val">
-          {pending > 0
-            ? `${pending} vectorless ${pending === 1 ? 'memory' : 'memories'} — backfill retries while the embedder is down`
-            : 'none'}
+          {pending === null
+            ? 'unavailable'
+            : pending > 0
+              ? `${pending} vectorless ${pending === 1 ? 'memory' : 'memories'} — backfill retries while the embedder is down`
+              : 'none'}
         </span>
       </div>
     </div>

--- a/ui/src/views/Health.tsx
+++ b/ui/src/views/Health.tsx
@@ -8,21 +8,15 @@ import { Empty, ErrorBanner, Loading } from '../components/States'
 import { relTime } from '../util'
 import { IconRefresh, IconCheck } from '../icons'
 
-// `live` deps (the store) are pinged on-demand by the server's storeDepBlock, so
-// `d.ok` already reflects a fresh probe and there is no last_success by design —
-// they read healthy straight off `d.ok`. Tracker-fed deps (embedder/llm/reranker)
-// carry no live probe, so ok-but-never-called stays idle until a real last_success.
-function depDot(d: DepStatus, configured = true, live = false): string {
+function depDot(d: DepStatus, configured = true): string {
   if (!configured) return 'idle'
   if (!d.ok) return 'bad'
-  if (live) return 'ok'
   return d.last_success ? 'ok' : 'idle' // ok-but-never-called reads as idle, not healthy
 }
 
-function depDetail(d: DepStatus, configured = true, live = false): string {
+function depDetail(d: DepStatus, configured = true): string {
   if (!configured) return 'not configured'
   if (!d.ok) return d.last_error || 'failing'
-  if (live) return 'responding' // pinged live for this response; no last_success to date from
   return d.last_success ? `last success ${relTime(d.last_success)}` : 'no calls yet'
 }
 
@@ -39,10 +33,8 @@ function Pipeline() {
   if (error) return <ErrorBanner message={error} />
   if (!health) return null
 
-  const rows: { name: string; dep: DepStatus; configured: boolean; live?: boolean }[] = [
-    // store is a live on-demand ping (server storeDepBlock), not a tracker snapshot,
-    // so it never sets last_success — it must read off d.ok, hence live: true.
-    { name: 'store', dep: health.deps.store, configured: true, live: true },
+  const rows: { name: string; dep: DepStatus; configured: boolean }[] = [
+    { name: 'store', dep: health.deps.store, configured: true },
     { name: 'embedder', dep: health.deps.embedder, configured: true },
     { name: 'llm', dep: health.deps.llm, configured: health.deps.llm.configured },
     { name: 'reranker', dep: health.deps.reranker, configured: health.deps.reranker.configured },
@@ -59,8 +51,8 @@ function Pipeline() {
         {rows.map((r) => (
           <Fragment key={r.name}>
             <span class="key">{r.name}</span>
-            <span class={`status-dot ${depDot(r.dep, r.configured, r.live)}`} style={{ alignSelf: 'center' }} />
-            <span class="val">{depDetail(r.dep, r.configured, r.live)}</span>
+            <span class={`status-dot ${depDot(r.dep, r.configured)}`} style={{ alignSelf: 'center' }} />
+            <span class="val">{depDetail(r.dep, r.configured)}</span>
           </Fragment>
         ))}
         <span class="key">awaiting embed</span>


### PR DESCRIPTION
## Why

When the embedder is unreachable and a write-embed timeout is configured, a write is stored vectorless with `metadata.pending_embed="true"` and waits for the backfill loop to re-embed it. Until that happens the memory matches keyword retrieval only. Nothing showed this to a human: the flag was buried in the drawer's raw metadata JSON, the backlog gauge went only to Prometheus, and `/healthz?verbose=1` said nothing about the reranker.

The symptom that started this was memories in the UI that looked like they held placeholder values, with no way to tell whether they were still queued for embedding or reranking. Auditing that suspicion showed most of those values are real: confidence 0.40 is the fresh-fact seed (0.5626 is that seed corroborated three times), importance 0.6/0.3/0.1 are the tier seeds, and reranking is purely query-time, so there is no per-memory rerank state to wait on. So this PR does two things: it surfaces the one genuine "still queued" state at every level a human looks, and it labels the seeded defaults so they stop reading as placeholders.

## What changed

**Stats.** `service.Stats`/`StatsAll` count live memories carrying the flag, exposed as a required `pending_embed` integer on `GET /v1/stats` (spec, generated Go/TS, and docs regenerated). Counting the flag rather than "rows without vectors" is deliberate: it counts exactly what the backfill will process; unflagged vectorless rows are an fsck concern.

**Doctor.** The write-path signals section gains `pending embed (vectorless, awaiting backfill): N`, and the section now prints when the backlog is the only nonzero signal. The tally is gated to live rows so it matches stats and the backfill; without the gate, a flagged row that is later superseded or expires would be reported forever while never draining.

**Healthz.** `/healthz?verbose=1` gains a `deps.reranker` block (`configured`, `ok`, `last_error`, `last_success`) fed by a `recordingReranker` wrapper on the recall path, the same pattern as `recordingEmbedder`. `llmDepBlock` is renamed `optionalDepBlock` since two optional deps now share it; the wire shape of the existing blocks is unchanged. `storeDepBlock` now stamps `last_success` on a healthy ping, so consumers can tell "probed healthy just now" from "never called" without special-casing the store.

**UI.** Memory cards and the drawer show an amber `awaiting embed` chip keyed off the metadata flag (the backfill deletes the flag on success, so the chip self-clears). The Dashboard grows an "Awaiting embedding" tile that only renders when the backlog is nonzero. The Health view gets a read-only Pipeline panel above fsck/dedup: store, embedder, LLM, and reranker rows with status dots and last-error/last-success detail, plus the backlog count. The backlog row is tri-state: it shows "unavailable" rather than a reassuring "none" when the stats fetch itself fails. Confidence values are labeled `seed` at exactly 0.40 and `corroborated` above it, and importance values that equal their tier seed say so; the displayed numbers derive from the shared constant rather than being retyped in the copy.

**Flag contract.** The key and sentinel now live in one place, `memory.PendingEmbedKey`/`memory.PendingEmbedValue` with a `Memory.PendingEmbed()` predicate; the write stamp, backfill filter, stats count, doctor count, and the MCP degraded check all use it instead of each spelling out the literal.

## Deliberate trade-offs, so you know they are not oversights

- No per-memory rerank status exists or is invented: reranking reorders candidates per query and persists nothing, so the reranker gets liveness reporting only.
- The UI mirrors the Go seed constants (`seedImportance`, `ConfidenceSeedFresh`) with a keep-in-sync comment rather than a server-exposed provenance field. Those constants have never been retuned since introduction, the feature is display-only, and since the copy derives from the constant a future retune can only miss a label, never show a wrong number.
- The verbose-healthz response shape stays out of the OpenAPI spec (its 200 is schemaless there on purpose); the UI types it by hand next to the other hand-written interfaces, with a comment pointing at the Go source of truth.

## Verification

- `mise run test`, `lint`, and `docs-check` green; the oapi-codegen and UI-schema drift gates are clean; `pnpm run typecheck` and `pnpm run build` clean.
- Live end-to-end pass, not just suites: a server built from the branch, embedder pointed at a dead port with a small write-embed timeout and rerank configured against another dead port. A write landed flagged; `/v1/stats` showed `pending_embed:1`, verbose healthz showed `embedder.ok:false` with the error and `reranker.configured:true`, doctor printed the backlog line, and a real browser showed the chip on the card and drawer, the seed and tier-default labels, the Dashboard tile, and the Pipeline panel with the store row healthy, the embedder row failing, and the backlog at 1. Pointing the embedder at a working stub and waiting one backfill tick cleared every surface, including the metadata flag itself.
