### PR TITLE
feat(logging): attribute request logs and record namespace resolutions

### DIFF
--- a/internal/api/mcp/actor_test.go
+++ b/internal/api/mcp/actor_test.go
@@ -1,0 +1,58 @@
+package mcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	meminimcp "github.com/eleboucher/memini/internal/api/mcp"
+	"github.com/eleboucher/memini/internal/embed/embedtest"
+	"github.com/eleboucher/memini/internal/httputil"
+	"github.com/eleboucher/memini/internal/service"
+	"github.com/eleboucher/memini/internal/store"
+	"github.com/eleboucher/memini/internal/store/sqlitevec"
+)
+
+// TestHTTPHandlerRecordsActor asserts the MCP surface records the
+// authenticated actor into an actor holder installed by an outer wrapper (in
+// production, internal/server's request logger) — the same attribution REST's
+// /v1 chain records, so /mcp access-log lines name the key too. Recording
+// happens at auth time, so even a request the MCP layer itself rejects is
+// attributed.
+func TestHTTPHandlerRecordsActor(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlitevec.Open(ctx, filepath.Join(t.TempDir(), "mcp-actor.db"), dims)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	var ks store.APIKeyStore = st
+	if err := ks.PutAPIKey(ctx, store.APIKey{Name: "bot", Hash: hashOf("tok-bot")}); err != nil {
+		t.Fatalf("PutAPIKey: %v", err)
+	}
+	svc := service.New(st, embedtest.New(dims))
+	h := meminimcp.HTTPHandler(svc, "X-Memini-Namespace", "default", "X-Memini-Home", "", ks, nil)
+
+	var gotName, gotKind string
+	var recorded bool
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(httputil.WithActorHolder(r.Context()))
+		h.ServeHTTP(w, r)
+		gotName, gotKind, recorded = httputil.RecordedActor(r.Context())
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer tok-bot")
+	req.Header.Set("Content-Type", "application/json")
+	wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !recorded {
+		t.Fatal("no actor recorded, want one")
+	}
+	if gotName != "bot" || gotKind != "key" {
+		t.Errorf("recorded actor = (%q, %q), want (bot, key)", gotName, gotKind)
+	}
+}

--- a/internal/api/mcp/mcp.go
+++ b/internal/api/mcp/mcp.go
@@ -446,6 +446,19 @@ func HTTPHandlerWithAuth(svc *service.Service, nsHeader, defaultNS, homeHeader s
 			http.Error(w, `{"error":"missing or invalid bearer token"}`, http.StatusUnauthorized)
 			return
 		}
