### PR TITLE
feat(server): measure HTTP response body size per route

### DIFF
--- a/charts/memini/dashboards/memini.json
+++ b/charts/memini/dashboards/memini.json
@@ -1179,7 +1179,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 16,
         "x": 0,
         "y": 73
       },
@@ -1215,6 +1215,65 @@
           "expr": "histogram_quantile(0.95, sum by (op, le) (rate(memini_op_duration_seconds_bucket[5m])))",
           "legendFormat": "{{op}}",
           "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 34,
+      "type": "timeseries",
+      "title": "HTTP response size by route (p50/p90)",
+      "description": "Body bytes shipped per response. The recall/briefing routes are what hooks inject from — watch these when tuning context-injection volume.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 73
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "unit": "bytes"
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.90, sum by (route, le) (rate(memini_http_response_bytes_bucket{route=~\"/v1/search|/v1/namespaces/briefing\"}[5m])))",
+          "legendFormat": "p90 {{route}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (route, le) (rate(memini_http_response_bytes_bucket{route=~\"/v1/search|/v1/namespaces/briefing\"}[5m])))",
+          "legendFormat": "p50 {{route}}",
+          "refId": "B"
         }
       ]
     },

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -11,10 +11,17 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// Label names shared by every HTTP-surface collector.
+const (
+	labelRoute  = "route"
+	labelMethod = "method"
+)
+
 // metrics holds the Prometheus collectors for the HTTP surface.
 type metrics struct {
 	reqTotal    *prometheus.CounterVec
 	reqDuration *prometheus.HistogramVec
+	respBytes   *prometheus.HistogramVec
 }
 
 func newMetrics(reg prometheus.Registerer) *metrics {
@@ -23,12 +30,19 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		reqTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Name: "memini_http_requests_total",
 			Help: "Total HTTP requests by route, method and status.",
-		}, []string{"route", "method", "status"}),
+		}, []string{labelRoute, labelMethod, "status"}),
 		reqDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "memini_http_request_duration_seconds",
 			Help:    "HTTP request latency by route and method.",
 			Buckets: prometheus.DefBuckets,
-		}, []string{"route", "method"}),
+		}, []string{labelRoute, labelMethod}),
+		respBytes: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name: "memini_http_response_bytes",
+			Help: "Response body size in bytes by route and method.",
+			// Sized for API payloads: briefing/search responses live in the
+			// single-digit-KB range today; 256k headroom covers export routes.
+			Buckets: []float64{256, 1024, 4096, 16384, 65536, 262144},
+		}, []string{labelRoute, labelMethod}),
 	}
 }
 
@@ -46,5 +60,6 @@ func (m *metrics) middleware(next http.Handler) http.Handler {
 		}
 		m.reqTotal.WithLabelValues(route, r.Method, strconv.Itoa(ww.Status())).Inc()
 		m.reqDuration.WithLabelValues(route, r.Method).Observe(time.Since(start).Seconds())
+		m.respBytes.WithLabelValues(route, r.Method).Observe(float64(ww.BytesWritten()))
 	})
 }

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,6 +24,54 @@ func TestMetricsOnMainPortByDefault(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("/metrics on main router = %d, want 200", rec.Code)
 	}
+}
+
+// Every response is measured into memini_http_response_bytes, labelled by the
+// matched chi route pattern (not the raw path) so cardinality stays bounded.
+func TestResponseBytesHistogram(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reg := prometheus.NewRegistry()
+	srv := server.New(server.Options{Addr: ":0", ShutdownTimeout: time.Second}, log, reg)
+
+	body := strings.Repeat("x", 1000)
+	srv.Router().Get("/v1/things/{id}", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/things/abc", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("request = %d, want 200", rec.Code)
+	}
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "memini_http_response_bytes" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["route"] != "/v1/things/{id}" || labels["method"] != http.MethodGet {
+				continue
+			}
+			h := m.GetHistogram()
+			if h.GetSampleCount() != 1 {
+				t.Fatalf("sample count = %d, want 1", h.GetSampleCount())
+			}
+			if h.GetSampleSum() != 1000 {
+				t.Fatalf("sample sum = %v, want 1000", h.GetSampleSum())
+			}
+			return
+		}
+		t.Fatalf("memini_http_response_bytes present but no series for route=/v1/things/{id} method=GET")
+	}
+	t.Fatalf("memini_http_response_bytes not registered")
 }
 
 // A dedicated MetricsAddr moves /metrics off the main router so a route that


### PR DESCRIPTION
Adds a `memini_http_response_bytes` histogram (chi route pattern + method, buckets 256B–256K) observed from the bytes the wrapped ResponseWriter already counts, plus a p50/p90 dashboard panel for the recall and briefing routes.

**Why:** the hook-driven injection pipeline ships several MB of `/v1/search` payload per day (measured on a production deployment: mean 6.8KB, p90 11.8KB per search response, ~1,300 searches/day), but only request counts and latency were measured. Response volume — the thing injection tuning changes — was invisible. This is the baseline metric for the injection-efficiency series.

Standalone; no behavior change. The series: #58 (directive slimming) → #59 (injection telemetry) → #60 (progressive disclosure) → #61 (server budgets) → #62 (enforcement core) → #63 (integration parity), plus #64 (floors, stacked on #56) and #65 (capture hygiene) — each independently mergeable in order.