### PR TITLE
fix(pi): sync the npm lockfile root with the v0.7.6 release version

### DIFF
--- a/integrations/pi/plugin/package-lock.json
+++ b/integrations/pi/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eleboucher/pi-memini",
-  "version": "0.7.4",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eleboucher/pi-memini",
-      "version": "0.7.4",
+      "version": "0.7.6",
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "0.80.6",
         "@earendil-works/pi-tui": "0.80.6",


### PR DESCRIPTION
Main's plugins CI job has been red since the v0.7.6 release: the release bump rewrote pi's `package.json` to 0.7.6 but not the npm lockfile root, and the package-sync guard test catches exactly that. One-line lockfile sync; no dependency changes.

Fixes the red `plugins` check currently inherited by every PR based on main (#57, #58, #59, #60, #65).