### PR TITLE
fix(activity): hydrate inject events with the serve's memory snapshot

### DIFF
--- a/internal/api/rest/activity_test.go
+++ b/internal/api/rest/activity_test.go
@@ -26,13 +26,14 @@ type activityEvent struct {
 	Query     string         `json:"query"`
 	Detail    map[string]any `json:"detail"`
 	Memories  []struct {
-		ID       string   `json:"id"`
-		Summary  string   `json:"summary"`
-		Tier     string   `json:"tier"`
-		Rank     int      `json:"rank"`
-		Score    *float64 `json:"score"`
-		Section  string   `json:"section"`
-		Injected *bool    `json:"injected"`
+		ID        string   `json:"id"`
+		Namespace string   `json:"namespace"`
+		Summary   string   `json:"summary"`
+		Tier      string   `json:"tier"`
+		Rank      int      `json:"rank"`
+		Score     *float64 `json:"score"`
+		Section   string   `json:"section"`
+		Injected  *bool    `json:"injected"`
 	} `json:"memories"`
 }
 
@@ -251,6 +252,20 @@ func TestReportInjected(t *testing.T) {
 		}
 		if len(ev.Memories) != 2 {
 			t.Fatalf("inject event carries %d memory refs, want 2 (unknown ids kept)", len(ev.Memories))
+		}
+		// The wire contract the dashboard renders from. A served id must come
+		// back with the snapshot of the serve that produced it — an empty one
+		// draws a blank row and leaves the UI no namespace to open it with —
+		// while an id nothing served stays bare.
+		byID := map[string]struct{ ns, tier, summary string }{}
+		for _, m := range ev.Memories {
+			byID[m.ID] = struct{ ns, tier, summary string }{m.Namespace, m.Tier, m.Summary}
+		}
+		if got := byID[injectedID]; got.ns != "acme" || got.tier != string(memory.TierSemantic) || got.summary == "" {
+			t.Errorf("injected ref = %+v, want a populated acme/semantic snapshot", got)
+		}
+		if got := byID["unknown-id-is-fine"]; got.ns != "" || got.tier != "" || got.summary != "" {
+			t.Errorf("unserved ref = %+v, want it left bare", got)
 		}
 	})
 

