### PR TITLE
feat(plugin): add native Codex distribution

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "memini",
+  "interface": {
+    "displayName": "Memini"
+  },
+  "plugins": [
+    {
+      "name": "memini",
+      "source": {
+        "source": "local",
+        "path": "./plugin"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -78,10 +78,13 @@ For the full walk-through, including wiring it into an agent, see
 
 ## Agent plugin
 
-Every integration reads the same two variables: **`MEMINI_BASE_URL`** for the server and
-**`MEMINI_API_KEY`** for the token. `MEMINI_URL` and `MEMINI_TOKEN` still work as aliases.
-Where a plugin has its own config (opencode options, Open WebUI Valves, `openclaw.json`),
-that config wins over the environment.
+Most integrations read **`MEMINI_BASE_URL`** for the server and
+**`MEMINI_API_KEY`** for the token. `MEMINI_URL` and `MEMINI_TOKEN` remain
+legacy aliases where documented. The native Codex plugin is the exception: its
+bundled server uses a fixed local URL and accepts only `MEMINI_API_KEY`; see the
+remote override recipe below. Where an integration has its own config (opencode
+options, Open WebUI Valves, `openclaw.json`), that config wins over the
+environment.
 
 **Claude Code:**
 
@@ -107,7 +110,17 @@ into Admin Panel, Functions, and optionally
 [`tools/memini_tools.py`](integrations/openwebui/tools/memini_tools.py) into Workspace,
 Tools.
 
-**Codex CLI:** MCP only, no plugin. Wire the `memini mcp` server directly: see
+**Codex:**
+
+```sh
+codex plugin marketplace add eleboucher/memini
+codex plugin add memini@memini
+```
+
+Start the local server first (`memini serve`, default
+`http://localhost:8080`), set `MEMINI_API_KEY` when authentication is enabled,
+review and trust the bundled hooks with `/hooks`, then start a new thread.
+Remote and custom-server setup is covered in
 [`integrations/codex/`](integrations/codex/).
 
 Full details, edge cases and every client-side setting live in

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,70 +1,72 @@
-# memini + Codex CLI
+# memini + Codex
 
-Codex reads MCP servers from `~/.codex/config.toml` (or a project-scoped
-`.codex/config.toml`) under `[mcp_servers.<name>]`.
-
-**Local (stdio)** — widely supported; see [`config.stdio.toml`](config.stdio.toml):
+## Install the native plugin
 
 ```sh
-codex mcp add memini -- memini mcp
+codex plugin marketplace add eleboucher/memini
+codex plugin add memini@memini
 ```
 
-**Remote (Streamable HTTP)** — recent Codex; see [`config.remote.toml`](config.remote.toml).
-
-**As a plugin** — memini's [`plugin/`](../../plugin/) directory carries a
-`.codex-plugin/` manifest, so you can mount it as a Codex plugin instead of
-registering the MCP server by hand; that also brings the hooks + skills layer
-(see the [integrations overview](../README.md)).
-
-Verify:
+Run the local server first; the bundled MCP server targets
+`http://localhost:8080/mcp`.
 
 ```sh
-codex mcp list
+memini serve
+curl http://localhost:8080/healthz
 ```
 
-## What you get
+Set authentication and optional static identity before starting Codex:
 
-Codex sees memini's full `memory_*` tool set — no extra config beyond the
-server registration above:
+```sh
+export MEMINI_API_KEY="..."
+export MEMINI_NAMESPACE="my-project" # optional
+export MEMINI_HOME="personal/me"      # optional
+```
 
-- **`memory_recall`** — hybrid (semantic + keyword) search, with optional
-  `tags` / `metadata` filters, `response_format: "concise"` for a token-cheap
-  first pass, and time-travel / nested-namespace options. Results carry
-  `created_at` and `tags`; a `degraded: "keyword_only"` field means semantic
-  search was unavailable and the results are keyword-only.
-- **`memory_list`** — query-less browse by tier / tags / metadata category
-  (e.g. all procedural memories, or everything categorized `bug_fixes`; see
-  [`docs/categories.md`](../../docs/categories.md)). Returns at most `limit`
-  (default 20) newest-first; page past it with `offset`.
-- **`memory_get`** — fetch one memory with full metadata, tags, and
-  timestamps by ID.
-- **`memory_history`** — trace a memory's supersession lineage by ID: the
-  fact plus what it superseded and what replaced it, oldest-first, including
-  tombstoned rows.
-- **`memory_remember`** — store a fact, with optional `tags` and `metadata`.
-  Set `metadata.category` on writes to browse by subject later.
-- **`memory_update`** — partial update of an existing memory by ID (only
-  provided fields change); MCP-only, so this is the one tool in the set that
-  the REST-backed integrations elsewhere in this repo don't get.
-- **`memory_forget`** — permanently delete a memory by ID.
-- **`memory_briefing`** — pinned context, durable facts, procedures, and
-  recent activity for the namespace in one query-less call.
-- **`memory_answer`** — ask a question and get an answer grounded on recalled
-  memories, with the same `tags` / `metadata` filters (only advertised when
-  the server has an LLM configured).
+`MEMINI_API_KEY` is Codex's bearer variable. The legacy `MEMINI_TOKEN` alias is
+Claude-only because Codex accepts one `bearer_token_env_var`.
 
-Use the same namespace as your other agents (the `MEMINI_DEFAULT_NAMESPACE` env
-for stdio, or the `X-Memini-Namespace` header for remote) to share memory.
-The `my-project` placeholder can be replaced with your real project name, or
-removed entirely to fall back to the server's own default namespace (the git
-repo basename of its own working directory, unless a `default_namespace` is
-configured — see [`docs/api-keys.md`](../../docs/api-keys.md) for remote,
-or `MEMINI_DEFAULT_NAMESPACE`/server config for stdio).
+Installing does not trust plugin hooks. Open `/hooks`, review the Memini
+commands, and trust the current definition. Start a new thread after install so
+Codex discovers all nine skills, the `memory_*` tools, and lifecycle hooks.
+Verify with `codex plugin list`, `codex mcp list`, `/hooks`, and a
+`memory_recall` call.
 
-Note that Codex is a plain MCP client: unlike the other integrations in this
-repo (pi, openclaw, opencode, hermes, Open WebUI), it does not perform the
-config-handshake (`POST /v1/handshake`) that resolves a namespace from project
-facts and picks up server-side pins (`memini namespace <ns>` /
-`POST /v1/pins`). A pin set for a project Codex works in has no effect here —
-use the key's bound `default_namespace` or a static `X-Memini-Namespace`
-header (see [`config.remote.toml`](config.remote.toml)) instead.
+The plugin provides session briefing and compaction recovery, prompt/file/tool
+recall, local tool-event buffering, rolling `Stop` checkpoints, PreCompact
+episodic checkpoints, and skills for remember, recall, recap, forget, pin,
+status, namespace, doctor, and backfill. Doctor and backfill require the local
+`memini` binary.
+
+## Remote or custom server URL
+
+Codex does not expand Claude-style `${VAR:-default}` expressions inside plugin
+MCP URLs. The bundled endpoint is therefore static. Disable the bundled server
+and register a project or user MCP server in `config.toml` using
+[`config.remote.toml`](config.remote.toml). This limitation is tracked in
+[openai/codex#2680](https://github.com/openai/codex/issues/2680).
+
+```toml
+[plugins.memini.mcp_servers.memini]
+enabled = false
+```
+
+Then configure `[mcp_servers.memini]` with the desired URL and headers.
+[`config.stdio.toml`](config.stdio.toml) remains available when you prefer the
+local `memini mcp` process.
+
+## Update
+
+Refresh the marketplace, reinstall `memini@memini`, and start a new thread.
+Codex loads an installed plugin copy and thread-scoped skills/tools, so an
+existing thread is not a reliable activation check.
+
+## Stable parity limits
+
+Codex has no reliable final-session event equivalent to Claude's `SessionEnd`,
+so it keeps rolling checkpoints but cannot guarantee the same final digest.
+Codex also does not expose a stable main-session transcript contract: Memini
+does not parse Codex transcripts for automatic turn capture, legacy inline
+extraction, or auto-save nudges. Explicit memory writes, recall, tool buffering,
+Stop checkpoints, and PreCompact recovery remain active. Hooks stay fail-soft
+when Memini is unreachable.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -11,5 +11,6 @@
   "repository": "https://github.com/eleboucher/memini",
   "keywords": ["memory", "agent", "claude-code"],
   "skills": "./skills/",
-  "commands": "./commands/"
+  "commands": "./commands/",
+  "hooks": "./hooks/hooks.claude.json"
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,12 +1,29 @@
 {
   "name": "memini",
   "version": "0.7.12",
-  "description": "Persistent memory for AI coding agents via the memini memory service. Shares the Claude Code hook wiring (hooks/hooks.json), which Codex auto-discovers and runs by expanding ${CLAUDE_PLUGIN_ROOT}, capturing tool usage and surfacing prior context at session start.",
+  "description": "Persistent memory for coding agents, with automatic context recall, rolling checkpoints, skills, and bundled memory tools.",
   "author": {
     "name": "memini maintainers",
     "url": "https://github.com/eleboucher/memini"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/eleboucher/memini",
-  "repository": "https://github.com/eleboucher/memini"
+  "repository": "https://github.com/eleboucher/memini",
+  "keywords": ["memory", "agent", "codex", "mcp", "developer-tools"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.codex.json",
+  "interface": {
+    "displayName": "Memini",
+    "shortDescription": "Persistent memory for coding agents",
+    "longDescription": "Recall project context automatically, create rolling work checkpoints, and manage durable memories with bundled MCP tools and skills.",
+    "developerName": "memini maintainers",
+    "category": "Developer Tools",
+    "capabilities": ["Interactive", "Read", "Write"],
+    "websiteURL": "https://github.com/eleboucher/memini",
+    "defaultPrompt": [
+      "Recall what we know about this project.",
+      "Save this decision to project memory.",
+      "Catch me up on recent work."
+    ]
+  }
 }

--- a/plugin/.mcp.codex.json
+++ b/plugin/.mcp.codex.json
@@ -1,0 +1,11 @@
+{
+  "memini": {
+    "type": "http",
+    "url": "http://localhost:8080/mcp",
+    "bearer_token_env_var": "MEMINI_API_KEY",
+    "env_http_headers": {
+      "X-Memini-Namespace": "MEMINI_NAMESPACE",
+      "X-Memini-Home": "MEMINI_HOME"
+    }
+  }
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -17,6 +17,11 @@ the agent _when_ to use the memory tools.
 | `PreCompact`       | Before context compaction, distills the buffer into an episodic emergency checkpoint (Claude Code only)                                                                                            |
 | `SessionEnd`       | Distills the buffer into one durable episodic **session digest**                                                                                                                                   |
 
+The table describes the full Claude lifecycle. Codex uses the same shared
+scripts for its documented events but omits `SessionEnd` and all
+transcript-dependent behavior; see [Codex CLI](#codex-cli) for the stable
+differences.
+
 ### Auto-save (Stop)
 
 Agents forget to save. So the `Stop` hook counts the conversation's user
@@ -80,7 +85,8 @@ real memories out of the box — not just session digests:
   a back-compat fallback for sessions started under the old directive.
   Model-curated, so it stays low-noise. Set to `0` to disable both.
 
-Plus 3 skills (`remember`, `recall`, `recap`) the agent invokes directly.
+Plus 9 skills (`remember`, `recall`, `recap`, `forget`, `pin`, `status`,
+`namespace`, `doctor`, `backfill`) the agent invokes directly.
 
 ### Turning session digests off (`MEMINI_SESSION_DIGEST=0`)
 
@@ -194,14 +200,27 @@ namespaced `mcp__plugin_memini_memini__*`).
 
 ### Codex CLI
 
-Codex implements a Claude-Code-compatible plugin model: it auto-discovers
-`hooks/hooks.json` and expands `${CLAUDE_PLUGIN_ROOT}` (which Codex provides for
-compatibility), so the same hook wiring drives both. Mount this directory as a
-Codex plugin via `.codex-plugin/plugin.json` — no Codex-specific hooks file is
-needed. (Matchers naming Claude-only tools like `Read`/`Glob`/`Grep` just don't
-fire under Codex, which exposes `Bash`/`apply_patch`/`mcp__*`.) The
-`PostToolUse` hook captures Codex `apply_patch` calls by parsing the patch
-header lines, so session digests still list edited files.
+Install through the repository marketplace:
+
+```sh
+codex plugin marketplace add eleboucher/memini
+codex plugin add memini@memini
+```
+
+The bundled server targets `http://localhost:8080/mcp`. Start `memini serve`,
+set `MEMINI_API_KEY` when needed, review and trust the plugin commands in
+`/hooks`, then start a new thread. Codex uses `hooks/hooks.json` with
+`${PLUGIN_ROOT}` and native `Bash`, `apply_patch`, and MCP matchers; Claude uses
+`hooks/hooks.claude.json`.
+
+For a remote URL, disable the bundled MCP server and use the `config.toml`
+recipe in [`integrations/codex/`](../integrations/codex/). Codex does not
+support Claude-style URL interpolation in the bundled MCP file.
+
+Codex has no reliable final-session event, and Memini does not parse Codex's
+unstable transcript format. Rolling Stop checkpoints and PreCompact recovery
+work, but final SessionEnd digests, transcript-based turn capture, legacy inline
+extraction, and auto-save nudges remain Claude-only.
 
 ### opencode
 
@@ -218,8 +237,10 @@ uncapped); see the opencode recipe for its options.
 plugin/
 ├── .claude-plugin/plugin.json   # Claude Code manifest
 ├── .codex-plugin/plugin.json    # Codex manifest
+├── .mcp.codex.json              # Codex local HTTP MCP server
 ├── hooks/
-│   └── hooks.json               # hook wiring (Claude Code + Codex, via ${CLAUDE_PLUGIN_ROOT})
+│   ├── hooks.json               # Codex wiring (${PLUGIN_ROOT})
+│   └── hooks.claude.json        # full Claude Code event set
 ├── scripts/
 │   ├── _shared.mjs              # resolveProject, postJSON/Search/Remember, session buffer + digest
 │   ├── session-start.mjs
@@ -229,9 +250,7 @@ plugin/
 │   ├── pre-tool-use.mjs
 │   └── post-tool-use.mjs
 └── skills/
-    ├── remember/SKILL.md
-    ├── recall/SKILL.md
-    └── recap/SKILL.md
+    └── <nine plugin-scoped skills>/SKILL.md
 ```
 
 ## How the namespace gets resolved

--- a/plugin/hooks/hooks.claude.json
+++ b/plugin/hooks/hooks.claude.json
@@ -1,0 +1,78 @@
+{
+  "//": "Claude Code lifecycle wiring. Business logic is shared with Codex in ../scripts; keep Claude-only SessionEnd and transcript behavior here.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs\"",
+            "statusMessage": "memini: loading session context"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/user-prompt-submit.mjs\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/stop.mjs\""
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs\""
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write|Read|Glob|Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-tool-use.mjs\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write|Bash|NotebookEdit|Agent|Task|apply_patch|mcp__.*memini.*__memory_(recall|briefing|get)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,12 +1,12 @@
 {
-  "//": "memini plugin hooks for Claude Code. Wired into Claude Code's plugin engine via the parent .claude-plugin/plugin.json manifest. Each hook reads the agent's payload from stdin (per Claude Code's hook protocol) and POSTs to memini.",
+  "//": "Codex-native lifecycle wiring. Installing does not trust hooks automatically; review /hooks before enabling them.",
   "hooks": {
     "SessionStart": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs\"",
+            "command": "\"${PLUGIN_ROOT}/scripts/run.sh\" \"${PLUGIN_ROOT}/scripts/session-start.mjs\"",
             "statusMessage": "memini: loading session context"
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/user-prompt-submit.mjs\""
+            "command": "\"${PLUGIN_ROOT}/scripts/run.sh\" \"${PLUGIN_ROOT}/scripts/user-prompt-submit.mjs\""
           }
         ]
       }
@@ -27,17 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/stop.mjs\""
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/session-end.mjs\""
+            "command": "\"${PLUGIN_ROOT}/scripts/run.sh\" \"${PLUGIN_ROOT}/scripts/stop.mjs\""
           }
         ]
       }
@@ -47,29 +37,29 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.mjs\""
+            "command": "\"${PLUGIN_ROOT}/scripts/run.sh\" \"${PLUGIN_ROOT}/scripts/pre-compact.mjs\""
           }
         ]
       }
     ],
     "PreToolUse": [
       {
-        "matcher": "Edit|MultiEdit|Write|Read|Glob|Grep",
+        "matcher": "apply_patch|Edit|Write|Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-tool-use.mjs\""
+            "command": "\"${PLUGIN_ROOT}/scripts/run.sh\" \"${PLUGIN_ROOT}/scripts/pre-tool-use.mjs\""
           }
         ]
       }
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|MultiEdit|Write|Bash|NotebookEdit|Agent|Task|apply_patch|mcp__.*memini.*__memory_(recall|briefing|get)",
+        "matcher": "apply_patch|Edit|Write|Bash|mcp__.*memini.*__memory_(recall|briefing|get)",
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use.mjs\""
+            "command": "\"${PLUGIN_ROOT}/scripts/run.sh\" \"${PLUGIN_ROOT}/scripts/post-tool-use.mjs\""
           }
         ]
       }

--- a/plugin/scripts/_codex_test.mjs
+++ b/plugin/scripts/_codex_test.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const fixtures = path.join(root, "test", "fixtures", "codex");
+
+function fixture(name) {
+  return fs.readFileSync(path.join(fixtures, name), "utf8");
+}
+
+function hook(script, payload, extra = {}) {
+  const cache = fs.mkdtempSync(path.join(os.tmpdir(), "memini-codex-"));
+  return spawnSync(process.execPath, [path.join(root, "scripts", script)], {
+    input: payload,
+    encoding: "utf8",
+    cwd: root,
+    env: {
+      ...process.env,
+      PLUGIN_ROOT: root,
+      XDG_CACHE_HOME: cache,
+      MEMINI_BASE_URL: "http://127.0.0.1:1",
+      MEMINI_TIMEOUT_MS: "50",
+      MEMINI_API_KEY: "super-secret-test-token",
+      ...extra,
+    },
+  });
+}
+
+test("Codex startup and compact SessionStart use native context envelopes", () => {
+  for (const name of ["session-start-startup.json", "session-start-compact.json"]) {
+    const r = hook("session-start.mjs", fixture(name));
+    assert.equal(r.status, 0);
+    assert.ok(r.stdout, r.stderr);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.hookSpecificOutput.hookEventName, "SessionStart");
+    assert.match(out.hookSpecificOutput.additionalContext, /memini-(?:memory-directive|compact-recovery)/);
+    assert.doesNotMatch(r.stdout + r.stderr, /super-secret-test-token/);
+  }
+});
+
+test("Codex apply_patch and Bash payloads buffer without leaking secrets", () => {
+  const cache = fs.mkdtempSync(path.join(os.tmpdir(), "memini-codex-tools-"));
+  const env = { XDG_CACHE_HOME: cache };
+  for (const name of ["pre-tool-apply-patch.json", "post-tool-bash.json"]) {
+    const script = name.startsWith("pre-") ? "pre-tool-use.mjs" : "post-tool-use.mjs";
+    const r = hook(script, fixture(name), env);
+    assert.equal(r.status, 0);
+    assert.doesNotMatch(r.stdout + r.stderr, /super-secret-test-token/);
+  }
+});
+
+test("Codex prompt recall and PreCompact fail soft with valid outputs", () => {
+  const prompt = hook("user-prompt-submit.mjs", fixture("user-prompt.json"));
+  assert.equal(prompt.status, 0);
+  assert.equal(prompt.stdout, "");
+  const compact = hook("pre-compact.mjs", fixture("pre-compact.json"));
+  assert.equal(compact.status, 0);
+  assert.deepEqual(JSON.parse(compact.stdout), {});
+  assert.doesNotMatch(prompt.stderr + compact.stderr, /super-secret-test-token/);
+});
+
+test("Codex Stop ignores transcript paths and always returns valid JSON", () => {
+  const r = hook("stop.mjs", fixture("stop.json"));
+  assert.equal(r.status, 0);
+  assert.ok(r.stdout, r.stderr);
+  assert.deepEqual(JSON.parse(r.stdout), {});
+  assert.doesNotMatch(r.stdout + r.stderr, /super-secret-test-token|must\/not\/be\/read/);
+});
+
+test("Codex wiring is documented-event-only and Claude retains SessionEnd", () => {
+  const codex = JSON.parse(fs.readFileSync(path.join(root, "hooks", "hooks.json")));
+  const claude = JSON.parse(fs.readFileSync(path.join(root, "hooks", "hooks.claude.json")));
+  assert.deepEqual(Object.keys(codex.hooks).sort(), [
+    "PostToolUse", "PreCompact", "PreToolUse", "SessionStart", "Stop", "UserPromptSubmit",
+  ].sort());
+  assert.ok(claude.hooks.SessionEnd);
+  assert.match(JSON.stringify(codex), /PLUGIN_ROOT/);
+});
+
+test("all nine skills are installed with required safety invariants", () => {
+  const dirs = fs.readdirSync(path.join(root, "skills")).sort();
+  assert.deepEqual(dirs, ["backfill", "doctor", "forget", "namespace", "pin", "recall", "recap", "remember", "status"]);
+  assert.match(fs.readFileSync(path.join(root, "skills", "forget", "SKILL.md"), "utf8"), /explicit user\s+confirmation/i);
+  assert.match(fs.readFileSync(path.join(root, "skills", "pin", "SKILL.md"), "utf8"), /existing tags plus/);
+  for (const name of ["doctor", "backfill"])
+    assert.match(fs.readFileSync(path.join(root, "skills", name, "SKILL.md"), "utf8"), /local memini binary/i);
+});

--- a/plugin/scripts/namespace.mjs
+++ b/plugin/scripts/namespace.mjs
@@ -35,6 +35,7 @@ import path from "node:path";
 const args = process.argv.slice(2).filter((a) => a !== "--");
 const cwd = process.cwd();
 const boot = readBootstrap(process.env);
+const CODEX_HOST = Boolean(process.env.PLUGIN_ROOT);
 
 // Send a JSON request to the pins endpoint. Returns { ok, status, body } or
 // throws (network/guard) so callers can render the offline message.
@@ -168,7 +169,9 @@ async function set(raw) {
     `project key:      ${entry.key || Object.values(facts)[0]}`,
     ``,
     `hooks:  active on the next invocation (session digests, turn capture, recall).`,
-    `MCP:    run /reload-plugins to apply (the headersHelper only runs on connect).`,
+    CODEX_HOST
+      ? `MCP:    start a new thread (or restart Codex) to apply the new namespace.`
+      : `MCP:    run /reload-plugins to apply (the headersHelper only runs on connect).`,
     ``,
     `The pin lives on the memini server, so it follows you across machines and`,
     `every client resolves the same namespace. It beats MEMINI_NAMESPACE.`,
@@ -209,7 +212,7 @@ async function clear() {
     `namespace pin cleared — this project resolves automatically again.`,
     ``,
     `hooks:  active on the next invocation.`,
-    `MCP:    run /reload-plugins to apply.`,
+    CODEX_HOST ? `MCP:    start a new thread (or restart Codex) to apply.` : `MCP:    run /reload-plugins to apply.`,
   ].join("\n");
 }
 

--- a/plugin/scripts/pre-compact.mjs
+++ b/plugin/scripts/pre-compact.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-// PreCompact hook. Fires right before Claude Code compacts the context window.
+// PreCompact hook. Fires right before Claude Code or Codex compacts context.
 // Distills the buffered tool events into a durable episodic checkpoint so the
 // session's work survives compaction. Unlike SessionEnd it does NOT delete the
-// buffer — the session continues after compaction and SessionEnd still writes
-// the final digest. Claude-Code-only: Codex has no compaction lifecycle event.
+// buffer — the session continues after compaction. Claude SessionEnd later
+// writes the final digest; Codex retains rolling Stop checkpoints instead.
 
 import {
   readStdin,
@@ -36,14 +36,23 @@ async function main() {
   const project = ctx.namespace;
 
   const digest = buildSessionDigest(readSessionEvents(sessionId), project);
-  if (!digest) return; // nothing buffered → no checkpoint, no noise
+  if (!digest) {
+    if (process.env.PLUGIN_ROOT) process.stdout.write("{}");
+    return;
+  }
   // session_digest off → no activity records at all. This checkpoint exists to
   // rescue the digest from a compaction, so with digests off there is nothing
   // to rescue.
-  if (!ctx.setting("session_digest").value) return;
+  if (!ctx.setting("session_digest").value) {
+    if (process.env.PLUGIN_ROOT) process.stdout.write("{}");
+    return;
+  }
   // A checkpoint tagged session_id:"unknown" shares one exclusion bucket with
   // every other unknown-id session (exact-match exclusion), so skip it.
-  if (sessionId === "unknown") return;
+  if (sessionId === "unknown") {
+    if (process.env.PLUGIN_ROOT) process.stdout.write("{}");
+    return;
+  }
 
   if (DEBUG)
     console.error(`[memini] PreCompact project=${project} session=${sessionId} events=${digest.count}`);
@@ -55,6 +64,7 @@ async function main() {
     summary: digest.summary,
     metadata: { session_id: sessionId, trigger: payload.trigger || "unknown" },
   });
+  if (process.env.PLUGIN_ROOT) process.stdout.write("{}");
 }
 
 main().catch((e) => {

--- a/plugin/scripts/session-start.mjs
+++ b/plugin/scripts/session-start.mjs
@@ -40,6 +40,19 @@ import {
   COMPACT_RECOVERY_DIRECTIVE,
   DEBUG,
 } from "./_shared.mjs";
+
+function emitContext(context) {
+  if (!context) return;
+  if (process.env.PLUGIN_ROOT) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: context },
+      }),
+    );
+  } else {
+    process.stdout.write(context);
+  }
+}
 import { readOverride, assertBearerTransportSafe } from "./_client.gen.mjs";
 
 // Buffers older than this are abandoned (crashed/killed sessions) and removed.
@@ -303,7 +316,7 @@ async function main() {
     const note = b
       ? `<memini-context project="${project}" read-only>(no stored memories yet for this project)</memini-context>`
       : "";
-    if (note || directive) process.stdout.write(note + directive);
+    emitContext(note + directive);
     return;
   }
 
@@ -324,7 +337,7 @@ async function main() {
     // Skip the unchanged briefing; the directive var already encodes what this
     // fire source owes the context (nothing on resume — the transcript replay
     // carries the original injection — a fresh directive on clear).
-    if (directive) process.stdout.write(directive);
+    emitContext(directive);
     // Telemetry beacon AFTER the stdout payload: the whole briefing was
     // withheld as unchanged, so report the item count and no injected ids.
     // Best-effort and awaited — see postInjected.
@@ -386,7 +399,7 @@ async function main() {
   // be emitted, or a session with only blank-content memories is silently told
   // nothing to save.
   if (blocks.length === 0) {
-    if (directive) process.stdout.write(directive);
+    emitContext(directive);
     return;
   }
 
@@ -495,9 +508,10 @@ async function main() {
     writeInjectedState(sessionId, injectedState);
   }
 
-  // Both Claude Code and Codex interpret stdout as additional context.
+  // Use the host-native Codex envelope. Claude Code continues to receive the
+  // plain stdout format it has always consumed.
   const emitted = lines.join("\n");
-  process.stdout.write(emitted);
+  emitContext(emitted);
   if (DEBUG) {
     console.error(
       `[memini] SessionStart injected ${lines.length - 2} lines ` +

--- a/plugin/scripts/stop.mjs
+++ b/plugin/scripts/stop.mjs
@@ -139,6 +139,7 @@ async function captureTurn(payload, sessionId, project, ctx) {
 
 async function main() {
   const payload = parseJSON(await readStdin()) || {};
+  const codexHost = Boolean(process.env.PLUGIN_ROOT);
   const sessionId = payload.session_id || payload.sessionId || "unknown";
   // A server write tagged session_id:"unknown" shares one exclusion bucket
   // with every other unknown-id session (pre-tool-use excludes by exact
@@ -183,7 +184,7 @@ async function main() {
   // for <memory> blocks in the reply text. New sessions save via the memory_remember
   // MCP tool directly; any block that still shows up here is persisted as a durable
   // semantic fact so nothing is lost.
-  if (ctx.setting("inline_extract").value && hasSessionIdentity && payload.transcript_path) {
+  if (!codexHost && ctx.setting("inline_extract").value && hasSessionIdentity && payload.transcript_path) {
     const transcript = readTranscript(payload.transcript_path);
     const assistantTexts = extractAssistantText(transcript);
     const allBlocks = [];
@@ -203,12 +204,17 @@ async function main() {
     }
   }
 
-  await captureTurn(payload, sessionId, project, ctx);
+  // Codex transcript storage is intentionally not part of its stable hook
+  // contract. Do not parse transcript_path even if an experimental build sends
+  // one; Codex retains rolling activity checkpoints without transcript capture.
+  if (!codexHost) await captureTurn(payload, sessionId, project, ctx);
 
-  const reason = autoSaveReasonFor(payload, sessionId, project, ctx);
+  const reason = codexHost ? null : autoSaveReasonFor(payload, sessionId, project, ctx);
   if (reason) process.stdout.write(JSON.stringify({ decision: "block", reason }));
+  else if (codexHost) process.stdout.write("{}");
 }
 
 main().catch((e) => {
   if (DEBUG) console.error("[memini] Stop error:", e);
+  if (process.env.PLUGIN_ROOT) process.stdout.write("{}");
 });

--- a/plugin/skills/backfill/SKILL.md
+++ b/plugin/skills/backfill/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: backfill
+description: Import older Claude Code sessions into memini. Requires the local memini binary.
+---
+
+# backfill (memini)
+
+First verify `memini` is available on `PATH`. If it is missing, say this
+workflow requires the local binary.
+
+Preview before writing:
+
+```sh
+memini import --source claude-code --dry-run ~/.claude/projects
+```
+
+After showing the preview, run the import only when the user asked to perform
+the backfill. The importer reconstructs exchanges, assigns project namespaces,
+and uses deterministic ids, so reruns are idempotent. Report the per-namespace
+histogram. If only one project is wanted, use that project's transcript
+directory instead.

--- a/plugin/skills/doctor/SKILL.md
+++ b/plugin/skills/doctor/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: doctor
+description: Run read-only memini store and namespace diagnostics. Requires the local memini binary.
+---
+
+# doctor (memini)
+
+First verify `memini` is available on `PATH`. If not, say this workflow requires
+the local memini binary and point the user to the repository installation docs.
+Do not substitute an MCP call.
+
+Run `memini doctor` and explain its namespace, read-set, store-health, and
+warning output. `memini doctor` is read-only. Do not run `--fix --yes` without
+separate explicit authorization; `--fix` alone is only a preview.

--- a/plugin/skills/forget/SKILL.md
+++ b/plugin/skills/forget/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: forget
+description: Delete a specific memini memory safely. Use when the user asks to forget, remove, or permanently delete stored memory.
+---
+
+# forget (memini)
+
+Find the target first with `memory_get` when given an id, or `memory_recall`
+when given a description. Copy the returned `namespace` verbatim.
+
+Before deletion, show the full memory content and obtain explicit user
+confirmation. Never delete more than one memory per confirmation, and never
+guess between multiple candidates. Only after confirmation call
+`memory_forget` with the id and returned namespace.
+
+Prefer `memory_update` when the fact is merely wrong or outdated because it
+preserves history. After deletion, say that the memory is permanently removed
+from memini and may still remain in the current chat transcript.

--- a/plugin/skills/namespace/SKILL.md
+++ b/plugin/skills/namespace/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: namespace
+description: Show, set, clear, or migrate memini namespace pins with provenance. Use when project memories resolve to the wrong namespace.
+---
+
+# namespace (memini)
+
+Resolve this skill's directory and run:
+
+```sh
+"<skill-directory>/../../scripts/run.sh" "<skill-directory>/../../scripts/namespace.mjs" <arguments>
+```
+
+No arguments shows the namespace and provenance. A namespace argument pins this
+project server-side; `--clear` removes its pin; `--migrate` migrates legacy
+overrides. Pins require a reachable server and beat `MEMINI_NAMESPACE`.
+
+After setting or clearing a pin, explain that hooks pick it up on their next
+invocation. Codex MCP configuration is established for a thread, so tell the
+user to start a new thread (or restart Codex) before using `memory_*` tools with
+the new namespace.

--- a/plugin/skills/pin/SKILL.md
+++ b/plugin/skills/pin/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: pin
+description: Pin or unpin a memini memory while preserving its existing tags. Use when the user wants a memory in every briefing.
+---
+
+# pin (memini)
+
+Locate the memory with `memory_get` or `memory_recall` and copy its id and
+namespace verbatim. Read its current tags: `memory_update` replaces rather than
+merges the tag list.
+
+To pin, call `memory_update` with the existing tags plus `pinned`, preserving
+order and avoiding duplicates. To unpin, pass the existing tags minus `pinned`.
+If several candidates match, ask the user which one. Report the updated memory.
+
+Pins are exempt from retro-tiering demotion, but not confidence decay or the
+briefing token/item budget. Warn when the pinned set is becoming large.

--- a/plugin/skills/status/SKILL.md
+++ b/plugin/skills/status/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: status
+description: Show memini connection health, effective settings, namespace provenance, and read set. Use for configuration or recall diagnostics.
+---
+
+# status (memini)
+
+Resolve this skill's directory, then run its bundled script without assuming a
+global plugin path:
+
+```sh
+"<skill-directory>/../../scripts/run.sh" "<skill-directory>/../../scripts/status.mjs"
+```
+
+Pass `--json` when machine-readable output is requested. This command is
+read-only and redacts secrets. Lead with the effective namespace and warnings;
+explain degraded mode, a global `MEMINI_NAMESPACE` pin, and cwd split-brain in
+plain language.

--- a/plugin/test/fixtures/codex/post-tool-bash.json
+++ b/plugin/test/fixtures/codex/post-tool-bash.json
@@ -1,0 +1,9 @@
+{
+  "session_id": "codex-tools",
+  "cwd": ".",
+  "turn_id": "turn-tools",
+  "tool_name": "Bash",
+  "tool_use_id": "tool-bash",
+  "tool_input": { "command": "go test ./..." },
+  "tool_response": { "output": "ok" }
+}

--- a/plugin/test/fixtures/codex/pre-compact.json
+++ b/plugin/test/fixtures/codex/pre-compact.json
@@ -1,0 +1,1 @@
+{ "session_id": "codex-tools", "cwd": ".", "turn_id": "turn-compact", "trigger": "auto" }

--- a/plugin/test/fixtures/codex/pre-tool-apply-patch.json
+++ b/plugin/test/fixtures/codex/pre-tool-apply-patch.json
@@ -1,0 +1,10 @@
+{
+  "session_id": "codex-tools",
+  "cwd": ".",
+  "turn_id": "turn-tools",
+  "tool_name": "apply_patch",
+  "tool_use_id": "tool-patch",
+  "tool_input": {
+    "command": "*** Begin Patch\n*** Update File: auth.go\n@@\n-old\n+new\n*** End Patch"
+  }
+}

--- a/plugin/test/fixtures/codex/session-start-compact.json
+++ b/plugin/test/fixtures/codex/session-start-compact.json
@@ -1,0 +1,1 @@
+{ "session_id": "codex-compact", "cwd": ".", "source": "compact", "turn_id": "turn-compact" }

--- a/plugin/test/fixtures/codex/session-start-startup.json
+++ b/plugin/test/fixtures/codex/session-start-startup.json
@@ -1,0 +1,1 @@
+{ "session_id": "codex-start", "cwd": ".", "source": "startup" }

--- a/plugin/test/fixtures/codex/stop.json
+++ b/plugin/test/fixtures/codex/stop.json
@@ -1,0 +1,8 @@
+{
+  "session_id": "codex-tools",
+  "cwd": ".",
+  "turn_id": "turn-stop",
+  "stop_hook_active": false,
+  "last_assistant_message": "Implemented and verified the change.",
+  "transcript_path": "/must/not/be/read/codex.jsonl"
+}

--- a/plugin/test/fixtures/codex/user-prompt.json
+++ b/plugin/test/fixtures/codex/user-prompt.json
@@ -1,0 +1,6 @@
+{
+  "session_id": "codex-prompt",
+  "cwd": ".",
+  "turn_id": "turn-prompt",
+  "prompt": "What did we decide about authentication?"
+}


### PR DESCRIPTION
## Summary

Completes Memini's shared Claude Code plugin as a native, repository-distributed Codex plugin without regressing Claude behavior.

### Native Codex packaging

- expands `.codex-plugin/plugin.json` with skills, Codex MCP wiring, Developer Tools presentation metadata, capabilities, keywords, and starter prompts
- adds the repository marketplace at `.agents/plugins/marketplace.json`
- adds `.mcp.codex.json` for the default local `http://localhost:8080/mcp` server, using `MEMINI_API_KEY`, `MEMINI_NAMESPACE`, and `MEMINI_HOME`
- preserves Claude's existing `.mcp.json` and release-controlled version (`0.7.12`)

### Host-specific lifecycle behavior

- moves the full Claude event set to `hooks/hooks.claude.json` and references it explicitly from the Claude manifest
- makes `hooks/hooks.json` Codex-native, using `${PLUGIN_ROOT}` and only documented Codex events
- includes Codex `Bash`, `apply_patch`, and Memini MCP matchers
- emits native Codex hook context envelopes
- keeps Stop working checkpoints and PreCompact episodic recovery
- intentionally avoids Codex transcript parsing for turn capture, inline extraction, and auto-save nudges
- leaves Claude transcript behavior and `SessionEnd` final digests intact

### Skill parity and documentation

- adds `forget`, `pin`, `status`, `namespace`, `doctor`, and `backfill` alongside `remember`, `recall`, and `recap`
- preserves explicit deletion confirmation, pin tag merging, and namespace provenance
- resolves bundled scripts relative to each skill and requires the local binary only for doctor/backfill
- documents marketplace install, hook trust, environment variables, local server setup, verification, remote URL override, updates, new-thread activation, and stable parity limits

## Verification

- `node plugin/scripts/_test.mjs` — 215/215 passing
- `node plugin/scripts/_codex_test.mjs` — 6/6 passing
- `claude plugin validate plugin` — passing
- all nine skills pass `quick_validate.py`
- all JSON files parse successfully
- isolated `CODEX_HOME` marketplace add/install — plugin installed and enabled as `memini@memini` version `0.7.12`; installed cache includes nine skills, Codex MCP config, and native hooks
- `go test ./...` — passing
- pre-commit formatting and pre-push test/bench hooks — passing

## Validator note

The bundled `plugin-creator` validator currently hard-codes `mcpServers` to the filename `.mcp.json` and then validates that file as Codex MCP config. This repository intentionally preserves Claude's `.mcp.json` and points Codex at `.mcp.codex.json`, as required for the host split. The actual Codex CLI accepts and installs this manifest successfully in an isolated home.

## Stable parity limits

Codex has no reliable final-session equivalent to Claude's `SessionEnd`, and its main-session transcript is not a stable hook contract. Codex therefore uses rolling Stop/PreCompact checkpoints but does not perform transcript-dependent turn capture, legacy inline extraction, or auto-save nudges.
