### PR TITLE
feat(service): strip harness boilerplate from turn captures at write time

### DIFF
--- a/internal/service/capture_hygiene.go
+++ b/internal/service/capture_hygiene.go
@@ -1,0 +1,122 @@
+package service
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/eleboucher/memini/internal/memory"
+)
+
+// Turn captures — conversation turns auto-saved by client integrations — are
+// identified by isTurnCapture (metadata format="turn", see service.go): every
+// integration stamps it (the Claude Code plugin adds source="turn_capture",
+// hermes/pi/openclaw/openwebui stamp their own source), and it is the same
+// predicate the recall echo guard keys on.
+
+// dropsAsCaptureOrLowSignal is Remember's write-drop decision. It first
+// applies capture hygiene — a turn capture (metadata format="turn") arrives
+// polluted with harness boilerplate that recall would re-inject as noise, so
+// its content is rewritten in place via stripCaptureBoilerplate. Stripping
+// runs BEFORE the value gate so a capture that was boilerplate-only shrinks
+// under MEMINI_EPISODIC_MIN_CHARS and gets value-gated instead of stored; a
+// capture emptied entirely is dropped outright, gate or no gate. Non-capture
+// writes are never touched, only gated.
+func (s *Service) dropsAsCaptureOrLowSignal(tier memory.Tier, in *RememberInput) bool {
+	if isTurnCapture(in.Metadata) {
+		in.Content = stripCaptureBoilerplate(in.Content)
+		if in.Content == "" {
+			return true
+		}
+	}
+	return s.dropsLowSignalEpisodic(tier, in.Content)
+}
+
+// captureBoilerplateBlocks match harness boilerplate that pollutes captured
+// assistant text and would otherwise be re-injected by recall as noise: the
+// plugin's own injected wrappers echoed back in the capture, plus harness
+// <system-reminder> blocks. Whole blocks are stripped — the body is injected
+// context, not conversation. Tags are case-sensitive; the opening tag may
+// carry attributes; a block missing its closing tag is stripped to the end of
+// the string.
+var captureBoilerplateBlocks = func() []*regexp.Regexp {
+	tags := []string{
+		"memini-context",
+		"memini-recall",
+		"memini-pretool",
+		"memini-memory-directive",
+		"memini-compact-recovery",
+		"system-reminder",
+	}
+	res := make([]*regexp.Regexp, 0, len(tags))
+	for _, tag := range tags {
+		res = append(res, regexp.MustCompile(`(?s)<`+tag+`(?:\s[^>]*)?>.*?(?:</`+tag+`>|\z)`))
+	}
+	return res
+}()
+
+// newlineRuns collapses the 3+ newline runs left behind where a stripped block
+// sat between paragraphs.
+var newlineRuns = regexp.MustCompile(`\n{3,}`)
+
+// insightMarker opens a Claude Code output-style banner block:
+//
+//	★ Insight ─────────────────────────────────────
+//	stylized commentary
+//	─────────────────────────────────────────────────
+const insightMarker = "★ Insight"
+
+// boxDashLine reports whether a line consists solely of box-drawing dashes —
+// the closing line of a ★ Insight banner.
+func boxDashLine(line string) bool {
+	t := strings.TrimSpace(line)
+	if t == "" {
+		return false
+	}
+	for _, r := range t {
+		if r != '─' {
+			return false
+		}
+	}
+	return true
+}
+
+// stripInsightBanners removes ★ Insight banner blocks: from a line starting
+// with the marker through the next line consisting of box-drawing dashes,
+// inclusive. The whole block goes — the body is stylized commentary, not
+// conversation. A banner with no closing dash line is stripped to the end.
+func stripInsightBanners(s string) string {
+	if !strings.Contains(s, insightMarker) {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	kept := make([]string, 0, len(lines))
+	for i := 0; i < len(lines); i++ {
+		if strings.HasPrefix(strings.TrimLeft(lines[i], " \t"), insightMarker) {
+			// Skip to the closing dash line; the loop increment then steps
+			// past it. Without one, i runs off the end and the rest is gone.
+			for i++; i < len(lines) && !boxDashLine(lines[i]); i++ {
+			}
+			continue
+		}
+		kept = append(kept, lines[i])
+	}
+	return strings.Join(kept, "\n")
+}
+
+// stripCaptureBoilerplate removes harness boilerplate from a captured
+// conversation turn: injected wrapper blocks (see captureBoilerplateBlocks)
+// and ★ Insight banners, then collapses the newline runs left behind and trims
+// the result. Clean text comes back unchanged. Pure — the caller decides which
+// writes it applies to (turn captures only, see isTurnCapture).
+func stripCaptureBoilerplate(s string) string {
+	out := s
+	for _, re := range captureBoilerplateBlocks {
+		out = re.ReplaceAllString(out, "")
+	}
+	out = stripInsightBanners(out)
+	if out == s {
+		return s
+	}
+	out = newlineRuns.ReplaceAllString(out, "\n\n")
+	return strings.TrimSpace(out)
+}

--- a/internal/service/capture_hygiene_internal_test.go
+++ b/internal/service/capture_hygiene_internal_test.go
@@ -1,0 +1,101 @@
+package service
+
+import "testing"
+
+func TestStripCaptureBoilerplate(t *testing.T) {
+	banner := "★ Insight ─────────────────────────────────────\n" +
+		"stylized commentary the harness decorated the answer with\n" +
+		"─────────────────────────────────────────────────"
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "memini-context block stripped",
+			content: "before\n\n<memini-context session=\"abc\">\ninjected recall\n</memini-context>\n\nafter",
+			want:    "before\n\nafter",
+		},
+		{
+			name:    "memini-recall block stripped",
+			content: "before\n\n<memini-recall query=\"x\">\nhits\n</memini-recall>\n\nafter",
+			want:    "before\n\nafter",
+		},
+		{
+			name:    "memini-pretool block stripped",
+			content: "before\n\n<memini-pretool tool=\"Read\" read-only>\nrelated memories\n</memini-pretool>\n\nafter",
+			want:    "before\n\nafter",
+		},
+		{
+			name:    "memini-memory-directive block stripped",
+			content: "before\n\n<memini-memory-directive>\nsave things\n</memini-memory-directive>\n\nafter",
+			want:    "before\n\nafter",
+		},
+		{
+			name:    "memini-compact-recovery block stripped",
+			content: "before\n\n<memini-compact-recovery>\nrestored context\n</memini-compact-recovery>\n\nafter",
+			want:    "before\n\nafter",
+		},
+		{
+			name:    "system-reminder block stripped",
+			content: "before\n\n<system-reminder>\nhook context\n</system-reminder>\n\nafter",
+			want:    "before\n\nafter",
+		},
+		{
+			name:    "unterminated block strips to end",
+			content: "the real answer\n\n<system-reminder>\nnever closed",
+			want:    "the real answer",
+		},
+		{
+			name:    "insight banner with closing line stripped whole",
+			content: "prose above\n" + banner + "\nprose below",
+			want:    "prose above\nprose below",
+		},
+		{
+			name:    "insight banner without closing line strips to end",
+			content: "prose above\n★ Insight ─────────────\nbody that never closes\nstill body",
+			want:    "prose above",
+		},
+		{
+			name: "mixed content preserves surrounding prose",
+			content: "first paragraph\n\n" + banner + "\n\nsecond paragraph\n\n" +
+				"<memini-context>echo</memini-context>\n\nthird paragraph",
+			want: "first paragraph\n\nsecond paragraph\n\nthird paragraph",
+		},
+		{
+			name:    "newline runs collapse to two",
+			content: "a\n<system-reminder>x</system-reminder>\n\n\n<system-reminder>y</system-reminder>\n\nb",
+			want:    "a\n\nb",
+		},
+		{
+			name:    "boilerplate only becomes empty",
+			content: "<memini-context>\nall noise\n</memini-context>\n\n<system-reminder>more</system-reminder>",
+			want:    "",
+		},
+		{
+			name:    "tags are case-sensitive",
+			content: "before <SYSTEM-REMINDER>shouty</SYSTEM-REMINDER> after",
+			want:    "before <SYSTEM-REMINDER>shouty</SYSTEM-REMINDER> after",
+		},
+		{
+			name:    "dash line without insight opener kept",
+			content: "a\n─────────\nb",
+			want:    "a\n─────────\nb",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripCaptureBoilerplate(tt.content); got != tt.want {
+				t.Fatalf("stripCaptureBoilerplate(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("clean text untouched", func(t *testing.T) {
+		clean := "User: how do we deploy?\n\nAssistant: via the runbook, step by step.\n"
+		if got := stripCaptureBoilerplate(clean); got != clean {
+			t.Fatalf("clean text must round-trip unchanged, got %q", got)
+		}
+	})
+}

--- a/internal/service/capture_hygiene_test.go
+++ b/internal/service/capture_hygiene_test.go
@@ -1,0 +1,101 @@
+package service_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/eleboucher/memini/internal/embed/embedtest"
+	"github.com/eleboucher/memini/internal/memory"
+	"github.com/eleboucher/memini/internal/service"
+)
+
+// TestTurnCaptureBoilerplateHygiene pins the server-side capture hygiene: a
+// write identified as a turn capture (metadata format="turn", the same
+// predicate the recall echo guard uses; the Claude Code plugin also stamps
+// source="turn_capture") has harness boilerplate stripped before the episodic
+// value gate, so a boilerplate-only capture is value-gated instead of stored;
+// any other write with the same markup is left alone.
+func TestTurnCaptureBoilerplateHygiene(t *testing.T) {
+	ctx := context.Background()
+	ns := "alice"
+	captureMeta := func() map[string]any {
+		return map[string]any{"source": "turn_capture", "session_id": "sess-1", "format": "turn"}
+	}
+	prose := "User: deploy plan\n\nAssistant: " + strings.Repeat("postgres failover steps ", 10)
+	markup := "<system-reminder>\nhook context echoed back\n</system-reminder>"
+
+	t.Run("capture stripped before storage", func(t *testing.T) {
+		svc := service.New(openTestStore(t), embedtest.New(dims), service.WithSyncReinforce(), service.WithEpisodicMinChars(80))
+		m, err := svc.Remember(ctx, service.RememberInput{
+			Namespace: ns, Content: prose + "\n\n" + markup,
+			Tier: memory.TierEpisodic, Metadata: captureMeta(),
+		})
+		if err != nil || m == nil {
+			t.Fatalf("substantive capture should persist, got m=%v err=%v", m, err)
+		}
+		if strings.Contains(m.Content, "<system-reminder>") {
+			t.Fatalf("boilerplate survived stripping: %q", m.Content)
+		}
+		if want := strings.TrimSpace(prose); m.Content != want {
+			t.Fatalf("stored content = %q, want the prose alone %q", m.Content, want)
+		}
+	})
+
+	t.Run("boilerplate-only capture is value-gated", func(t *testing.T) {
+		svc := service.New(openTestStore(t), embedtest.New(dims), service.WithSyncReinforce(), service.WithEpisodicMinChars(80))
+		m, err := svc.Remember(ctx, service.RememberInput{
+			Namespace: ns, Content: "ok\n\n" + markup,
+			Tier: memory.TierEpisodic, Metadata: captureMeta(),
+		})
+		if err != nil {
+			t.Fatalf("drop should not error: %v", err)
+		}
+		if m != nil {
+			t.Fatalf("boilerplate-only capture should be value-gated (nil), got %q", m.Content)
+		}
+	})
+
+	t.Run("capture emptied entirely is dropped even without the gate", func(t *testing.T) {
+		svc := service.New(openTestStore(t), embedtest.New(dims), service.WithSyncReinforce())
+		m, err := svc.Remember(ctx, service.RememberInput{
+			Namespace: ns, Content: markup,
+			Tier: memory.TierEpisodic, Metadata: captureMeta(),
+		})
+		if err != nil {
+			t.Fatalf("drop should not error: %v", err)
+		}
+		if m != nil {
+			t.Fatalf("emptied capture should be dropped (nil), got %q", m.Content)
+		}
+	})
+
+	t.Run("capture from another integration is stripped too", func(t *testing.T) {
+		svc := service.New(openTestStore(t), embedtest.New(dims), service.WithSyncReinforce(), service.WithEpisodicMinChars(80))
+		m, err := svc.Remember(ctx, service.RememberInput{
+			Namespace: ns, Content: prose + "\n\n" + markup,
+			Tier:     memory.TierEpisodic,
+			Metadata: map[string]any{"source": "pi", "format": "turn", "session_id": "sess-2"},
+		})
+		if err != nil || m == nil {
+			t.Fatalf("substantive capture should persist, got m=%v err=%v", m, err)
+		}
+		if strings.Contains(m.Content, "<system-reminder>") {
+			t.Fatalf("boilerplate survived stripping for a non-plugin capture: %q", m.Content)
+		}
+	})
+
+	t.Run("non-capture write with the same markup is not stripped", func(t *testing.T) {
+		svc := service.New(openTestStore(t), embedtest.New(dims), service.WithSyncReinforce(), service.WithEpisodicMinChars(80))
+		m, err := svc.Remember(ctx, service.RememberInput{
+			Namespace: ns, Content: prose + "\n\n" + markup,
+			Tier: memory.TierEpisodic,
+		})
+		if err != nil || m == nil {
+			t.Fatalf("non-capture write should persist, got m=%v err=%v", m, err)
+		}
+		if !strings.Contains(m.Content, "<system-reminder>") {
+			t.Fatalf("non-capture write was stripped, stored %q", m.Content)
+		}
+	})
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1183,11 +1183,14 @@ func (s *Service) Remember(ctx context.Context, in RememberInput) (*memory.Memor
 		return nil, err
 	}
 
-	// Episodic value gate: drop low-signal per-turn chatter ("keep going", "ok")
-	// before it embeds and lands in episodic memory for 90 days. Only episodic is
-	// gated, so durable writes and promotion are unaffected. A drop returns
-	// (nil, nil) — accepted, not stored.
-	if s.dropsLowSignalEpisodic(tier, in.Content) {
+	// Turn-capture hygiene + episodic value gate: strip harness boilerplate
+	// from an auto-captured conversation turn (mutates in.Content — see
+	// dropsAsCaptureOrLowSignal), then drop low-signal per-turn chatter ("keep
+	// going", "ok") before it embeds and lands in episodic memory for 90 days.
+	// Only captures are stripped and only episodic is gated, so durable writes
+	// and promotion are unaffected. A drop returns (nil, nil) — accepted, not
+	// stored.
+	if s.dropsAsCaptureOrLowSignal(tier, &in) {
 		s.metrics.RememberResult("dropped", string(tier))
 		return nil, nil
 	}


### PR DESCRIPTION
Standalone.

Auto-captured conversation turns (metadata `format=turn` — the predicate every integration stamps) arrive polluted with harness noise the model echoed or the hooks injected: the plugin's own `<memini-*>` wrapper blocks, `<system-reminder>` blocks, and output-style `★ Insight` banners. Stored as-is, recall re-serves that boilerplate as memory content — observed live.

Strips whole blocks server-side in `Remember`, before the episodic value gate, so a boilerplate-only capture shrinks under the min-chars gate and is dropped instead of stored; a capture emptied entirely drops outright. Non-capture writes are never touched. Keying on `format=turn` rather than the Claude-only `source=turn_capture` is what makes it land for every integration.