--- a/internal/service/events.go
+++ b/internal/service/events.go
@@ -83,6 +83,19 @@ func (s *Service) eventLog() (store.EventLogStore, bool) {
 // behaviour with WithSyncEventLog. Best-effort throughout: a failure here is
 // logged, never returned — losing an audit row must not fail a recall.
 func (s *Service) logEvents(ctx context.Context, events []store.Event) {
+	s.logEventsPrepared(ctx, events, nil)
+}
+
+// logEventsPrepared is logEvents with a hook that runs against the rows just
+// before they are appended, for a writer that must read the store to complete
+// them (RecordInjected's snapshot hydration). Running inside the same goroutine
+// as the append keeps the read off the caller's latency, and — since the
+// background write is already queued behind the serve that preceded it — gives
+// that serve's own rows a head start on landing, which is exactly what the
+// hydration looks for. prepare must be best-effort: it cannot fail the append.
+func (s *Service) logEventsPrepared(ctx context.Context, events []store.Event,
+	prepare func(context.Context, []store.Event),
+) {
 	els, ok := s.eventLog()
 	if !ok || len(events) == 0 {
 		return
@@ -96,6 +109,9 @@ func (s *Service) logEvents(ctx context.Context, events []store.Event) {
 		events[i].ActorKind = a.kind
 	}
 	write := func(ctx context.Context) {
+		if prepare != nil {
+			prepare(ctx, events)
+		}
 		if err := els.AppendEvents(ctx, events); err != nil {
 			slog.WarnContext(ctx, "activity: append events failed",
 				"kind", string(events[0].Kind), "count", len(events), "err", err)
@@ -236,8 +252,10 @@ func filteredDetail(base map[string]any) map[string]any {
 // /v1/activity/injected): after the server served memories (a recall or a
 // briefing), the client hook reports which of them actually reached model
 // context and what its local gates held back. Memory ids are taken on faith —
-// an unknown id is recorded as-is, never resolved or rejected — because the
-// report is best-effort observability, not a write to the memories themselves.
+// an unknown id is recorded as-is, never rejected — because the report is
+// best-effort observability, not a write to the memories themselves. An id the
+// caller's namespace was demonstrably served does pick up that serve's snapshot
+// so the row is renderable (hydrateInjected); one that was not stays bare.
 type InjectedReport struct {
 	// SessionID is the client session the injection happened in; "" when the
 	// client did not say.
@@ -282,11 +300,82 @@ func (s InjectedSuppressed) buckets() []suppressedBucket {
 	}
 }
 
+// injectHydrateWindow bounds how far back hydrateInjected looks for the serve
+// row carrying a memory's snapshot. A beacon follows its serve by seconds, so
+// this is generous by design; it exists to keep the lookup off the full history,
+// not to express a correctness bound. Deliberately NOT injectAnnotateWindow: an
+// id→snapshot mapping is a property of the memory, not of a moment, so the tight
+// join window that suits annotateInjected is the wrong bound here.
+const injectHydrateWindow = 24 * time.Hour
+
+// injectHydrateMaxIDs caps how many ids one beacon can turn into a lookup. Ids
+// are taken on faith and never authorized, so the bound is what keeps a buggy —
+// or hostile — client from building an unbounded query.
+const injectHydrateMaxIDs = 200
+
+// hydrateInjected fills in the memory snapshot (namespace, tier, summary) an
+// inject row cannot supply for itself. The client beacon reports bare ids, so
+// unlike recall and briefing — which hold the memory in hand and stamp it via
+// applyMemory — RecordInjected has nothing to snapshot, and a row left bare
+// renders as a blank line in the feed, misses the tier and text filters, and
+// offers the UI no namespace to open the memory with.
+//
+// The snapshot is BORROWED from the serve that produced the injection rather
+// than re-read from the memories table, which makes it both correct and safe:
+//
+//   - correct, because a cascading recall serves memories from ancestor
+//     namespaces, and the serve row is the only place that memory's own
+//     namespace was ever recorded (see store.Event.Namespace);
+//   - safe, because ids are never authorized. Resolving them against the
+//     memories table would let a client beacon arbitrary ids and read back the
+//     summaries of memories it was never served. Serves already logged against
+//     the caller's namespace bound what a report can learn to what it was shown.
+//
+// Score is deliberately not copied: the composite score belongs to the recall
+// that computed it against its query, and duplicating it onto the injection
+// would have two events claim the same number.
+//
+// Best-effort like everything else on this path — an unresolved id keeps its
+// bare row (the "taken on faith" contract), and a store error logs and leaves
+// every row bare.
+func (s *Service) hydrateInjected(ctx context.Context, namespace string, events []store.Event) {
+	els, ok := s.eventLog()
+	if !ok {
+		return
+	}
+	ids := make([]string, 0, len(events))
+	seen := make(map[string]bool, len(events))
+	for _, e := range events {
+		if e.MemoryID == "" || seen[e.MemoryID] || len(ids) >= injectHydrateMaxIDs {
+			continue
+		}
+		seen[e.MemoryID] = true
+		ids = append(ids, e.MemoryID)
+	}
+	if len(ids) == 0 {
+		return
+	}
+	snaps, err := els.ServedSnapshots(ctx, namespace, ids, s.now().Add(-injectHydrateWindow))
+	if err != nil {
+		slog.WarnContext(ctx, "activity: inject snapshot hydration failed",
+			"namespace", namespace, "count", len(ids), "err", err)
+		return
+	}
+	for i := range events {
+		if snap, ok := snaps[events[i].MemoryID]; ok {
+			events[i].MemoryNS = snap.Namespace
+			events[i].MemoryTier = snap.Tier
+			events[i].MemorySummary = snap.Summary
+		}
+	}
+}
+
 // RecordInjected records one injection-telemetry report as a single inject
 // activity event: the session/surface/source and size estimates ride the
 // event detail (the way recall stores its source), the injected ids become
-// the event's memory refs, and the suppression counts land under detail
-// "suppressed" with zero reasons omitted. Metrics are incremented per report
+// the event's memory refs — hydrated with the snapshot of the serve that
+// produced them, see hydrateInjected — and the suppression counts land under
+// detail "suppressed" with zero reasons omitted. Metrics are incremented per report
 // regardless of the event log's availability. Best-effort like every other
 // event writer: nothing here can fail the request path — the report IS the
 // request, so a lost row costs an audit line, never a client error — and it
@@ -346,7 +435,9 @@ func (s *Service) RecordInjected(ctx context.Context, namespace string, r Inject
 		e.Rank = i + 1
 		events = append(events, e)
 	}
-	s.logEvents(ctx, events)
+	s.logEventsPrepared(ctx, events, func(ctx context.Context, evs []store.Event) {
+		s.hydrateInjected(ctx, namespace, evs)
+	})
 }
 
 // briefingExplorationWindow bounds "recently shown" for the briefing's reserved

--- a/internal/service/events_test.go
+++ b/internal/service/events_test.go
@@ -685,6 +685,187 @@ func TestRecordInjectedWritesEvent(t *testing.T) {
 	}
 }
 
+// TestRecordInjectedHydratesServedSnapshot is the regression for inject rows
+// rendering blank in the activity feed. The client beacon carries bare ids, so
+// before hydration every inject row landed with an empty namespace, tier and
+// summary: the UI drew an empty line, the tier and text filters never matched
+// it, and clicking it 404'd because there was no namespace to fetch with.
+//
+// The assertion that matters is that the inject row carries the SAME snapshot
+// the recall row does — the injection is a view of that serve, not an
+// independent lookup.
+func TestRecordInjectedHydratesServedSnapshot(t *testing.T) {
+	ctx := context.Background()
+	svc := newEventSvc(t)
+
+	m, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "n", Content: "the primary database is postgres", Tier: memory.TierSemantic,
+	})
+	if err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+	if _, err := svc.Recall(ctx, service.RecallInput{
+		Namespace: "n", Query: "database", Limit: 5,
+	}); err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	svc.RecordInjected(ctx, "n", service.InjectedReport{
+		SessionID: "s1", Surface: "pretool", InjectedIDs: []string{m.ID},
+	})
+
+	page, err := svc.Events(ctx, service.EventsInput{
+		Namespace: "n", Kinds: []store.EventKind{store.EventRecall, store.EventInject},
+	})
+	if err != nil {
+		t.Fatalf("events: %v", err)
+	}
+	var injectRow, recallRow *service.ActivityMemory
+	for i := range page.Events {
+		for j := range page.Events[i].Memories {
+			if page.Events[i].Memories[j].ID != m.ID {
+				continue
+			}
+			switch page.Events[i].Kind {
+			case store.EventInject:
+				injectRow = &page.Events[i].Memories[j]
+			case store.EventRecall:
+				recallRow = &page.Events[i].Memories[j]
+			}
+		}
+	}
+	if injectRow == nil || recallRow == nil {
+		t.Fatalf("missing rows: inject=%v recall=%v", injectRow, recallRow)
+	}
+	if injectRow.Namespace != "n" || injectRow.Tier != memory.TierSemantic || injectRow.Summary == "" {
+		t.Errorf("inject row = {ns:%q tier:%q summary:%q}, want a populated snapshot",
+			injectRow.Namespace, injectRow.Tier, injectRow.Summary)
+	}
+	if injectRow.Namespace != recallRow.Namespace ||
+		injectRow.Tier != recallRow.Tier ||
+		injectRow.Summary != recallRow.Summary {
+		t.Errorf("inject snapshot %+v does not match the serve it reports on %+v", injectRow, recallRow)
+	}
+	// The serve's composite score belongs to the recall that computed it — two
+	// events must not claim the same number.
+	if injectRow.Score != nil {
+		t.Errorf("inject row carries score %v, want none", *injectRow.Score)
+	}
+}
+
+// TestRecordInjectedHydratesAncestorNamespace is the case that distinguishes
+// borrowing the serve's snapshot from simply stamping the request namespace.
+//
+// Recall cascades into ancestor namespaces, so a memory served to "acme/dev"
+// may well live in "acme". The serve row is the only place that fact is ever
+// recorded — the beacon does not send it and store.Get is strict namespace
+// equality — so stamping the request namespace would write a plausible lie and
+// the UI's click-through would still 404.
+func TestRecordInjectedHydratesAncestorNamespace(t *testing.T) {
+	ctx := context.Background()
+	svc := newEventSvc(t)
+
+	parent, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "acme", Content: "deploys go out on fridays", Tier: memory.TierProcedural,
+	})
+	if err != nil {
+		t.Fatalf("remember parent: %v", err)
+	}
+	res, err := svc.Recall(ctx, service.RecallInput{
+		Namespace: "acme/dev", Query: "deploys fridays", Limit: 5,
+	})
+	if err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	var served bool
+	for _, r := range res {
+		if r.Memory.ID == parent.ID {
+			served = true
+		}
+	}
+	if !served {
+		t.Fatalf("ancestor memory was not served to the child namespace; got %d hits", len(res))
+	}
+
+	svc.RecordInjected(ctx, "acme/dev", service.InjectedReport{
+		SessionID: "s1", Surface: "pretool", InjectedIDs: []string{parent.ID},
+	})
+
+	page, err := svc.Events(ctx, service.EventsInput{
+		Namespace: "acme/dev", Kinds: []store.EventKind{store.EventInject},
+	})
+	if err != nil {
+		t.Fatalf("events: %v", err)
+	}
+	if len(page.Events) != 1 || len(page.Events[0].Memories) != 1 {
+		t.Fatalf("inject events = %+v, want one event with one memory", page.Events)
+	}
+	got := page.Events[0].Memories[0]
+	if got.Namespace != "acme" {
+		t.Errorf("inject row namespace = %q, want %q (the memory's own namespace, not the request's)",
+			got.Namespace, "acme")
+	}
+	if got.Tier != memory.TierProcedural || got.Summary == "" {
+		t.Errorf("inject row = {tier:%q summary:%q}, want the ancestor serve's snapshot", got.Tier, got.Summary)
+	}
+	// The event itself is still recorded against the requesting namespace.
+	if page.Events[0].Namespace != "acme/dev" {
+		t.Errorf("event namespace = %q, want acme/dev", page.Events[0].Namespace)
+	}
+}
+
+// TestRecordInjectedLeavesUnservedIDsBare is the containment test. Injected ids
+// are taken on faith and never authorized, so hydration must not become a way
+// to read memories the caller was never served: an id that exists but was only
+// served to ANOTHER namespace, and an id that was written but never served,
+// both stay bare.
+func TestRecordInjectedLeavesUnservedIDsBare(t *testing.T) {
+	ctx := context.Background()
+	svc := newEventSvc(t)
+
+	secret, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "victim", Content: "the vault combination is written down", Tier: memory.TierSemantic,
+	})
+	if err != nil {
+		t.Fatalf("remember secret: %v", err)
+	}
+	// Served — but to the victim's namespace, not the attacker's.
+	if _, err := svc.Recall(ctx, service.RecallInput{
+		Namespace: "victim", Query: "vault combination", Limit: 5,
+	}); err != nil {
+		t.Fatalf("recall victim: %v", err)
+	}
+	written, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "attacker", Content: "never served to anyone", Tier: memory.TierSemantic,
+	})
+	if err != nil {
+		t.Fatalf("remember written: %v", err)
+	}
+
+	svc.RecordInjected(ctx, "attacker", service.InjectedReport{
+		SessionID: "s1", Surface: "pretool",
+		InjectedIDs: []string{secret.ID, written.ID, "no-such-id"},
+	})
+
+	page, err := svc.Events(ctx, service.EventsInput{
+		Namespace: "attacker", Kinds: []store.EventKind{store.EventInject},
+	})
+	if err != nil {
+		t.Fatalf("events: %v", err)
+	}
+	if len(page.Events) != 1 {
+		t.Fatalf("inject events = %d, want 1", len(page.Events))
+	}
+	if n := len(page.Events[0].Memories); n != 3 {
+		t.Fatalf("inject event carries %d refs, want 3 (unknown ids are still recorded)", n)
+	}
+	for _, m := range page.Events[0].Memories {
+		if m.Namespace != "" || m.Tier != "" || m.Summary != "" {
+			t.Errorf("ref %s leaked a snapshot it was never served: {ns:%q tier:%q summary:%q}",
+				m.ID, m.Namespace, m.Tier, m.Summary)
+		}
+	}
+}
+
 // TestEventsAnnotatesInjectedMemories is the served→injected join: a recall
 // event's memory is marked injected=true when a later inject report names it,
 // injected=false when a report exists but omits it (the client suppressed it),