+		// Record the actor for the access log (the outer request logger's
+		// holder — see httputil.RecordActor), classified exactly like REST's
+		// actorMiddleware and NewServer's attribution kind below. At auth
+		// time, deliberately: even a request the MCP layer goes on to reject
+		// is attributed in the log.
+		switch {
+		case p != nil && p.Name != "":
+			httputil.RecordActor(r.Context(), p.Name, "key")
+		case strings.TrimSpace(token) != "":
+			httputil.RecordActor(r.Context(), "", "env")
+		default:
+			httputil.RecordActor(r.Context(), "", "none")
+		}
 		if v := strings.TrimSpace(r.Header.Get(nsHeader)); v != "" {
 			if err := httputil.ValidateNamespace(v); err != nil {
 				http.Error(w, `{"error":"invalid namespace header"}`, http.StatusBadRequest)

--- a/internal/api/rest/handshake.go
+++ b/internal/api/rest/handshake.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -99,6 +100,12 @@ func (h *Server) Handshake(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	keyName := ""
+	if principal != nil {
+		keyName = principal.Name
+	}
+	logNamespaceResolved(ctx, facts, merged, sources, keyName, res)
+
 	entries, err := h.svc.ResolveReadSetInfo(ctx, res.Namespace, homeFromContext(ctx))
 	if err != nil {
 		writeError(w, r, statusFor(err), err)
@@ -134,6 +141,43 @@ func (h *Server) Handshake(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	httputil.JSON(w, http.StatusOK, resp)
+}
+
+// logNamespaceResolved emits the operator-side record of a handshake's
+// namespace decision: who asked (key), what they got (namespace), why
+// (source, plus the winning facts and any prefix with its settings layer).
+// The handshake response reports all of this too, but only to the client that
+// asked — this line is what lets an operator answer "why did that session
+// write there?" from the server logs alone, without asking the person whose
+// session it was. One line per handshake, so volume tracks session starts,
+// not requests.
+func logNamespaceResolved(ctx context.Context, f nsresolve.Facts, merged store.ClientSettings,
+	sources map[string]string, keyName string, res nsresolve.Result,
+) {
+	attrs := make([]slog.Attr, 0, 8)
+	if keyName != "" {
+		attrs = append(attrs, slog.String("key", keyName))
+	}
+	attrs = append(attrs,
+		slog.String("namespace", res.Namespace),
+		slog.String("source", res.Source),
+		slog.String("cwd", f.CwdBasename),
+	)
+	if f.RemoteURL != "" {
+		attrs = append(attrs, slog.String("remote_url", f.RemoteURL))
+	}
+	if f.Agent != "" {
+		attrs = append(attrs, slog.String("agent", f.Agent))
+	}
+	if merged.NamespacePrefix != nil && *merged.NamespacePrefix != "" {
+		attrs = append(attrs,
+			slog.String("prefix", *merged.NamespacePrefix),
+			slog.String("prefix_source", sources["namespace_prefix"]))
+	}
+	if res.Source == nsresolve.SourcePin {
+		attrs = append(attrs, slog.String("pin_key", res.PinKey))
+	}
+	slog.LogAttrs(ctx, slog.LevelInfo, "handshake: namespace resolved", attrs...)
 }
 
 // pinLookup builds an nsresolve.PinLookup over the pins table, fetching the

--- a/internal/api/rest/logging_test.go
+++ b/internal/api/rest/logging_test.go
@@ -1,0 +1,99 @@
+package rest_test
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/eleboucher/memini/internal/httputil"
+)
+
+// TestV1RequestsRecordActor asserts the /v1 middleware chain records the
+// authenticated actor into an actor holder installed by an outer wrapper (in
+// production, internal/server's request logger): a named key records (name,
+// "key"), the admin env key ("", "env"). Without this every access-log line
+// is anonymous and operators cannot tell whose session did what.
+func TestV1RequestsRecordActor(t *testing.T) {
+	fileYAML := `
+keys:
+  - name: filebot
+    secret: "tok-file"
+`
+	h, _ := newConfigServer(t, "admin-secret", fileYAML, nil)
+
+	cases := []struct {
+		name, token, wantName, wantKind string
+	}{
+		{"named file key", "tok-file", "filebot", "key"},
+		{"admin env key", "admin-secret", "", "env"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var gotName, gotKind string
+			var recorded bool
+			wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				r = r.WithContext(httputil.WithActorHolder(r.Context()))
+				h.ServeHTTP(w, r)
+				gotName, gotKind, recorded = httputil.RecordedActor(r.Context())
+			})
+
+			rec := do(t, wrapped, http.MethodGet, "/v1/self", "", c.token, nil)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("GET /v1/self: want 200, got %d (%s)", rec.Code, rec.Body)
+			}
+			if !recorded {
+				t.Fatal("no actor recorded, want one")
+			}
+			if gotName != c.wantName || gotKind != c.wantKind {
+				t.Errorf("recorded actor = (%q, %q), want (%q, %q)", gotName, gotKind, c.wantName, c.wantKind)
+			}
+		})
+	}
+}
+
+// TestHandshakeLogsResolution asserts a successful handshake emits one info
+// log line stating the resolved namespace and its full provenance — key,
+// source, and the prefix with the settings layer it came from. This is the
+// operator-side record of every session's namespace decision; the handshake
+// response alone reports it only to the client that asked.
+func TestHandshakeLogsResolution(t *testing.T) {
+	var logBuf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	fileYAML := `
+keys:
+  - name: filebot
+    secret: "tok-file"
+    settings:
+      namespace_prefix: team
+`
+	h, _ := newConfigServer(t, "admin-secret", fileYAML, nil)
+
+	body := handshakeBody(map[string]any{
+		"cwd_basename": "proj",
+		"remote_url":   "https://github.com/acme/phoenix.git",
+	})
+	rec := do(t, h, http.MethodPost, "/v1/handshake", "", "tok-file", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("handshake: want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+
+	logged := logBuf.String()
+	for _, want := range []string{
+		`"msg":"handshake: namespace resolved"`,
+		`"key":"filebot"`,
+		`"namespace":"team/phoenix"`,
+		`"source":"remote"`,
+		`"remote_url":"https://github.com/acme/phoenix.git"`,
+		`"prefix":"team"`,
+		`"prefix_source":"key"`,
+	} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("handshake log missing %s; got: %s", want, logged)
+		}
+	}
+}

