### PR TITLE
feat(plugin): slim the memory directive and emit it per fire source

### DIFF
--- a/plugin/scripts/_shared.mjs
+++ b/plugin/scripts/_shared.mjs
@@ -1257,49 +1257,25 @@ export function readToolCall(payload) {
 // keeps a legacy scraper (parseMemoryBlocks) as a back-compat fallback for
 // sessions still emitting inline <memory> blocks under the old instruction.
 //
-// The save-policy invariants below (what is durable, visibility, correction
-// hygiene) are canonical in internal/api/mcp/mcp.go serverInstructions; keep
-// the two phrasings in sync.
+// This is deliberately the ABRIDGED trigger, not the full save policy. The
+// canonical policy (what is durable, visibility rules, correction hygiene)
+// lives in internal/api/mcp/mcp.go serverInstructions, which MCP-capable
+// hosts carry in the system prompt every turn — the directive only has to
+// re-arm the habit, so keep it under ~700 chars and let the server text be
+// the single source of truth.
 
 export const MEMORY_INSTRUCTION = `
 
 <memini-memory-directive>
-You have persistent cross-session memory via the memini memory_remember MCP
-tool. Saving is your job — do not wait for the user to ask. Save one memory
-per durable fact when you learn:
-- a decision and the reason it was made
-- a bug's root cause, or a gotcha worth flagging next time
-- a project convention (layout, style, test/deploy commands)
-- a stated user preference, or a correction the user gives you — a
-  correction IS a preference
-- an environment or tool quirk, or a non-obvious command/workflow
-
-When the user says "remember this" or corrects you, call memory_remember
-first, then acknowledge — and save an explicit request unconditionally, even
-if it seems trivial or already stored; secrets and credentials are the one
-exception. Before ending a turn in which you
-learned something durable, make sure it was saved.
-
-Rules:
-- Each memory must be self-contained, readable without this conversation's
-  context. State facts, not commands: "User prefers concise replies" (good),
-  "Always reply concisely" (bad).
-- visibility: "personal" for anything true of the USER wherever they go
-  (their preferences, habits, how they like to work); "project" (the
-  default) for anything specific to this codebase. Getting this wrong is
-  the common failure: a preference saved as "project" is stranded here and
-  will not follow them to their next repo.
-- Omit tier to let the server classify. Tag a critical, always-relevant
-  fact "pinned" so it surfaces in every session briefing.
-- Never save secrets or credentials, transient session state, task
-  progress, or facts already in CLAUDE.md or project docs.
-- If a stored memory turns out to be wrong or outdated, fix it immediately:
-  correct it in place with the memory_update MCP tool, or delete it with
-  memory_forget if it should not exist. Never leave a memory you know is
-  incorrect in place.
-- Never print memory markup or JSON memory payloads in your reply text.
-  Memories are saved only through the MCP tools. If the tools are
-  unavailable, do nothing.
+You have persistent cross-session memory via the memini MCP tools. Saving is
+your job — proactively call memory_remember (one self-contained fact per
+call) when you learn: a decision and its reason, a bug's root cause, a
+project convention, a stated user preference or correction (a correction IS
+a preference), an environment quirk or non-obvious workflow. "Remember this"
+→ save first, then acknowledge. visibility: "personal" for facts about the
+user anywhere, "project" (default) for this codebase. Never save secrets,
+credentials, or transient session state. Fix a wrong memory immediately via
+memory_update or memory_forget. Never print memory markup in reply text.
 </memini-memory-directive>`;
 
 // Injected by SessionStart after a compaction (wired by a later task): durable

--- a/plugin/scripts/_test.mjs
+++ b/plugin/scripts/_test.mjs
@@ -750,10 +750,11 @@ test("MEMORY_INSTRUCTION tells the agent about visibility, not just tier", async
   assert.match(MEMORY_INSTRUCTION, /personal/);
 });
 