--- a/internal/store/postgres/events.go
+++ b/internal/store/postgres/events.go
@@ -133,6 +133,47 @@ func (s *Store) ListEvents(ctx context.Context, f store.EventFilter) ([]store.Ev
 	return out, rs.Err()
 }
 
+// ServedSnapshots returns the newest serve-row snapshot per memory ID. DISTINCT
+// ON keeps the first row of each memory_id group, and the matching ORDER BY
+// makes that the newest — ids are monotonic, so the greatest is the latest.
+func (s *Store) ServedSnapshots(
+	ctx context.Context, namespace string, ids []string, since time.Time,
+) (map[string]store.MemorySnapshot, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	b := &args{}
+	var q strings.Builder
+	q.WriteString(`SELECT DISTINCT ON (memory_id) memory_id, memory_ns, memory_tier, memory_summary
+		FROM memory_events
+		WHERE namespace = ` + b.add(namespace) + `
+		  AND memory_ns <> ''
+		  AND kind = ANY(` + b.add([]string{string(store.EventRecall), string(store.EventBriefing)}) + `)
+		  AND memory_id = ANY(` + b.add(ids) + `)`)
+	if !since.IsZero() {
+		q.WriteString(" AND created_at >= " + b.add(since))
+	}
+	q.WriteString(" ORDER BY memory_id, id DESC")
+
+	rs, err := s.pool.Query(ctx, q.String(), b.vals...)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: lookup served snapshots: %w", err)
+	}
+	defer rs.Close()
+
+	out := make(map[string]store.MemorySnapshot, len(ids))
+	for rs.Next() {
+		var id, tier string
+		var snap store.MemorySnapshot
+		if err := rs.Scan(&id, &snap.Namespace, &tier, &snap.Summary); err != nil {
+			return nil, fmt.Errorf("postgres: scan served snapshot: %w", err)
+		}
+		snap.Tier = memory.Tier(tier)
+		out[id] = snap
+	}
+	return out, rs.Err()
+}
+
 // PruneEvents trims the log by age and by row cap.
 func (s *Store) PruneEvents(ctx context.Context, olderThan time.Time, keepMax int) (int64, error) {
 	var deleted int64

--- a/internal/store/sqlitevec/events.go
+++ b/internal/store/sqlitevec/events.go
@@ -157,6 +157,56 @@ func (s *Store) ListEvents(ctx context.Context, f store.EventFilter) ([]store.Ev
 	return out, rows.Err()
 }
 
+// ServedSnapshots returns the newest serve-row snapshot per memory ID. The
+// inner MAX(id) picks one row per memory — ids are monotonic, so the greatest is
+// the newest — and the outer select reads that row's columns; grouping and
+// projecting in one statement would leave the non-aggregated columns ambiguous.
+func (s *Store) ServedSnapshots(
+	ctx context.Context, namespace string, ids []string, since time.Time,
+) (map[string]store.MemorySnapshot, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var b strings.Builder
+	args := []any{namespace}
+	b.WriteString(`SELECT memory_id, memory_ns, memory_tier, memory_summary
+		FROM memory_events WHERE id IN (
+			SELECT MAX(id) FROM memory_events
+			WHERE namespace = ? AND memory_ns <> '' AND kind IN (?,?) AND memory_id IN (`)
+	args = append(args, string(store.EventRecall), string(store.EventBriefing))
+	for i, id := range ids {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString("?")
+		args = append(args, id)
+	}
+	b.WriteString(")")
+	if !since.IsZero() {
+		b.WriteString(" AND created_at >= ?")
+		args = append(args, ms(since))
+	}
+	b.WriteString(" GROUP BY memory_id)")
+
+	rows, err := s.db.QueryContext(ctx, b.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("sqlitevec: lookup served snapshots: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[string]store.MemorySnapshot, len(ids))
+	for rows.Next() {
+		var id, tier string
+		var snap store.MemorySnapshot
+		if err := rows.Scan(&id, &snap.Namespace, &tier, &snap.Summary); err != nil {
+			return nil, fmt.Errorf("sqlitevec: scan served snapshot: %w", err)
+		}
+		snap.Tier = memory.Tier(tier)
+		out[id] = snap
+	}
+	return out, rows.Err()
+}
+
 // PruneEvents trims the log by age and by row cap.
 func (s *Store) PruneEvents(ctx context.Context, olderThan time.Time, keepMax int) (int64, error) {
 	var deleted int64

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -979,6 +979,17 @@ func ValidEventKind(k EventKind) bool {
 	return false
 }
 
+// MemorySnapshot is the denormalized (namespace, tier, summary) triple an event
+// row carries for the memory it touched. Looked up by memory ID so a writer that
+// knows only an ID can record the same snapshot an earlier serve already took —
+// see EventLogStore.ServedSnapshots and the injection beacon, whose client sends
+// bare IDs and nothing else.
+type MemorySnapshot struct {
+	Namespace string
+	Tier      memory.Tier
+	Summary   string
+}
+
 // Event is one (operation, memory) row of the activity log: what was served or
 // written, when, and — for a recall — the query that pulled it and where it
 // ranked. Memories served by one operation share an OpID, so a recall that
@@ -1081,6 +1092,23 @@ type EventLogStore interface {
 	// none by age) and, when keepMax > 0, the oldest rows beyond the newest
 	// keepMax. Returns the number of rows deleted.
 	PruneEvents(ctx context.Context, olderThan time.Time, keepMax int) (int64, error)
+	// ServedSnapshots returns, per ID, the newest memory snapshot a SERVE row
+	// (recall or briefing) recorded for it against namespace, ignoring rows
+	// older than since and rows that carry no snapshot. An ID with no covering
+	// serve is absent from the map — never an error.
+	//
+	// It backs the inject event's hydration: an injection beacon carries bare
+	// IDs, so the snapshot is borrowed from the serve that produced them. That
+	// also makes it the SAFE source. Injected IDs are taken on faith and never
+	// authorized, so resolving them against the memories table would let a
+	// buggy or hostile client read back summaries of memories it was never
+	// served; scoping to serves already logged against the caller's namespace
+	// bounds what a report can learn to what it was already shown.
+	//
+	// Borrowing rather than re-reading is also what recovers the memory's own
+	// namespace, which for a cascading recall differs from the request
+	// namespace (see Event.Namespace) and is recorded nowhere else.
+	ServedSnapshots(ctx context.Context, namespace string, ids []string, since time.Time) (map[string]MemorySnapshot, error)
 }
 
 // OrEmptyMap returns m, or an empty map when m is nil, so drivers persist an

--- a/internal/store/storetest/conformance.go
+++ b/internal/store/storetest/conformance.go
@@ -325,6 +325,7 @@ func testEventLog(t *testing.T, st store.Store, _ int) {
 	t.Run("RoundTripAndOrder", func(t *testing.T) { testEventRoundTrip(t, els, ns, base) })
 	t.Run("Filters", func(t *testing.T) { testEventFilters(t, els, ns, other, base) })
 	t.Run("Cursor", func(t *testing.T) { testEventCursor(t, els, ns) })
+	t.Run("ServedSnapshots", func(t *testing.T) { testServedSnapshots(t, els, ns, base) })
 	t.Run("Prune", func(t *testing.T) { testEventPrune(t, els, ns, base) })
 }
 
@@ -552,6 +553,121 @@ func testEventCursor(t *testing.T, els store.EventLogStore, ns string) {
 
 // testEventPrune covers pruning by age and by row cap. It destroys the fixture,
 // so it runs last.
+// testServedSnapshots pins the lookup backing inject-event hydration. It seeds
+// its own namespace at timestamps after the shared fixture's, so it stays
+// invisible to the read subtests that already ran and leaves testEventPrune's
+// counts untouched.
+//
+// The cases that matter are the ones a naive implementation gets wrong: an
+// ancestor-namespace serve must report the MEMORY's namespace and not the
+// request's, a bare inject row must not shadow the real snapshot beneath it,
+// and a non-serve kind must not be a donor.
+func testServedSnapshots(t *testing.T, els store.EventLogStore, ns string, base time.Time) {
+	ctx := context.Background()
+	snapNS := ns + "-snap"
+	parent := ns + "-parent"
+	at := base.Add(3 * time.Minute)
+
+	// One id per case the lookup has to get right.
+	const (
+		idTwice     = "s-twice"     // served twice: newest snapshot wins
+		idAncestor  = "s-ancestor"  // served to a child, owned by the parent
+		idShadowed  = "s-shadowed"  // a bare inject row sits on top of the serve
+		idWritten   = "s-written"   // written, never served: not a donor
+		idElsewhere = "s-elsewhere" // served, but to another namespace
+		idUnknown   = "s-unknown"   // never seen at all
+	)
+
+	seed := []store.Event{
+		// Served twice: the newer snapshot must win.
+		{
+			OpID: "op-s1", Kind: store.EventRecall, Namespace: snapNS,
+			MemoryID: idTwice, MemoryNS: snapNS, MemoryTier: memory.TierSemantic,
+			MemorySummary: "stale text", CreatedAt: at,
+		},
+		{
+			OpID: "op-s2", Kind: store.EventRecall, Namespace: snapNS,
+			MemoryID: idTwice, MemoryNS: snapNS, MemoryTier: memory.TierProcedural,
+			MemorySummary: "current text", CreatedAt: at.Add(time.Minute),
+		},
+		// A cascading recall: served against snapNS, but the memory lives in an
+		// ancestor. The serve row is the only record of that fact.
+		{
+			OpID: "op-s3", Kind: store.EventBriefing, Namespace: snapNS,
+			MemoryID: idAncestor, MemoryNS: parent, MemoryTier: memory.TierSemantic,
+			MemorySummary: "inherited fact", CreatedAt: at,
+		},
+		// A real serve, then a bare inject row on top of it. The bare row is
+		// newer, so a lookup that forgets to skip snapshot-less rows returns
+		// empty strings here instead of the snapshot underneath.
+		{
+			OpID: "op-s4", Kind: store.EventRecall, Namespace: snapNS,
+			MemoryID: idShadowed, MemoryNS: snapNS, MemoryTier: memory.TierEpisodic,
+			MemorySummary: "still findable", CreatedAt: at,
+		},
+		{
+			OpID: "op-s5", Kind: store.EventInject, Namespace: snapNS,
+			MemoryID: idShadowed, Rank: 1, CreatedAt: at.Add(time.Minute),
+		},
+		// Written but never served: not a donor, so a beacon cannot use a write
+		// it did not see to learn the memory's text.
+		{
+			OpID: "op-s6", Kind: store.EventRemember, Namespace: snapNS,
+			MemoryID: idWritten, MemoryNS: snapNS, MemoryTier: memory.TierSemantic,
+			MemorySummary: "never served", CreatedAt: at,
+		},
+		// Served, but to a different namespace.
+		{
+			OpID: "op-s7", Kind: store.EventRecall, Namespace: parent,
+			MemoryID: idElsewhere, MemoryNS: parent, MemoryTier: memory.TierSemantic,
+			MemorySummary: "someone else's", CreatedAt: at,
+		},
+	}
+	if err := els.AppendEvents(ctx, seed); err != nil {
+		t.Fatalf("append snapshot fixture: %v", err)
+	}
+
+	ids := []string{idTwice, idAncestor, idShadowed, idWritten, idElsewhere, idUnknown}
+	got, err := els.ServedSnapshots(ctx, snapNS, ids, time.Time{})
+	if err != nil {
+		t.Fatalf("served snapshots: %v", err)
+	}
+
+	want := map[string]store.MemorySnapshot{
+		idTwice:    {Namespace: snapNS, Tier: memory.TierProcedural, Summary: "current text"},
+		idAncestor: {Namespace: parent, Tier: memory.TierSemantic, Summary: "inherited fact"},
+		idShadowed: {Namespace: snapNS, Tier: memory.TierEpisodic, Summary: "still findable"},
+	}
+	for id, w := range want {
+		if got[id] != w {
+			t.Errorf("snapshot[%s] = %+v, want %+v", id, got[id], w)
+		}
+	}
+	for _, id := range []string{idWritten, idElsewhere, idUnknown} {
+		if snap, ok := got[id]; ok {
+			t.Errorf("snapshot[%s] = %+v, want absent", id, snap)
+		}
+	}
+
+	// The since bound excludes a serve older than the window.
+	fresh, err := els.ServedSnapshots(ctx, snapNS, []string{idAncestor}, at.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("served snapshots since: %v", err)
+	}
+	if snap, ok := fresh[idAncestor]; ok {
+		t.Errorf("snapshot outside the window = %+v, want absent", snap)
+	}
+
+	// No ids is not an error — the caller has nothing to hydrate.
+	empty, err := els.ServedSnapshots(ctx, snapNS, nil, time.Time{})
+	if err != nil {
+		t.Fatalf("served snapshots with no ids: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("served snapshots with no ids = %+v, want empty", empty)
+	}
+}
+
 func testEventPrune(t *testing.T, els store.EventLogStore, ns string, base time.Time) {
 	ctx := context.Background()
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -48,8 +48,13 @@ export class ApiError extends Error {
 function headers(extra?: Record<string, string>, ns?: string): Record<string, string> {
   const h: Record<string, string> = { ...extra }
   // An explicit ns overrides the active namespace (used to scope a request to a
-  // specific namespace without switching the global selection).
-  const effective = ns ?? namespace.value
+  // specific namespace without switching the global selection). `||`, not `??`:
+  // an empty string means "the caller had no namespace to give" — an activity
+  // row with no recorded namespace — and must fall back to the active one
+  // rather than sending the request unscoped. No caller passes '' to mean "omit
+  // the header"; All-namespaces mode is expressed by namespace.value itself
+  // being '', where the two operators agree.
+  const effective = ns || namespace.value
   if (effective) h[namespaceHeader.value] = effective
   // The server bearer-gates /v1, /mcp and /metrics when MEMINI_API_KEY is set;
   // send the configured token so the dashboard works against that setup.

--- a/ui/src/components/TierBadge.tsx
+++ b/ui/src/components/TierBadge.tsx
@@ -1,5 +1,12 @@
 import type { Tier } from '../types'
 
 export function TierBadge({ tier }: { tier: Tier }) {
+  // An activity row can carry no tier: the snapshot columns are stamped at write
+  // time, and a row whose writer had nothing to snapshot (a pre-hydration inject
+  // event, or an id no serve covered) round-trips as "". Rendering that anyway
+  // produced a stray dot with no label — `.tier` leaves --tc unset without a
+  // tier modifier, so the pill lost its colours but `.tier::before` still
+  // painted. Nothing is the honest rendering of nothing.
+  if (!tier) return null
   return <span class={`tier ${tier}`}>{tier}</span>
 }

--- a/ui/src/views/Activity.tsx
+++ b/ui/src/views/Activity.tsx
@@ -184,6 +184,7 @@ export function Activity() {
   const [hasMore, setHasMore] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [openError, setOpenError] = useState<string | null>(null)
   const [open, setOpen] = useState<Memory | null>(null)
 
   const kinds = EVENT_KINDS.filter((k) => !hidden.includes(k))
@@ -263,12 +264,23 @@ export function Activity() {
     }
   }
 
-  const openMemory = async (id: string, ns: string) => {
+  // ns is optional: a row whose snapshot recorded no namespace has none to pass,
+  // and api.get then falls back to the active one rather than sending the
+  // request unscoped.
+  const openMemory = async (id: string, ns?: string) => {
+    setOpenError(null)
     try {
       setOpen(await api.get(id, ns))
-    } catch {
-      // The memory is gone (a forget event, most likely). The row still renders
-      // from its snapshot; there is simply nothing to open.
+    } catch (e) {
+      // Swallowing this made a 404 look like a dead button, which is what hid
+      // the empty-snapshot bug for as long as it hid. Say something.
+      setOpenError(
+        e instanceof ApiError && e.status === 404
+          ? 'That memory could not be opened — it may have been forgotten, or this row recorded no namespace to look it up in.'
+          : e instanceof Error
+            ? e.message
+            : 'Could not open that memory.',
+      )
     }
   }
 
@@ -342,6 +354,7 @@ export function Activity() {
         </div>
 
         {error && <ErrorBanner message={error} />}
+        {openError && <ErrorBanner message={openError} />}
         {loading && events.length === 0 ? (
           <Loading />
         ) : events.length === 0 ? (
@@ -390,11 +403,21 @@ export function Activity() {
                         key={m.id}
                         type="button"
                         class={`act-mem${m.filtered ? ' floored' : ''}`}
-                        onClick={() => openMemory(m.id, m.namespace)}
+                        onClick={() => openMemory(m.id, m.namespace || undefined)}
                       >
                         {m.rank ? <span class="act-rank mono">#{m.rank}</span> : <span class="act-rank" />}
                         <TierBadge tier={m.tier} />
-                        <span class="act-summary">{m.summary}</span>
+                        {/* A row whose writer recorded no snapshot has no text
+                            to show. Fall back to the id prefix rather than an
+                            empty line — memini resolves short ids, so it is
+                            something you can actually act on. */}
+                        {m.summary ? (
+                          <span class="act-summary">{m.summary}</span>
+                        ) : (
+                          <span class="act-summary mono muted" title="No snapshot was recorded for this memory">
+                            {m.id.slice(0, 8)}
+                          </span>
+                        )}
                         {m.section && <span class="chip">{m.section}</span>}
                         {/* The score is the "why": how well this memory matched
                             the query it was served for. */}
@@ -421,7 +444,7 @@ export function Activity() {
                             floored
                           </span>
                         )}
-                        {showNs && m.namespace !== ev.namespace && (
+                        {showNs && m.namespace && m.namespace !== ev.namespace && (
                           <span class="chip mono">{m.namespace}</span>
                         )}
                       </button>


### PR DESCRIPTION
## The problem

`inject` events render as blank rows in the activity feed, and clicking one 404s. Every injected-memory row on my instance was affected (104 of 104 came back with an empty `namespace`, `tier` and `summary`). Because `recall` and `inject` events interleave in the feed and recall rows render fine, it reads as an intermittent glitch rather than a total failure of one event kind.

A served row looks like this:

```json
{"id": "...", "namespace": "acme", "rank": 1, "score": 0.61, "summary": "...", "tier": "semantic"}
```

An injected row looks like this:

```json
{"id": "...", "namespace": "", "rank": 1, "summary": "", "tier": ""}
```

## Root cause

Event rows carry a denormalized snapshot of the memory (`memory_ns`, `memory_tier`, `memory_summary`), stamped at write time by `applyMemory`. `logRecallEvent` and `logBriefingEvent` both call it. `RecordInjected` never did, setting only `MemoryID` and `Rank`, so inject rows persisted three empty strings.

That single omission causes three separate symptoms:

1. The UI draws an empty line (and an unstyled `TierBadge` dot).
2. Inject events never match the `?tier=` or `?q=` activity filters, since both subqueries key off `memory_tier` and `memory_summary`. This one is silent and I do not think it has been reported.
3. Click-through 404s. The UI passes the row's empty namespace to `api.get`, and `ns ?? namespace.value` does not fall back on `""`, so the request goes out with no `X-Memini-Namespace` header at all.

## Why it is not a one-line fix

The obvious patch is to stamp the request namespace onto the row. That writes a plausible lie: recall serves across the ancestor read-set cascade, so a memory served to `acme/dev` may well live in `acme`. The click would still 404, now with wrong data on the row.

The beacon cannot supply it either. `injected_ids` is a list of bare id strings, and any fix has to work for already-deployed plugin versions.

Resolving ids against the memories table would work (ids are globally unique) but opens an information leak. Injected ids are taken on faith and never authorized, so a buggy or hostile client could beacon arbitrary ids and read back their summaries out of the activity feed.

## The fix

Borrow the snapshot from the serve that produced the injection, via a new `EventLogStore.ServedSnapshots`. That source is both the accurate one and the safe one:

- **Accurate**, because the serve row is the only place the memory's own namespace was ever recorded. The inject row ends up reading identically to the recall row above it in the feed.
- **Safe**, because the lookup is scoped to serves already logged against the caller's namespace. A report can only learn what it was already shown. An id no serve covered keeps its bare row, preserving the existing "taken on faith" contract.

Hydration runs inside the existing background log goroutine rather than inline, so it stays off the beacon's latency path and gives the preceding serve's own append a head start on landing.

Implemented for both backends over the `idx_memory_events_memory` index that already exists. No migration and no schema change.

`Score` is deliberately not copied. The composite score belongs to the recall that computed it against its query, and duplicating it would have two events claim the same number.

## UI

Server-side hydration fixes new events, but rows written before this change stay bare until they age out of the retention window, so the frontend degrades rather than blanking:

- `TierBadge` renders nothing for an empty tier. Fixed in the shared component, since `MemoryCard` and `MemoryDrawer` have the same exposure.
- An empty summary falls back to the id prefix, which memini can resolve, instead of an empty line.
- `api.ts` uses `||` rather than `??` so an empty namespace falls back to the active one instead of dropping the header.
- The silent `catch` around opening a memory now surfaces a message. Swallowing it is what made a 404 look like a dead button and hid this for as long as it hid.

## Tests

`TestRecordInjectedWritesEvent` existed and asserted only that the ids survived, never that a row was renderable, which is how this shipped. Added:

- `TestRecordInjectedHydratesServedSnapshot`: the inject row carries the same snapshot as the serve it reports on, and no score.
- `TestRecordInjectedHydratesAncestorNamespace`: a memory owned by a parent namespace and served to a child reports the parent. This is the assertion that distinguishes this fix from stamping the request namespace, and it is exactly the case that 404s today.
- `TestRecordInjectedLeavesUnservedIDsBare`: an id served only to another namespace, and one written but never served, both stay bare.
- Store conformance coverage for `ServedSnapshots` (newest-wins, snapshot-less rows are not donors, namespace scoping, kind filtering, the `since` bound, empty input). Runs against sqlitevec and postgres automatically.
- `TestReportInjected` now asserts the wire shape the dashboard actually reads.

I confirmed the new service tests fail without the fix, with the reported symptom (`ns:"" tier:"" summary:""`), rather than passing vacuously.

## Verification

- `go test ./...` green.
- Store conformance green on sqlitevec and on a real vchord-postgres container (`-tags integration`).
- `pnpm typecheck` and `pnpm build` green.
- End to end against a local server: seeded a memory in a parent namespace and one in a child, recalled from the child so the cascade served both, then POSTed a bare-id beacon exactly as the plugin does. Both rows came back fully populated, the ancestor-owned one correctly reporting the parent namespace, and fetching each memory with the namespace its row reports returns 200 for both. `?kind=inject&tier=semantic` and `?kind=inject&q=...` now match. Beaconing an id from an unrelated namespace still records the row and still leaks nothing.

## Note for the changelog

Hydrated inject events now match `?tier=` and `?q=`, so a tier-filtered or text-filtered feed will start returning inject events it previously omitted. That is the fix working, but it could read as a regression to someone who does not know the filters were broken for that kind.