--- a/internal/api/rest/middleware.go
+++ b/internal/api/rest/middleware.go
@@ -237,6 +237,10 @@ func (a AuthConfig) actorMiddleware(next http.Handler) http.Handler {
 			kind = "none"
 		}
 		ctx := service.WithActor(r.Context(), name, kind)
+		// Also record it for the access log: the outer request logger's actor
+		// holder (httputil.RecordActor) is how the (name, kind) resolved here
+		// reaches a log line emitted OUTSIDE this middleware chain.
+		httputil.RecordActor(ctx, name, kind)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/httputil/actor.go
+++ b/internal/httputil/actor.go
@@ -1,0 +1,63 @@
+package httputil
+
+import (
+	"context"
+	"sync"
+)
+
+// The actor holder carries "who authenticated this request" OUTWARD to the
+// request logger. Context values only flow inward — the access logger wraps the
+// whole stack, auth runs several middlewares deeper, so anything auth puts on
+// its (child) context is invisible to the logger's (parent) context. The
+// holder inverts that: the logger installs a mutable box up front, auth writes
+// into the box through whatever derived context it holds, and the logger reads
+// the box back after the handler returns.
+//
+// It lives here rather than in internal/server because both REST and MCP must
+// write into it and server mounts them both — server → rest/mcp → httputil is
+// the one import direction with no cycle.
+type actorHolder struct {
+	mu   sync.Mutex
+	name string
+	kind string
+	set  bool
+}
+
+type actorHolderKey struct{}
+
+// WithActorHolder returns ctx carrying a fresh, empty actor holder for
+// RecordActor/RecordedActor to meet through. Installed once per request by the
+// outermost request logger.
+func WithActorHolder(ctx context.Context) context.Context {
+	return context.WithValue(ctx, actorHolderKey{}, &actorHolder{})
+}
+
+// RecordActor records the authenticated actor — name is the named key that
+// authenticated ("" for the admin env key or auth-disabled dev mode), kind the
+// same "key"/"env"/"none" classification the activity log's attribution uses —
+// into the holder, if the context carries one. A context with no holder (a
+// surface not wrapped by the request logger) is a silent no-op: recording is
+// best-effort telemetry, never a reason to fail a request.
+func RecordActor(ctx context.Context, name, kind string) {
+	h, _ := ctx.Value(actorHolderKey{}).(*actorHolder)
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.name, h.kind, h.set = name, kind, true
+}
+
+// RecordedActor returns what RecordActor stored for this request, ok=false
+// when no holder is present or nothing was recorded (the request never reached
+// an authenticating middleware — e.g. rejected before auth, or a route outside
+// the authenticated groups).
+func RecordedActor(ctx context.Context) (name, kind string, ok bool) {
+	h, _ := ctx.Value(actorHolderKey{}).(*actorHolder)
+	if h == nil {
+		return "", "", false
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.name, h.kind, h.set
+}

--- a/internal/httputil/actor_test.go
+++ b/internal/httputil/actor_test.go
@@ -1,0 +1,44 @@
+package httputil_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/eleboucher/memini/internal/httputil"
+)
+
+type childKey struct{}
+
+// TestRecordActorVisibleThroughParentContext exercises the property the holder
+// exists for: the request logger installs the holder on the OUTERMOST context,
+// auth middleware records the actor on a derived child context (several
+// middlewares deeper), and the logger must still see the recorded value when it
+// reads back through its own, older context. Plain context.WithValue cannot do
+// this — values only flow inward — which is why RecordActor writes through a
+// mutable holder instead of deriving a new context.
+func TestRecordActorVisibleThroughParentContext(t *testing.T) {
+	ctx := httputil.WithActorHolder(context.Background())
+
+	child := context.WithValue(ctx, childKey{}, "deeper")
+	httputil.RecordActor(child, "nicole_tyrfing", "key")
+
+	name, kind, ok := httputil.RecordedActor(ctx)
+	if !ok {
+		t.Fatal("RecordedActor ok = false, want true after RecordActor on child context")
+	}
+	if name != "nicole_tyrfing" || kind != "key" {
+		t.Errorf("RecordedActor = (%q, %q), want (nicole_tyrfing, key)", name, kind)
+	}
+}
+
+// TestRecordActorWithoutHolderIsNoop pins the no-holder behavior: surfaces that
+// aren't wrapped by the request logger (tests hitting a bare router, future
+// listeners) call RecordActor on a context with no holder, and that must be a
+// silent no-op — never a panic, never an implicit holder.
+func TestRecordActorWithoutHolderIsNoop(t *testing.T) {
+	httputil.RecordActor(context.Background(), "nicole_tyrfing", "key")
+
+	if _, _, ok := httputil.RecordedActor(context.Background()); ok {
+		t.Error("RecordedActor ok = true on a context with no holder, want false")
+	}
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -6,31 +6,52 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/eleboucher/memini/internal/httputil"
 )
 
 // requestLogger emits one structured log line per request at completion.