-test("session-start.mjs: source \"compact\" appends the compact-recovery directive (fresh briefing)", async () => {
-  // After a compaction the context was rebuilt and durable facts learned before
-  // it may no longer be visible — so the fresh-briefing path must emit BOTH the
-  // save directive AND the compact-recovery directive.
+test("session-start.mjs: source \"compact\" emits the compact-recovery directive alone (fresh briefing)", async () => {
+  // After a compaction the context was rebuilt, so the briefing re-injects and
+  // the recovery nudge fires — but NOT the save directive: the MCP server's
+  // instructions (the canonical copy of the save policy) persist in the system
+  // prompt across compaction, so re-sending the directive is pure duplication.
   const { url, close } = await startMockServer(
     withHandshake(mkHS({ namespace: "team/app" }), (req, res) => {
       res.setHeader("Content-Type", "application/json");
@@ -774,16 +775,17 @@ test("session-start.mjs: source \"compact\" appends the compact-recovery directi
       JSON.stringify({ session_id: "compact-fresh", cwd: __dirname, source: "compact" }),
       { MEMINI_BASE_URL: url, XDG_CACHE_HOME: freshCache() },
     );
-    assert.match(stdout, /<memini-memory-directive>/, "the save directive must still be emitted");
-    assert.match(stdout, /<memini-compact-recovery>/, "post-compaction must also emit the recovery directive");
+    assert.doesNotMatch(stdout, /<memini-memory-directive>/, "the save directive is NOT re-sent after compaction (MCP instructions persist)");
+    assert.match(stdout, /<memini-compact-recovery>/, "post-compaction must emit the recovery directive");
   } finally {
     await close();
   }
 });
 
-test("session-start.mjs: source \"compact\" appends the compact-recovery directive (empty briefing)", async () => {
+test("session-start.mjs: source \"compact\" emits the compact-recovery directive alone (empty briefing)", async () => {
   // The empty-briefing path is one of the three emission sites; a post-compaction
-  // fire with no memories yet must still carry both directives.
+  // fire with no memories yet still carries the recovery nudge, but not the
+  // save directive (see the fresh-briefing compact test).
   const { url, close } = await startMockServer(
     withHandshake(mkHS({ namespace: "memini" }), (req, res) => {
       res.setHeader("Content-Type", "application/json");
@@ -796,8 +798,8 @@ test("session-start.mjs: source \"compact\" appends the compact-recovery directi
       JSON.stringify({ session_id: "compact-empty", cwd: __dirname, source: "compact" }),
       { MEMINI_BASE_URL: url, XDG_CACHE_HOME: freshCache() },
     );
-    assert.match(stdout, /<memini-memory-directive>/, "the save directive must still be emitted on an empty briefing");
-    assert.match(stdout, /<memini-compact-recovery>/, "post-compaction must also emit the recovery directive on an empty briefing");
+    assert.doesNotMatch(stdout, /<memini-memory-directive>/, "the save directive is NOT re-sent after compaction, even on an empty briefing");
+    assert.match(stdout, /<memini-compact-recovery>/, "post-compaction must emit the recovery directive on an empty briefing");
     // The reachable-but-empty note precedes both directives.
     assert.match(
       stdout,
@@ -830,6 +832,70 @@ test("session-start.mjs: source \"startup\" emits the memory directive but NOT c
     );
     assert.match(stdout, /<memini-memory-directive>/, "startup still gets the save directive");
     assert.doesNotMatch(stdout, /<memini-compact-recovery>/, "a non-compact start must not emit the recovery directive");
+    // The directive is the abridged trigger, not the full policy — the canonical
+    // save policy lives in the MCP server instructions. Keep it slim.
+    const directive = stdout.slice(stdout.indexOf("<memini-memory-directive>"), stdout.indexOf("</memini-memory-directive>"));
+    assert.ok(directive.length > 0 && directive.length < 900, `directive must stay abridged (<900 chars), got ${directive.length}`);
+  } finally {
+    await close();
+  }
+});
+
+test("session-start.mjs: source \"clear\" emits the memory directive (fresh conversation)", async () => {
+  // /clear starts a fresh conversation: nothing is in context, so the directive
+  // must come back exactly as on startup.
+  const { url, close } = await startMockServer(
+    withHandshake(mkHS({ namespace: "team/app" }), (req, res) => {
+      res.setHeader("Content-Type", "application/json");
+      res.end(
+        JSON.stringify(
+          briefingBody({ namespace: "team/app", facts: [bi({ content: "convention: use tabs" })] }),
+        ),
+      );
+    }),
+  );
+  try {
+    const { stdout } = await runHook(
+      "session-start.mjs",
+      JSON.stringify({ session_id: "clear1", cwd: __dirname, source: "clear" }),
+      { MEMINI_BASE_URL: url, XDG_CACHE_HOME: freshCache() },
+    );
+    assert.match(stdout, /<memini-memory-directive>/, "clear rebuilds context, so the directive is emitted");
+    assert.doesNotMatch(stdout, /<memini-compact-recovery>/);
+  } finally {
+    await close();
+  }
+});
+
+test("session-start.mjs: source \"resume\" with a CHANGED briefing injects the briefing but no directive", async () => {
+  // A changed briefing must reach the context on resume — but the directive is
+  // still in the replayed transcript, so it stays out.
+  const cache = freshCache();
+  let calls = 0;
+  const { url, close } = await startMockServer(
+    withHandshake(mkHS({ namespace: "team/app" }), (req, res) => {
+      calls++;
+      res.setHeader("Content-Type", "application/json");
+      res.end(
+        JSON.stringify(
+          briefingBody({
+            namespace: "team/app",
+            facts: [bi({ content: calls === 1 ? "convention: use tabs" : "convention: use spaces now" })],
+          }),
+        ),
+      );
+    }),
+  );
+  const env = { MEMINI_BASE_URL: url, XDG_CACHE_HOME: cache };
+  try {
+    await runHook("session-start.mjs", JSON.stringify({ session_id: "resume-changed", cwd: __dirname, source: "startup" }), env);
+    const resumed = await runHook(
+      "session-start.mjs",
+      JSON.stringify({ session_id: "resume-changed", cwd: __dirname, source: "resume" }),
+      env,
+    );
+    assert.match(resumed.stdout, /use spaces now/, "a changed briefing is injected on resume");
+    assert.doesNotMatch(resumed.stdout, /<memini-memory-directive>/, "the directive stays out — it is already in the replayed transcript");
   } finally {
     await close();
   }
@@ -875,11 +941,11 @@ test("session-start.mjs: source \"compact\" re-injects an unchanged briefing", a
   }
 });
 
-test("session-start.mjs: source \"resume\" still skips an unchanged briefing but re-emits the directive", async () => {
-  // The guard's surviving purpose: on a resume the context is intact, so an
-  // identical briefing block is already in it — re-injecting is pure token
-  // waste. Only the directive (dropped by the context rebuild machinery on
-  // some clients) is re-emitted.
+test("session-start.mjs: source \"resume\" with an unchanged briefing emits nothing at all", async () => {
+  // On a resume the context is intact AND Claude Code replays previously
+  // injected hook text for past turns — so both the briefing block and the
+  // directive are already in the transcript. Re-emitting either is pure
+  // duplication; an unchanged resume must be completely silent.
   const cache = freshCache();
   const { url, close } = await startMockServer(
     withHandshake(mkHS({ namespace: "team/app" }), (req, res) => {
@@ -900,7 +966,7 @@ test("session-start.mjs: source \"resume\" still skips an unchanged briefing but
       env,
     );
     assert.doesNotMatch(resumed.stdout, /<memini-context/, "an unchanged briefing is not re-injected on resume");
-    assert.match(resumed.stdout, /<memini-memory-directive>/, "the directive is re-emitted");
+    assert.equal(resumed.stdout, "", "resume replays prior injections — nothing to emit, not even the directive");
   } finally {
     await close();
   }
@@ -928,7 +994,7 @@ test("session-start.mjs: a resume after a compact re-injection still skips (hash
     assert.match(compacted.stdout, /<memini-context/, "compact re-injects");
     const resumed = await runHook("session-start.mjs", payload("resume"), env);
     assert.doesNotMatch(resumed.stdout, /<memini-context/, "the later resume still skips");
-    assert.match(resumed.stdout, /<memini-memory-directive>/);
+    assert.equal(resumed.stdout, "", "a resume after compact is silent too — the compact fire's output is in the transcript");
   } finally {
     await close();
   }

--- a/plugin/scripts/session-start.mjs
+++ b/plugin/scripts/session-start.mjs
@@ -249,13 +249,23 @@ async function main() {
 
   // The single memory directive emitted by all three paths below (empty briefing,
   // unchanged briefing, fresh briefing) — computed once so they cannot drift.
-  // Claude Code sets payload.source to "startup" | "resume" | "clear" | "compact";
-  // after a compaction the context was rebuilt and durable facts learned before
-  // it may have fallen out of view, so append the compact-recovery prompt to nudge
-  // the model to flush anything not yet persisted. Empty when inline_extract is off.
-  const directive = inlineExtract
-    ? MEMORY_INSTRUCTION + (payload.source === "compact" ? COMPACT_RECOVERY_DIRECTIVE : "")
-    : "";
+  // Claude Code sets payload.source to "startup" | "resume" | "clear" | "compact",
+  // and what to emit depends on what the context already carries:
+  //   startup/clear (and hosts that send no source, e.g. Codex) — fresh context,
+  //     emit the directive.
+  //   resume — Claude Code REPLAYS previously injected hook text for past turns,
+  //     so the startup directive is already in the transcript; emit nothing.
+  //   compact — the context was rebuilt, but MCP server instructions (the
+  //     canonical save policy) persist in the system prompt; only the
+  //     compaction-specific "flush unsaved facts" nudge is emitted.
+  // Empty when inline_extract is off.
+  const directive = !inlineExtract
+    ? ""
+    : payload.source === "resume"
+      ? ""
+      : payload.source === "compact"
+        ? COMPACT_RECOVERY_DIRECTIVE
+        : MEMORY_INSTRUCTION;
 
   // A single query-less briefing call returns a layered view: pinned identity,
   // durable facts/procedures, and recent activity — server-side ranked, so the
@@ -296,9 +306,9 @@ async function main() {
   const contentHash = crypto.createHash("sha256").update(JSON.stringify(b)).digest("hex").slice(0, 16);
   if (sessionId && !compacted && briefingUnchanged(sessionId, contentHash)) {
     if (DEBUG) console.error("[memini] SessionStart: briefing unchanged this session, skipping re-injection");
-    // A re-fire usually means the context was rebuilt (resume / clear / compact),
-    // which drops the memory directive. Skip the unchanged briefing but re-emit
-    // the directive so the agent keeps saving durable facts via memory_remember.
+    // Skip the unchanged briefing; the directive var already encodes what this
+    // fire source owes the context (nothing on resume — the transcript replay
+    // carries the original injection — a fresh directive on clear).
     if (directive) process.stdout.write(directive);
     return;
   }


### PR DESCRIPTION
Two cuts to SessionStart's fixed overhead:

**The directive shrinks ~2,070 → ~640 chars.** It was a full copy of the save policy whose canonical text already ships in the MCP server instructions every session (`mcp.go` serverInstructions — the sync comment in `_shared.mjs` already named it canonical). The hook copy is now explicitly the abridged trigger; one source of truth.

**Emission follows `payload.source`** instead of firing on every path:
- `startup` / `clear` / no source (Codex) → slim directive (fresh context)
- `resume` → **nothing** — Claude Code replays previously injected hook text on resume, so re-emitting was pure duplication
- `compact` → the compact-recovery nudge only — the MCP instructions persist in the system prompt across compaction

Net: ~72% less directive cost on startup, zero on resume/compact. Verified e2e (real server + hooks): startup output drops to ~1.4KB total, resume is byte-silent, compact re-briefs with the nudge alone.

Plugin-only, negative LOC. Stack base for the injection-efficiency series; #57 is independent.