-// Health and metrics probes are logged at debug to avoid noise.
+// Health and metrics probes are logged at debug to avoid noise, and so is
+// /v1/stats: the admin UI polls it once per namespace per refresh, which at
+// info level buried everything meaningful under bursts of identical lines.
+//
+// The line carries the authenticated actor when one was resolved: this
+// middleware is the OUTERMOST wrapper, so it installs an actor holder
+// (httputil.WithActorHolder) before dispatch, the auth middlewares deeper in
+// (REST's actorMiddleware, MCP's bearer wrapper) record into it, and the
+// attrs are read back here after the handler returns — "key" names the key,
+// "auth" is the key/env/none attribution kind. Requests that never reach an
+// authenticating middleware (probes, 404s, the UI shell) record nothing and
+// log exactly as before.
 func requestLogger(log *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+			r = r.WithContext(httputil.WithActorHolder(r.Context()))
 			next.ServeHTTP(ww, r)
 
 			level := slog.LevelInfo
 			switch r.URL.Path {
-			case "/healthz", "/readyz", "/metrics":
+			case "/healthz", "/readyz", "/metrics", "/v1/stats":
 				level = slog.LevelDebug
 			}
 
-			log.LogAttrs(r.Context(), level, "http request",
+			attrs := []slog.Attr{
 				slog.String("method", r.Method),
 				slog.String("path", r.URL.Path),
 				slog.Int("status", ww.Status()),
 				slog.Int("bytes", ww.BytesWritten()),
 				slog.Duration("duration", time.Since(start)),
 				slog.String("request_id", middleware.GetReqID(r.Context())),
-			)
+			}
+			if name, kind, ok := httputil.RecordedActor(r.Context()); ok {
+				if name != "" {
+					attrs = append(attrs, slog.String("key", name))
+				}
+				attrs = append(attrs, slog.String("auth", kind))
+			}
+			log.LogAttrs(r.Context(), level, "http request", attrs...)
 		})
 	}
 }

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 
+	"github.com/eleboucher/memini/internal/httputil"
 	"github.com/eleboucher/memini/internal/server"
 )
 
@@ -53,6 +54,74 @@ func TestPanicHandlerStillLoggedAndCounted(t *testing.T) {
 	}
 	if !strings.Contains(logged, `"status":500`) {
 		t.Errorf("request-completion log missing status=500; got: %s", logged)
+	}
+}
+
+// TestRequestLoggerStatsAtDebug pins /v1/stats to debug level in the request
+// log: the admin UI polls it once per namespace per refresh, which at info
+// level buried every meaningful line under ~40-line bursts of identical
+// entries. Same treatment the health/readiness/metrics probes already get.
+func TestRequestLoggerStatsAtDebug(t *testing.T) {
+	var logBuf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	srv := server.New(server.Options{Addr: ":0", ShutdownTimeout: time.Second}, log, prometheus.NewRegistry())
+
+	srv.Router().Handle("GET /v1/stats", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/stats", nil))
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, `"path":"/v1/stats"`) {
+		t.Fatalf("request log missing /v1/stats entry; got: %s", logged)
+	}
+	if !strings.Contains(logged, `"level":"DEBUG"`) {
+		t.Errorf("/v1/stats logged above debug; got: %s", logged)
+	}
+}
+
+// TestRequestLoggerIncludesRecordedActor asserts the request-completion line
+// carries the actor an inner (auth) middleware recorded via
+// httputil.RecordActor: the key name as "key" when a named key authenticated,
+// and the auth kind always. Without this every line is anonymous and log
+// triage cannot tell whose session did what.
+func TestRequestLoggerIncludesRecordedActor(t *testing.T) {
+	cases := []struct {
+		name, actor, kind string
+		wantInLog         []string
+		wantAbsent        string
+	}{
+		{"named key", "nicole_tyrfing", "key",
+			[]string{`"key":"nicole_tyrfing"`, `"auth":"key"`}, ""},
+		{"admin env key", "", "env",
+			[]string{`"auth":"env"`}, `"key":`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			log := slog.New(slog.NewJSONHandler(&logBuf, nil))
+			srv := server.New(server.Options{Addr: ":0", ShutdownTimeout: time.Second}, log, prometheus.NewRegistry())
+
+			srv.Router().Handle("GET /v1/memories", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				httputil.RecordActor(r.Context(), c.actor, c.kind)
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			rec := httptest.NewRecorder()
+			srv.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/memories", nil))
+
+			logged := logBuf.String()
+			for _, want := range c.wantInLog {
+				if !strings.Contains(logged, want) {
+					t.Errorf("request log missing %s; got: %s", want, logged)
+				}
+			}
+			if c.wantAbsent != "" && strings.Contains(logged, c.wantAbsent) {
+				t.Errorf("request log has %s, want it absent; got: %s", c.wantAbsent, logged)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## The problem

The request log is an anonymous access log: every line is method/path/status/duration, with no actor and no application context. That leaves two operator questions it cannot answer:

1. **"Why did that session write to that namespace?"** Namespace resolution happens in `POST /v1/handshake`, and the response reports the decision (`namespace`, `namespace_source`) — but only to the client that asked. The server records nothing. Diagnosing a misrouted session today means asking the person whose session it was to run a client-side status check, because the server logs hold no trace of the decision.
2. **"Whose request was this?"** Every line is anonymous even when the request authenticated with a named API key, so the log cannot connect a burst of traffic, an error, or a surprising write to the key that did it.

On top of that, the admin UI polls `/v1/stats` once per namespace per refresh, so at info level the meaningful lines are buried under bursts of identical entries.

## The fix

Three changes, one per gap.

**Handshake resolutions get one info line each.** `POST /v1/handshake` now logs `handshake: namespace resolved` with the key that asked, the resolved namespace, the `source` (the same value the response's `namespace_source` carries), the winning facts (`cwd` basename, `remote_url`, `agent`), any `namespace_prefix` together with the settings layer it came from, and the pin key when a pin won. It is the operator-side twin of the handshake response: the same decision, recorded where the operator can see it. Volume tracks session starts, not requests, since clients handshake once per session.

**The request-completion line carries the authenticated actor.** There is a structural wrinkle here: the request logger is the *outermost* middleware (it has to be, to time the whole request), auth resolves several wrappers deeper, and context values only flow inward — anything auth puts on its child context is invisible to the logger's parent context. The new `internal/httputil/actor.go` inverts that flow with a mutable holder: the logger installs an empty holder up front (`WithActorHolder`), the auth layers write into it through whatever derived context they hold (`RecordActor`), and the logger reads it back after the handler returns.

Both surfaces record into it with the same `key`/`env`/`none` classification the activity log's attribution already uses, so the access log and the activity feed agree on who someone is:

- REST's `actorMiddleware` records right where it already resolves the actor for `service.WithActor`.
- MCP's bearer wrapper records at auth time, deliberately before its own header validation — so even a request the MCP layer goes on to reject is attributed in the log.

The resulting line gains `key` (the key name, when a named key authenticated) and `auth` (the classification). Requests that never reach an authenticating middleware — probes, 404s, the UI shell — record nothing and log exactly as before, and `RecordActor` on a context with no holder is a silent no-op: attribution is best-effort telemetry, never a reason to fail a request.

The holder lives in `internal/httputil` rather than `internal/server` because both REST and MCP must write into it and `server` mounts them both — `server → rest/mcp → httputil` is the one import direction with no cycle.

**`/v1/stats` joins the probes at debug level.** `/healthz`, `/readyz`, and `/metrics` were already demoted for exactly this reason; the UI's stats polling is the same class of noise.

## Tests

- `TestHandshakeLogsResolution` (rest): a handshake emits one info line carrying the full provenance — key, namespace, source, and the prefix with its settings layer.
- `TestV1RequestsRecordActor` (rest): the real `/v1` middleware chain records `(name, "key")` for a named key and `("", "env")` for the admin env key into a holder installed by an outer wrapper, exactly as production wires it.
- `TestHTTPHandlerRecordsActor` (mcp): the bearer wrapper records the named key for `/mcp` requests.
- `TestRequestLoggerIncludesRecordedActor` and `TestRequestLoggerStatsAtDebug` (server): the completion line carries `key`/`auth` when an inner handler recorded an actor, and `/v1/stats` logs at debug.
- `TestRecordActorVisibleThroughParentContext` and `TestRecordActorWithoutHolderIsNoop` (httputil): the holder mechanism itself — a write through a child context is visible to the parent that installed the holder, and recording without a holder is a no-op rather than a panic.

## Verification

- `mise run test` green: `go fmt` clean, `go vet ./...` clean, `go test ./...` all packages ok.
- `golangci-lint run`: 0 issues.
