### PR TITLE
feat(auth): add read-only API keys

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -723,7 +723,7 @@ paths:
     get:
       operationId: listApiKeys
       tags: [memory]
-      summary: List API keys (name/home/default namespace/created/disabled/admin/source — never a secret or hash)
+      summary: List API keys (name/home/default namespace/created/disabled/admin/read_only/source — never a secret or hash)
       description: >
         Admin-gated: allowed for the admin env key (MEMINI_API_KEY), a named
         key with admin=true, or dev/bootstrap mode (auth disabled entirely —
@@ -777,7 +777,7 @@ paths:
     patch:
       operationId: updateApiKey
       tags: [memory]
-      summary: Update an API key's home namespace, default namespace, disabled state, admin capability, and/or per-key settings
+      summary: Update an API key's home namespace, default namespace, disabled state, admin capability, read-only capability, and/or per-key settings
       description: >
         Admin-gated, see listApiKeys. Preserve-unspecified semantics matching
         `memini key add`'s rotation contract: an omitted field leaves the
@@ -2100,7 +2100,7 @@ components:
         delete all reject a "file" key with 409.
     ApiKey:
       type: object
-      required: [name, disabled, admin, source]
+      required: [name, disabled, admin, read_only, source]
       properties:
         name: { type: string }
         home:
@@ -2127,6 +2127,16 @@ components:
             exactly like the admin env key (MEMINI_API_KEY). A self-guard
             still applies — an admin key cannot demote, disable, or delete
             itself over this API.
+        read_only:
+          type: boolean
+          description: >
+            Whether this key is a read-only credential: it may issue reads
+            (GET/HEAD, plus the read-shaped POSTs /v1/search, /v1/answer and
+            /v1/handshake) and every mutating request is refused with 403,
+            across both the REST and MCP surfaces. Independent of admin — an
+            admin key that is also read_only may enumerate keys but not change
+            them. Note this bounds what the key may CHANGE, not what it may
+            SEE: a read-only key can still name any namespace and read it.
         source: { $ref: "#/components/schemas/ApiKeySource" }
         settings:
           allOf:
@@ -2169,6 +2179,12 @@ components:
           description: >
             Create the key as an admin credential (see ApiKey.admin). Defaults
             to false — a plain key that cannot reach the admin-gated surfaces.
+        read_only:
+          type: boolean
+          default: false
+          description: >
+            Create the key as a read-only credential (see ApiKey.read_only).
+            Defaults to false — a key that may write.
     UpdateApiKeyRequest:
       type: object
       properties:
@@ -2192,6 +2208,15 @@ components:
             true, revoke it with false. A named admin key cannot revoke its own
             admin (admin=false targeting the key that authenticated the request)
             — that returns 409; use the admin env key or another admin key.
+        read_only:
+          type: boolean
+          description: >
+            Omit to leave the current read-only capability unchanged; impose it
+            with true, lift it with false. A named key cannot impose read_only
+            on itself (read_only=true targeting the key that authenticated the
+            request) — that returns 409, because a read-only credential can no
+            longer reach this endpoint to undo it; use the admin env key,
+            another admin key, or the CLI.
         settings:
           allOf:
             - $ref: "#/components/schemas/ClientSettings"
@@ -2201,7 +2226,7 @@ components:
             within it continue to inherit the server's global defaults).
     CallerIdentity:
       type: object
-      required: [authenticated, admin]
+      required: [authenticated, admin, read_only]
       description: Who the request authenticated as, independent of any resolved namespace.
       properties:
         authenticated: { type: boolean }
@@ -2212,6 +2237,14 @@ components:
             with no auth configured, and a named key with admin=true. When
             true the caller may reach the admin-gated surfaces (/v1/keys CRUD
             and /v1/settings/defaults); when false those return 403.
+        read_only:
+          type: boolean
+          description: >
+            Effective read-only capability: true only for a named key with
+            read_only=true. False for the admin env key and dev mode, which
+            authenticate with no named principal and so carry no capability
+            bits. When true, every mutating request is refused with 403 —
+            clients should skip writes rather than attempt and log them.
         key_name:
           type: string
           description: >

--- a/charts/memini/values.yaml
+++ b/charts/memini/values.yaml
@@ -206,6 +206,12 @@ controllers:
   # loaded once at boot (fail-loud validation). Mount the YAML from a Secret
   # via the `persistence.api-keys` block below (it needs `enabled: true` AND
   # this env var; either one alone does nothing) and point the server at it.
+  # Give unattended agents `read_only: true` so the server refuses their every
+  # write (docs/api-keys.md#the-read-only-attribute):
+  #   keys:
+  #     - name: ci-agent
+  #       secret: "…from your secret store…"
+  #       read_only: true
   # MEMINI_API_KEYS_FILE: /etc/memini/api-keys.yaml
 
   # -- Periodic fsck CronJob. Disabled by default — the in-process sweeper

--- a/cmd/memini/key.go
+++ b/cmd/memini/key.go
@@ -20,6 +20,7 @@ var (
 	keyDefaultNS string
 	keyDisabled  bool
 	keyAdmin     bool
+	keyReadOnly  bool
 )
 
 var keyCmd = &cobra.Command{
@@ -37,11 +38,12 @@ var keyAddCmd = &cobra.Command{
 		"once to stdout — it is never stored and cannot be recovered or shown again, so " +
 		"save it now. Re-running with a name that already exists ROTATES that key: a new " +
 		"secret is generated and the old one stops authenticating immediately, while the " +
-		"key's CreatedAt, home/default namespace bindings, disabled state, and admin state " +
-		"are all preserved unless the corresponding flag is explicitly passed (an explicit " +
-		"--home \"\" clears the binding; an explicit --disabled=false re-enables a " +
-		"disabled key — rotation alone never re-enables one; an explicit --admin=false " +
-		"demotes an admin key — rotation alone never demotes one).",
+		"key's CreatedAt, home/default namespace bindings, disabled state, admin state, and " +
+		"read-only state are all preserved unless the corresponding flag is explicitly " +
+		"passed (an explicit --home \"\" clears the binding; an explicit --disabled=false " +
+		"re-enables a disabled key — rotation alone never re-enables one; an explicit " +
+		"--admin=false demotes an admin key — rotation alone never demotes one; an explicit " +
+		"--read-only=false lifts the read-only restriction — rotation alone never lifts it).",
 	Args: cobra.ExactArgs(1),
 	RunE: runKeyAdd,
 }
@@ -55,7 +57,7 @@ var keyRmCmd = &cobra.Command{
 
 var keyLsCmd = &cobra.Command{
 	Use:   "ls",
-	Short: "List API keys (name, home/default namespace, created, disabled, admin — never secrets or hashes)",
+	Short: "List API keys (name, home/default namespace, created, disabled, admin, read-only — never secrets or hashes)",
 	Args:  cobra.NoArgs,
 	RunE:  runKeyLs,
 }
@@ -68,6 +70,8 @@ func init() {
 	keyAddCmd.Flags().BoolVar(&keyDisabled, "disabled", false, "create the key already disabled")
 	keyAddCmd.Flags().BoolVar(&keyAdmin, "admin", false,
 		"grant the key admin (the /v1/keys and /v1/settings/defaults surfaces, gated at the REST layer)")
+	keyAddCmd.Flags().BoolVar(&keyReadOnly, "read-only", false,
+		"make the key read-only: it may read but every mutating request is refused, over both REST and MCP")
 
 	keyCmd.AddCommand(keyAddCmd, keyRmCmd, keyLsCmd)
 	rootCmd.AddCommand(keyCmd)
@@ -120,6 +124,7 @@ type keyAddOpts struct {
 	DefaultNS *string
 	Disabled  *bool
 	Admin     *bool
+	ReadOnly  *bool
 }
 
 // addAPIKey validates home/defaultNS, generates a fresh secret, and upserts
@@ -130,7 +135,8 @@ type keyAddOpts struct {
 // existing row — most critically Disabled: a key disabled during incident
 // response must not be silently re-enabled by a later secret rotation. Admin
 // carries forward the same way: rotating an admin key never silently demotes
-// it, and rotating a non-admin key never silently promotes it. Settings has no
+// it, and rotating a non-admin key never silently promotes it. ReadOnly likewise
+// — rotating a read-only CI credential must never quietly hand it write access. Settings has no
 // CLI flag at all, so it is ALWAYS carried forward from the existing row — the
 // store upsert overwrites settings=excluded.settings, so omitting it here would
 // wipe a key's per-key Settings on every rotation.
@@ -147,7 +153,7 @@ func addAPIKey(ctx context.Context, ks store.APIKeyStore, name string, opts keyA
 	// Looked up via ListAPIKeys + filter rather than a new by-name store
 	// method: keys are few, and the store contract stays as-is.
 	var home, defaultNS string
-	var disabled, admin bool
+	var disabled, admin, readOnly bool
 	var settings store.ClientSettings
 	existing, err := findAPIKeyByName(ctx, ks, name)
 	if err != nil {
@@ -155,6 +161,7 @@ func addAPIKey(ctx context.Context, ks store.APIKeyStore, name string, opts keyA
 	}
 	if existing != nil {
 		home, defaultNS, disabled, admin = existing.HomeNS, existing.DefaultNS, existing.Disabled, existing.Admin
+		readOnly = existing.ReadOnly
 		// Settings has no --flag here, so it is always carried forward from the
 		// existing row: the store upsert overwrites settings=excluded.settings,
 		// so leaving this at the zero value would silently wipe a key's per-key
@@ -181,6 +188,9 @@ func addAPIKey(ctx context.Context, ks store.APIKeyStore, name string, opts keyA
 	if opts.Admin != nil {
 		admin = *opts.Admin
 	}
+	if opts.ReadOnly != nil {
+		readOnly = *opts.ReadOnly
+	}
 	secret, err := generateAPIKeySecret()
 	if err != nil {
 		return "", store.APIKey{}, err
@@ -192,6 +202,7 @@ func addAPIKey(ctx context.Context, ks store.APIKeyStore, name string, opts keyA
 		DefaultNS: defaultNS,
 		Disabled:  disabled,
 		Admin:     admin,
+		ReadOnly:  readOnly,
 		Settings:  settings,
 		// CreatedAt intentionally left zero: PutAPIKey stamps "now" for a
 		// brand-new row and preserves the existing CreatedAt on rotation.
@@ -259,6 +270,9 @@ func runKeyAdd(cmd *cobra.Command, args []string) error {
 		if cmd.Flags().Changed("admin") {
 			opts.Admin = &keyAdmin
 		}
+		if cmd.Flags().Changed("read-only") {
+			opts.ReadOnly = &keyReadOnly
+		}
 		secret, key, err := addAPIKey(cmd.Context(), ks, args[0], opts)
 		if err != nil {
 			return err
@@ -313,10 +327,11 @@ func printAPIKeys(out io.Writer, keys []store.APIKey) {
 		return
 	}
 	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
-	fmt.Fprintln(tw, "NAME\tHOME\tDEFAULT NS\tCREATED\tDISABLED\tADMIN") //nolint:errcheck
+	fmt.Fprintln(tw, "NAME\tHOME\tDEFAULT NS\tCREATED\tDISABLED\tADMIN\tREAD ONLY") //nolint:errcheck
 	for _, k := range keys {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%t\t%t\n", //nolint:errcheck
-			k.Name, dashIfEmpty(k.HomeNS), dashIfEmpty(k.DefaultNS), k.CreatedAt.Format(time.RFC3339), k.Disabled, k.Admin)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%t\t%t\t%t\n", //nolint:errcheck
+			k.Name, dashIfEmpty(k.HomeNS), dashIfEmpty(k.DefaultNS), k.CreatedAt.Format(time.RFC3339),
+			k.Disabled, k.Admin, k.ReadOnly)
 	}
 	_ = tw.Flush()
 }

--- a/cmd/memini/key_readonly_test.go
+++ b/cmd/memini/key_readonly_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestAddAPIKeyReadOnlyFlag: `memini key add <name> --read-only` mints a
+// credential that cannot write. This is how a CI credential is provisioned when
+// the server's api_keys table is the source of truth (the declarative
+// MEMINI_API_KEYS_FILE path is covered in internal/apiauth).
+func TestAddAPIKeyReadOnlyFlag(t *testing.T) {
+	st := openTestStore(t)
+	ks, err := keyStoreOf(st)
+	if err != nil {
+		t.Fatalf("keyStoreOf: %v", err)
+	}
+	_, key, err := addAPIKey(context.Background(), ks, "ci-frank", keyAddOpts{ReadOnly: new(true)})
+	if err != nil {
+		t.Fatalf("addAPIKey: %v", err)
+	}
+	if !key.ReadOnly {
+		t.Fatal("expected key to be created with ReadOnly=true")
+	}
+}
+
+func TestAddAPIKeyReadOnlyDefaultsFalse(t *testing.T) {
+	st := openTestStore(t)
+	ks, err := keyStoreOf(st)
+	if err != nil {
+		t.Fatalf("keyStoreOf: %v", err)
+	}
+	_, key, err := addAPIKey(context.Background(), ks, "plain-frank-ro", keyAddOpts{})
+	if err != nil {
+		t.Fatalf("addAPIKey: %v", err)
+	}
+	if key.ReadOnly {
+		t.Fatal("expected key to default to ReadOnly=false when --read-only is not passed")
+	}
+}
+
+// TestAddAPIKeyRotationPreservesReadOnly pins the contract that matters most
+// operationally: rotating a CI credential's secret must not quietly hand it
+// write access back.
+func TestAddAPIKeyRotationPreservesReadOnly(t *testing.T) {
+	st := openTestStore(t)
+	ks, err := keyStoreOf(st)
+	if err != nil {
+		t.Fatalf("keyStoreOf: %v", err)
+	}
+	ctx := context.Background()
+
+	if _, _, err := addAPIKey(ctx, ks, "ci-ivy", keyAddOpts{ReadOnly: new(true)}); err != nil {
+		t.Fatalf("addAPIKey: %v", err)
+	}
+	_, rotated, err := addAPIKey(ctx, ks, "ci-ivy", keyAddOpts{})
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if !rotated.ReadOnly {
+		t.Error("rotation must preserve ReadOnly, got false")
+	}
+}
+
+// TestAddAPIKeyRotationExplicitClearsReadOnly: stated operator intent wins,
+// mirroring --admin=false and --disabled=false.
+func TestAddAPIKeyRotationExplicitClearsReadOnly(t *testing.T) {
+	st := openTestStore(t)
+	ks, err := keyStoreOf(st)
+	if err != nil {
+		t.Fatalf("keyStoreOf: %v", err)
+	}
+	ctx := context.Background()
+
+	if _, _, err := addAPIKey(ctx, ks, "ci-kim", keyAddOpts{ReadOnly: new(true)}); err != nil {
+		t.Fatalf("addAPIKey: %v", err)
+	}
+	_, rotated, err := addAPIKey(ctx, ks, "ci-kim", keyAddOpts{ReadOnly: new(false)})
+	if err != nil {
+		t.Fatalf("rotate with explicit --read-only=false: %v", err)
+	}
+	if rotated.ReadOnly {
+		t.Error("explicit --read-only=false must lift the restriction")
+	}
+}
+
+// TestAddAPIKeyReadOnlyIndependentOfAdmin: the two capabilities compose, so a
+// CLI-minted admin+read-only auditor is expressible.
+func TestAddAPIKeyReadOnlyIndependentOfAdmin(t *testing.T) {
+	st := openTestStore(t)
+	ks, err := keyStoreOf(st)
+	if err != nil {
+		t.Fatalf("keyStoreOf: %v", err)
+	}
+	_, key, err := addAPIKey(context.Background(), ks, "auditor",
+		keyAddOpts{Admin: new(true), ReadOnly: new(true)})
+	if err != nil {
+		t.Fatalf("addAPIKey: %v", err)
+	}
+	if !key.Admin || !key.ReadOnly {
+		t.Fatalf("want Admin=true ReadOnly=true, got Admin=%v ReadOnly=%v", key.Admin, key.ReadOnly)
+	}
+}
+
+// TestPrintAPIKeysTableShowsReadOnlyColumn: `memini key ls` must show which
+// keys are read-only, or an operator cannot audit them from the CLI.
+func TestPrintAPIKeysTableShowsReadOnlyColumn(t *testing.T) {
+	st := openTestStore(t)
+	ks, err := keyStoreOf(st)
+	if err != nil {
+		t.Fatalf("keyStoreOf: %v", err)
+	}
+	ctx := context.Background()
+	if _, _, err := addAPIKey(ctx, ks, "ci-list", keyAddOpts{ReadOnly: new(true)}); err != nil {
+		t.Fatalf("addAPIKey: %v", err)
+	}
+	if _, _, err := addAPIKey(ctx, ks, "rw-list", keyAddOpts{}); err != nil {
+		t.Fatalf("addAPIKey: %v", err)
+	}
+	keys, err := ks.ListAPIKeys(ctx)
+	if err != nil {
+		t.Fatalf("ListAPIKeys: %v", err)
+	}
+	var buf bytes.Buffer
+	printAPIKeys(&buf, keys)
+	out := buf.String()
+	if !strings.Contains(out, "READ ONLY") {
+		t.Fatalf("key ls header must carry a READ ONLY column, got:\n%s", out)
+	}
+	for line := range strings.SplitSeq(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		switch fields[0] {
+		case "ci-list":
+			if !strings.HasSuffix(strings.TrimSpace(line), "true") {
+				t.Errorf("ci-list row must end with read-only true, got %q", line)
+			}
+		case "rw-list":
+			if !strings.HasSuffix(strings.TrimSpace(line), "false") {
+				t.Errorf("rw-list row must end with read-only false, got %q", line)
+			}
+		}
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,8 +35,10 @@ Read these when you want to know why memini behaves the way it does.
   page to read if recall is returning too much or too little.
 - [**Categories**](categories.md). An orthogonal topic axis, for filtering by
   what a memory is about rather than how durable it is.
-- [**API keys**](api-keys.md). Keys are identity, not authorization. Each key can
-  carry its own home and default namespace.
+- [**API keys**](api-keys.md). Keys are identity, not isolation: any key can read
+  any namespace. Each carries its own home and default namespace, plus two narrow
+  authorization bits — `admin` (manage keys and server defaults) and `read_only`
+  (refuse every write, for unattended agents).
 
 ## Guides
 

--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -3,47 +3,63 @@
 memini supports multiple named API keys, each optionally bound to a **home**
 namespace (identity) and a **default** namespace (context), instead of a
 single shared bearer token. This doc covers what a key is, the **admin
-attribute** that gates key management, how the two namespace bindings differ,
-the secret lifecycle, the declarative file format, bootstrap and lockout
-behavior, and attribution. If you are setting up a team from scratch, the
-task-oriented [access control guide](guides/access-control.md) walks the whole
-thing end to end; this page is the reference it builds on. It's orthogonal to
+attribute** that gates key management, the **read-only attribute** that refuses
+every write, how the two namespace bindings differ, the secret lifecycle, the
+declarative file format, bootstrap and lockout behavior, and attribution. If you
+are setting up a team from scratch, the task-oriented
+[access control guide](guides/access-control.md) walks the whole thing end to
+end; this page is the reference it builds on. It's orthogonal to
 [scopes.md](scopes.md) (how a namespace's read set is composed once a
 request's namespace/home are resolved — a key's bindings are one of the
 inputs to that resolution) and to [tiers.md](tiers.md) (what a memory's tier
 means, unaffected by which key wrote it).
 
-## Keys are identity, not authorization
+## Keys are identity, not isolation
 
 A memini API key answers "who is this caller" (a name, plus optional home and
-default namespace bindings) — it does **not** scope what that caller can read
-or write. Any valid key — admin, named, or file-sourced — can read or write
-any namespace, the same as the single shared `MEMINI_API_KEY` token always
-could. Binding a key to a home namespace makes memini use that namespace by
-default for `visibility:"personal"` writes and the read cascade's home leg;
-it is a convenience default, not a fence. If you need hard namespace
-isolation between teams, that's a deployment-topology decision (separate
-memini instances/stores), not something an API key's bindings enforce.
+default namespace bindings) — it does **not** scope which namespaces that caller
+can reach. Any valid key — admin, named, or file-sourced — can read **any**
+namespace, the same as the single shared `MEMINI_API_KEY` token always could.
+Binding a key to a home namespace makes memini use that namespace by default for
+`visibility:"personal"` writes and the read cascade's home leg; it is a
+convenience default, not a fence. If you need hard namespace isolation between
+teams, that's a deployment-topology decision (separate memini instances/stores),
+not something an API key's bindings enforce.
 
-There is exactly one authorization bit a key carries, and it is deliberately
-narrow: the **admin attribute**. It gates key management (`/v1/keys` CRUD) and
-the server-wide settings defaults (`/v1/settings/defaults`), and nothing else.
-An admin key reads and writes namespaces on exactly the same terms as any other
-key; a non-admin key is blocked only from those two surfaces. See
-[The admin attribute](#the-admin-attribute) below for the full model.
+A key carries exactly **two** authorization bits, both deliberately narrow, and
+both orthogonal to the namespace bindings above:
+
+| Bit         | What it changes                                                                                                             | Default |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `admin`     | Unlocks key management (`/v1/keys` CRUD) and the server-wide settings defaults (`/v1/settings/defaults`), and nothing else. | `false` |
+| `read_only` | Refuses **every** mutating request, across both the REST and MCP surfaces. Reads are untouched.                             | `false` |
+
+They are independent, and the combination is meaningful: an `admin` +
+`read_only` key is an auditor who can enumerate keys and inspect server defaults
+but change neither. See [The admin attribute](#the-admin-attribute) and
+[The read-only attribute](#the-read-only-attribute) for the full models.
+
+> [!WARNING]
+> `read_only` bounds what a key can **change**, not what it can **see**. A
+> read-only key can still send any `X-Memini-Namespace` it likes and read every
+> namespace on the server. For an unattended agent running against an untrusted
+> branch, that reading surface is the thing to think about — read-only removes
+> the risk of it corrupting your memory, not the risk of it seeing something.
+> Restricting what a credential can read is a deployment-topology decision, the
+> same as team isolation above.
 
 ## Three kinds of key
 
 A credential comes from one of three **sources**. The source decides how a key
-is created and whether it can change at runtime. Whether a key is an **admin**
-(the next section) is a separate attribute, orthogonal to its source: a named
-key or a file key can be an admin, and the env key always is.
+is created and whether it can change at runtime. The two authorization bits are
+separate attributes, orthogonal to the source: a named key or a file key can be
+an admin and/or read-only, and the env key is always admin and never read-only.
 
-| Kind              | Configured via                                                     | Mutable via API/CLI?                                    | Admin?                   | Typical use                                                                   |
-| ----------------- | ------------------------------------------------------------------ | ------------------------------------------------------- | ------------------------ | ----------------------------------------------------------------------------- |
-| Env (break-glass) | `MEMINI_API_KEY` env var                                           | n/a (one shared value)                                  | Always                   | The operator's always-on recovery credential; authenticates with no principal |
-| Named             | `memini key add` / `POST /v1/keys`, stored in the `api_keys` table | Yes: add/rotate/disable/delete, plus grant/revoke admin | Optional (`--admin`)     | Per-person or per-integration credentials, imperatively managed               |
-| File              | `MEMINI_API_KEYS_FILE` (declarative YAML), loaded once at boot     | No: immutable via the API; edit the file and restart    | Optional (`admin: true`) | GitOps-managed fleets, SOPS-encrypted secrets                                 |
+| Kind              | Configured via                                                     | Mutable via API/CLI?                                 | Admin?                   | Read-only?                   | Typical use                                                                   |
+| ----------------- | ------------------------------------------------------------------ | ---------------------------------------------------- | ------------------------ | ---------------------------- | ----------------------------------------------------------------------------- |
+| Env (break-glass) | `MEMINI_API_KEY` env var                                           | n/a (one shared value)                               | Always                   | Never                        | The operator's always-on recovery credential; authenticates with no principal |
+| Named             | `memini key add` / `POST /v1/keys`, stored in the `api_keys` table | Yes: add/rotate/disable/delete, plus flip either bit | Optional (`--admin`)     | Optional (`--read-only`)     | Per-person or per-integration credentials, imperatively managed               |
+| File              | `MEMINI_API_KEYS_FILE` (declarative YAML), loaded once at boot     | No: immutable via the API; edit the file and restart | Optional (`admin: true`) | Optional (`read_only: true`) | GitOps-managed fleets, SOPS-encrypted secrets                                 |
 
 The env key is no longer the _only_ credential that can manage other keys: any
 key with the admin attribute can. It stays special in one way that earns the
@@ -86,7 +102,8 @@ That string is deliberately different from the old `"admin key required"` so any
 out-of-tree tooling that matched the previous text fails loudly rather than
 silently mis-classifying a response. Nothing else changes for a non-admin key:
 it still reads and writes any namespace exactly as before (a key is
-[identity, not authorization](#keys-are-identity-not-authorization)).
+[identity, not isolation](#keys-are-identity-not-isolation)), unless it also
+carries [read_only](#the-read-only-attribute).
 
 ### Checking whether the current key is an admin
 
@@ -375,6 +392,142 @@ or verbose `/healthz` with its own bearer. If you run named admins and want
 key for the scraper to use. The verbose `/healthz` detail is likewise an
 operator-only view, not something a per-person admin key is meant to unlock.
 
+## The read-only attribute
+
+Every key is either **read-only** or it is not. Read-only is a boolean the server
+tracks per key (`store.APIKey.ReadOnly`, `ApiKey.read_only` on the wire), and it
+refuses every mutating request the key makes — on **both** HTTP surfaces, REST
+and MCP. Reads are entirely untouched.
+
+The case it exists for is an unattended agent: a CI job's LLM that should recall
+project context but must never write, mutate, or delete a memory. A bad write
+from a CI run is invisible until it poisons someone's recall weeks later, and
+nobody is watching the job when it happens.
+
+```console
+$ memini key add ci-agent --read-only
+Secret (save this now — it is not stored and cannot be shown again):
+7f3c…
+
+NAME      HOME  DEFAULT NS  CREATED               DISABLED  ADMIN  READ ONLY
+ci-agent  -     -           2026-07-26T22:17:29Z  false     false  true
+```
+
+A refused write returns a verbatim `403`:
+
+```json
+{
+  "error": "read-only credential: API key \"ci-agent\" has read_only=true and cannot perform mutating requests"
+}
+```
+
+### What counts as a read
+
+The gate is an **allowlist**, not a denylist. A read-only key may issue:
+
+- every `GET` and `HEAD`;
+- `POST /v1/search` and `POST /v1/answer` — queries that need a request body, so
+  they are POSTs despite mutating nothing (`/v1/answer` spends LLM tokens, but
+  spending tokens is not mutating stored state);
+- `POST /v1/handshake` — deliberately side-effect-free, and the call every client
+  makes to resolve its namespace before doing anything else. Denying it would
+  make a read-only credential unusable rather than merely unprivileged.
+
+Everything else is a write, **including any endpoint added in a future version**.
+That is the point of an allowlist: a new mutating endpoint is refused until
+someone consciously classifies it, so forgetting over-restricts (a loud 403)
+instead of silently granting write access. A spec-derived test enforces the
+classification in CI.
+
+Two consequences worth knowing:
+
+- **Dry runs are writes.** `POST /v1/namespaces/move` and `/split` are refused
+  even with `dry_run: true` — the preview posts to the mutating endpoint, so a
+  read-only key cannot preview a move either.
+- **`PUT /v1/self/settings` is a write.** A read-only key cannot change its own
+  per-key behavior settings. An admin has to do it for it.
+
+### Reads still leave a trace
+
+Serving a read still bumps the memory's access counters (`store.Reinforce`,
+which feeds ranking and episodic→durable promotion) and still appends to the
+activity log. That is internal relevance bookkeeping, not caller-facing
+mutation: **read-only bounds what the caller can change, not whether serving a
+read leaves a trace.** A read-only agent's recalls still make the memories it
+uses rank better, which is usually what you want.
+
+### On the MCP surface
+
+MCP is served on the same auth path, so the same credential behaves the same
+way. The write tools — `memory_remember`, `memory_update`, `memory_forget` —
+stay **listed** for a read-only session and are refused when called, with an
+error result the agent can read:
+
+```text
+read-only credential: this API key has read_only=true and cannot call
+"memory_remember", which modifies stored memories. Do not retry — reads
+(memory_recall, memory_briefing, memory_get, memory_list, memory_history)
+still work.
+```
+
+The refusal is an error tool _result_, not a protocol error, precisely so the
+model sees it as output and stops retrying rather than treating it as a
+transient failure.
+
+### Clients skip writes rather than collecting 403s
+
+`GET /v1/self` and `POST /v1/handshake` both report `identity.read_only`, so a
+client learns the capability in the one call it already makes. The bundled
+Claude Code / Codex plugin uses it to **skip** its capture and telemetry writes
+outright. Without that, an unattended agent posts a capture every turn, eats a
+403, and logs it to stderr forever — which reads to an operator as "memory is
+broken" rather than "this key cannot write".
+
+An older server omits the field. Clients must read absent as **writable**, never
+as "skip", or they silently stop saving against a server that predates it.
+
+### The self-guard
+
+A named key cannot make **itself** read-only — `PATCH /v1/keys/<its own name>`
+with `read_only: true` returns `409`:
+
+```json
+{
+  "error": "api key \"robin\" cannot make itself read-only; a read-only credential cannot reach this endpoint to undo it, so use the admin env key (MEMINI_API_KEY), another admin key, or `memini key add robin --read-only`"
+}
+```
+
+This is stricter than the admin self-demote guard for a reason: once the flag is
+set, the read-only gate refuses `/v1/keys` itself, so the key could never lift
+it. Going the other way — clearing `read_only` on itself — is allowed, because
+that direction is a restoration and is only reachable while the key is still
+writable.
+
+The env key and dev mode have no principal, so "self" never matches them; they
+are the escape hatch this points back at.
+
+### Rotation preserves it
+
+`memini key add <existing-name> --read-only` is not needed on a rotation: an
+omitted `--read-only` carries the stored value forward, exactly like `--admin`
+and `--disabled`. Rotating a CI credential's secret never quietly hands it write
+access back. Pass `--read-only=false` explicitly to lift the restriction.
+
+### Read-only does not imply non-admin
+
+The two bits are independent. `--admin --read-only` mints an auditor: it can
+`GET /v1/keys` and `GET /v1/settings/defaults`, and it can change neither. In the
+admin UI that session gets a persistent `read-only` chip and every write control
+disabled.
+
+### The grant/revoke activity event
+
+Imposing or lifting `read_only` writes a `settings` activity event carrying
+`{key_name, read_only}`, so the feed answers "when did this credential stop being
+able to write, and who did it". Deleting a read-only key deliberately writes
+nothing: that removes a restriction from a credential that no longer exists, so a
+`read_only: false` event would read as the opposite of what happened.
+
 ## Home binding vs default namespace: identity vs context
 
 Two fields can be set per key — `home` and `default_namespace` — and they
@@ -492,6 +645,13 @@ keys:
     secret: "correct-horse-battery-staple"
     disabled: false
 
+  # A read-only credential: it can recall everything it could before, and the
+  # server refuses its every write. This is the shape to hand an unattended
+  # agent — a CI job's LLM that should read project context but never change it.
+  - name: ci-agent
+    secret: "another-secret-from-your-secret-store"
+    read_only: true
+
   # disabled: true keeps a name+entry around (e.g. mid-rotation) without it
   # authenticating anything.
   - name: retired-bot
@@ -586,6 +746,8 @@ REST and MCP write paths.
 | `home` (per-key)              | unbound | The key's bound personal namespace — identity, overrides `X-Memini-Home`. See [Home binding vs default namespace](#home-binding-vs-default-namespace-identity-vs-context).                                                                                                                                                                                                                                                               |
 | `default_namespace` (per-key) | unset   | The namespace applied when the request sends no `X-Memini-Namespace` header — context, the header always wins. Same section as above.                                                                                                                                                                                                                                                                                                    |
 | `disabled` (per-key)          | `false` | Rejects the key outright at auth time without deleting it (e.g. incident response, mid-rotation holding pattern).                                                                                                                                                                                                                                                                                                                        |
+| `admin` (per-key)             | `false` | Unlocks `/v1/keys` CRUD and `/v1/settings/defaults`. See [The admin attribute](#the-admin-attribute).                                                                                                                                                                                                                                                                                                                                    |
+| `read_only` (per-key)         | `false` | Refuses every mutating request across REST and MCP; reads are untouched. See [The read-only attribute](#the-read-only-attribute).                                                                                                                                                                                                                                                                                                        |
 
 ## Revocation lag
 

--- a/docs/guides/access-control.md
+++ b/docs/guides/access-control.md
@@ -130,8 +130,9 @@ $ memini key add reviewer-bot --default-namespace acme/phoenix
 ```
 
 A non-admin key is still a full read/write credential for any namespace (a key
-is [identity, not authorization](../api-keys.md#keys-are-identity-not-authorization)).
-What it cannot do is manage other keys. If it tries, it gets a verbatim `403`:
+is [identity, not isolation](../api-keys.md#keys-are-identity-not-isolation)) —
+unless you also make it [read-only](../api-keys.md#the-read-only-attribute).
+What a non-admin key cannot do is manage other keys. If it tries, it gets a verbatim `403`:
 
 ```json
 {
@@ -153,6 +154,43 @@ Two per-key bindings are worth setting on these, both covered in full in
       -H 'Content-Type: application/json' \
       -d '{"settings": {"capture_turns": false, "recall_limit": 5}}'
   ```
+
+### An unattended agent: make it read-only
+
+A CI job's LLM is the one case where "non-admin" is not enough. It runs
+unwatched, often on a branch nobody has reviewed, and a bad write is invisible
+until it poisons someone's recall weeks later. Give it a **read-only** key: it
+recalls project context and the server refuses its every write, over both REST
+and MCP.
+
+```console
+$ memini key add ci-agent --read-only --default-namespace acme
+```
+
+Point the job at it exactly like any other credential — `MEMINI_API_KEY` in the
+runner's environment is the whole integration. The agent's plugin reads
+`identity.read_only` off its handshake and simply stops attempting captures, so
+you get no per-turn 403 noise in the job log.
+
+Verify before you trust it:
+
+```console
+$ curl -sS -o /dev/null -w '%{http_code}\n' -X POST http://localhost:8080/v1/memories \
+    -H "Authorization: Bearer $CI_TOKEN" -H 'Content-Type: application/json' \
+    -H 'X-Memini-Namespace: acme' -d '{"content":"x","tier":"semantic"}'
+403
+$ curl -sS -o /dev/null -w '%{http_code}\n' -X POST http://localhost:8080/v1/search \
+    -H "Authorization: Bearer $CI_TOKEN" -H 'Content-Type: application/json' \
+    -H 'X-Memini-Namespace: acme' -d '{"query":"auth"}'
+200
+```
+
+> [!WARNING]
+> Read-only stops the agent **changing** your memory. It does not stop it
+> **reading** — the key can still name any namespace and read it. If the job runs
+> untrusted code, think about what is readable from that namespace tree, or give
+> CI its own memini instance. See
+> [api-keys.md](../api-keys.md#keys-are-identity-not-isolation).
 
 ## Step 4: the GitOps file-keys pattern
 
@@ -293,6 +331,13 @@ purpose-built locked states for non-admins rather than hiding. Three roles:
   signed-in key and pointing at how to get admin (sign in with an admin key, or
   mint one with `memini key add --admin`). Reads, search, activity, scopes, and
   the health tools all work. `identity.admin` is `false`.
+
+- **Read-only (any key with `read_only: true`, admin or not).** Reads everything
+  its other bits allow, changes nothing. The top bar carries a persistent
+  **read-only** chip, and every write control across Keys, Namespaces, Scopes,
+  Config and the drawers is disabled with an explanation on hover rather than
+  failing on click. An `admin` + `read_only` key is an auditor: it can list keys
+  and read server defaults, and edit neither. `identity.read_only` is `true`.
 
 - **Dev mode (no auth configured).** A fresh server with no `MEMINI_API_KEY`,
   no keys, and no keys file treats every request as an unauthenticated admin, so

--- a/docs/guides/homelab-team.md
+++ b/docs/guides/homelab-team.md
@@ -124,9 +124,10 @@ bare `memini key add kit` never silently demotes or promotes; pass `--admin` /
 `--admin=false` to change it).
 
 Two rules that bite people, both covered in full in
-[api-keys.md](../api-keys.md): a key is **identity, not authorization** (any valid
-key can read or write any namespace, so key bindings are convenience, not a
-fence), and a key's bound `home` **beats** the `X-Memini-Home` header while its
+[api-keys.md](../api-keys.md): a key is **identity, not isolation** (any valid key
+can read any namespace, so key bindings are convenience, not a fence — and while
+`--read-only` stops a key writing, nothing stops it reading), and a key's bound
+`home` **beats** the `X-Memini-Home` header while its
 `default_namespace` **loses** to the `X-Memini-Namespace` header. Home is who you
 are; namespace is where you are working.
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -150,6 +150,10 @@ rendered as a ConfigMap for the grafana-operator.
 in-process sweeper already handles decay. Enable it only if you want an explicit,
 scheduled `POST /v1/fsck` on top (hourly, by default).
 
+The token it uses must **not** be read-only: `POST /v1/fsck` is a mutating
+maintenance call, so a read-only credential gets a `403` and the CronJob fails
+every run. See [api-keys.md](../api-keys.md#the-read-only-attribute).
+
 If you do, the fsck container needs `MEMINI_API_KEY` in its own env, pointing at
 the same Secret as the main container. It uses curl's `--variable` /
 `--expand-header` so the token never appears in `argv`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,7 +20,7 @@ flags below belong to the subcommands only. See the
 | [`memini import`](#memini-import) | Bulk-load an export from another memory system |
 | [`memini key`](#memini-key) | Manage local API keys (this store's api_keys table only) |
 | [`memini key add`](#memini-key-add) | Create an API key, or rotate an existing one's secret |
-| [`memini key ls`](#memini-key-ls) | List API keys (name, home/default namespace, created, disabled, admin — never secrets or hashes) |
+| [`memini key ls`](#memini-key-ls) | List API keys (name, home/default namespace, created, disabled, admin, read-only — never secrets or hashes) |
 | [`memini key rm`](#memini-key-rm) | Delete an API key |
 | [`memini link`](#memini-link) | Manage cross-namespace read links (durable-tier recall from another namespace) |
 | [`memini link add`](#memini-link-add) | Create or replace a read link from src to dst |
@@ -131,7 +131,7 @@ memini key
 
 ## `memini key add`
 
-Create a new named API key, generating a random secret that is printed exactly once to stdout — it is never stored and cannot be recovered or shown again, so save it now. Re-running with a name that already exists ROTATES that key: a new secret is generated and the old one stops authenticating immediately, while the key's CreatedAt, home/default namespace bindings, disabled state, and admin state are all preserved unless the corresponding flag is explicitly passed (an explicit --home "" clears the binding; an explicit --disabled=false re-enables a disabled key — rotation alone never re-enables one; an explicit --admin=false demotes an admin key — rotation alone never demotes one).
+Create a new named API key, generating a random secret that is printed exactly once to stdout — it is never stored and cannot be recovered or shown again, so save it now. Re-running with a name that already exists ROTATES that key: a new secret is generated and the old one stops authenticating immediately, while the key's CreatedAt, home/default namespace bindings, disabled state, admin state, and read-only state are all preserved unless the corresponding flag is explicitly passed (an explicit --home "" clears the binding; an explicit --disabled=false re-enables a disabled key — rotation alone never re-enables one; an explicit --admin=false demotes an admin key — rotation alone never demotes one; an explicit --read-only=false lifts the read-only restriction — rotation alone never lifts it).
 
 ```
 memini key add <name> [flags]
@@ -143,10 +143,11 @@ memini key add <name> [flags]
 | `--default-namespace` |  | namespace applied when a request presents this key with no explicit namespace header |
 | `--disabled` |  | create the key already disabled |
 | `--home` |  | bind the key to a home namespace (default: unbound) |
+| `--read-only` |  | make the key read-only: it may read but every mutating request is refused, over both REST and MCP |
 
 ## `memini key ls`
 
-List API keys (name, home/default namespace, created, disabled, admin — never secrets or hashes)
+List API keys (name, home/default namespace, created, disabled, admin, read-only — never secrets or hashes)
 
 ```
 memini key ls

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -80,10 +80,10 @@ Requires the admin key (`MEMINI_API_KEY`). See [API keys](../api-keys.md).
 
 | Endpoint | Does |
 | --- | --- |
-| `GET /v1/keys` | List API keys (name/home/default namespace/created/disabled/admin/source — never a secret or hash) |
+| `GET /v1/keys` | List API keys (name/home/default namespace/created/disabled/admin/read_only/source — never a secret or hash) |
 | `POST /v1/keys` | Create a new API key, returning its secret exactly once |
 | `DELETE /v1/keys/{name}` | Delete an API key |
-| `PATCH /v1/keys/{name}` | Update an API key's home namespace, default namespace, disabled state, admin capability, and/or per-key settings |
+| `PATCH /v1/keys/{name}` | Update an API key's home namespace, default namespace, disabled state, admin capability, read-only capability, and/or per-key settings |
 | `POST /v1/keys/{name}/rotate` | Rotate an API key's secret, returning the new secret exactly once |
 
 ## Operational

--- a/internal/api/mcp/mcp.go
+++ b/internal/api/mcp/mcp.go
@@ -181,7 +181,7 @@ const serverInstructions = "memini is persistent cross-session memory for this a
 // unauthenticated stdio/dev session — see store.Event); a receiving middleware
 // stamps (author, authorKind) onto every tool call's context via
 // service.WithActor, so all tools inherit it without threading a parameter.
-func NewServer(svc *service.Service, defaultNS, home, author, authorKind string) *mcpsdk.Server {
+func NewServer(svc *service.Service, defaultNS, home, author, authorKind string, opts ...ServerOption) *mcpsdk.Server {
 	s := mcpsdk.NewServer(&mcpsdk.Implementation{
 		Name:    "memini",
 		Version: version.Version,
@@ -195,6 +195,17 @@ func NewServer(svc *service.Service, defaultNS, home, author, authorKind string)
 			return next(service.WithActor(ctx, author, authorKind), method, req)
 		}
 	})
+
+	// Authorization, when the session's credential carries it. Registered after
+	// attribution so a refused call is still attributed, and only when needed so
+	// an ordinary session pays nothing for it.
+	var cfg serverOpts
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.readOnly {
+		s.AddReceivingMiddleware(readOnlyMiddleware)
+	}
 
 	h := &tools{svc: svc, defaultNS: defaultNS, defaultHome: home, defaultAuthor: author}
 
@@ -432,7 +443,7 @@ func HTTPHandlerWithAuth(svc *service.Service, nsHeader, defaultNS, homeHeader s
 		} else if strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")) != "" {
 			kind = "env"
 		}
-		return NewServer(svc, ns, home, p.Name, kind)
+		return NewServer(svc, ns, home, p.Name, kind, WithReadOnly(p.ReadOnly))
 	}, nil)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")

--- a/internal/api/mcp/readonly.go
+++ b/internal/api/mcp/readonly.go
@@ -1,0 +1,81 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// readTools is the ALLOWLIST of tools a read-only credential
+// (store.APIKey.ReadOnly) may call. It mirrors the readOnly ToolAnnotations
+// applied at registration, and TestMCPReadToolAllowlistMatchesAnnotations
+// asserts the two agree for every registered tool — so a tool added on one side
+// only fails CI instead of silently becoming reachable.
+//
+// Like the REST classifier, the default is denial: a tool absent from this map
+// is refused, so forgetting to classify a new write tool over-restricts (a loud
+// refusal) rather than granting write access.
+var readTools = map[string]bool{
+	"memory_recall":   true,
+	"memory_briefing": true,
+	"memory_answer":   true,
+	"memory_list":     true,
+	"memory_get":      true,
+	"memory_history":  true,
+}
+
+// IsReadTool reports whether name is a tool a read-only session may call. It is
+// exported for the parity test that cross-checks this allowlist against the
+// tools' own ReadOnlyHint annotations.
+func IsReadTool(name string) bool { return readTools[name] }
+
+// ServerOption customizes NewServer. Options exist so the common call sites —
+// stdio, the docs generator, and a pile of tests — stay unchanged as
+// per-session capabilities accumulate, rather than growing another positional
+// bool argument each time.
+type ServerOption func(*serverOpts)
+
+type serverOpts struct {
+	readOnly bool
+}
+
+// WithReadOnly marks the session as authenticated by a read-only credential, so
+// every tool outside readTools is refused at call time.
+func WithReadOnly(v bool) ServerOption {
+	return func(o *serverOpts) { o.readOnly = v }
+}
+
+// readOnlyMiddleware refuses a tools/call for any tool outside readTools.
+//
+// It is a receiving middleware rather than a guard inside each write handler
+// for the same reason the REST side uses one middleware instead of ~20
+// per-handler calls: one choke point that a newly added tool cannot forget to
+// join. Non-tools/call methods (initialize, tools/list, ...) pass through
+// untouched, which is what keeps the write tools VISIBLE to a read-only session
+// — this build refuses them at call time rather than hiding them (see
+// TestMCPWriteToolsStayVisibleToReadOnlySession).
+//
+// The refusal is a CallToolResult with IsError set, NOT a returned error.
+// Returning an error makes the SDK emit a protocol-level failure, which an agent
+// reads as "the call broke" — the kind of thing worth retrying. An error tool
+// RESULT is ordinary tool output the model sees and can act on, so it learns
+// once that this credential cannot write and stops attempting it. That
+// distinction is the whole point for an unattended agent whose hooks would
+// otherwise retry a write every turn.
+func readOnlyMiddleware(next mcpsdk.MethodHandler) mcpsdk.MethodHandler {
+	return func(ctx context.Context, method string, req mcpsdk.Request) (mcpsdk.Result, error) {
+		call, ok := req.(*mcpsdk.CallToolRequest)
+		if !ok || call.Params == nil || IsReadTool(call.Params.Name) {
+			return next(ctx, method, req)
+		}
+		return &mcpsdk.CallToolResult{
+			IsError: true,
+			Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: fmt.Sprintf(
+				"read-only credential: this API key has read_only=true and cannot call %q, "+
+					"which modifies stored memories. Do not retry — reads (memory_recall, "+
+					"memory_briefing, memory_get, memory_list, memory_history) still work.",
+				call.Params.Name)}},
+		}, nil
+	}
+}

--- a/internal/api/mcp/readonly_test.go
+++ b/internal/api/mcp/readonly_test.go
@@ -1,0 +1,220 @@
+package mcp_test
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	meminimcp "github.com/eleboucher/memini/internal/api/mcp"
+	"github.com/eleboucher/memini/internal/embed/embedtest"
+	"github.com/eleboucher/memini/internal/service"
+	"github.com/eleboucher/memini/internal/store"
+	"github.com/eleboucher/memini/internal/store/sqlitevec"
+)
+
+// mcpWriteToolCalls are the tool calls a read-only session must be refused.
+// Arguments are valid so a refusal can never be confused with a schema error.
+var mcpWriteToolCalls = []mcpsdk.CallToolParams{
+	{Name: "memory_remember", Arguments: map[string]any{"content": "a write attempt", "tier": "semantic"}},
+	{Name: "memory_update", Arguments: map[string]any{"id": "some-id", "content": "an update attempt"}},
+	{Name: "memory_forget", Arguments: map[string]any{"id": "some-id"}},
+}
+
+// newReadOnlyMCP builds an MCP HTTP handler backed by a key store holding a
+// read-only key ("tok-ci") and an ordinary read-write key ("tok-bot").
+func newReadOnlyMCP(t *testing.T) http.Handler {
+	t.Helper()
+	ctx := context.Background()
+	st, err := sqlitevec.Open(ctx, filepath.Join(t.TempDir(), "mcp-readonly.db"), dims)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	var ks store.APIKeyStore = st
+	if err := ks.PutAPIKey(ctx, store.APIKey{Name: "ci", Hash: hashOf("tok-ci"), ReadOnly: true}); err != nil {
+		t.Fatalf("PutAPIKey(ci): %v", err)
+	}
+	if err := ks.PutAPIKey(ctx, store.APIKey{Name: "bot", Hash: hashOf("tok-bot")}); err != nil {
+		t.Fatalf("PutAPIKey(bot): %v", err)
+	}
+	svc := service.New(st, embedtest.New(dims))
+	return meminimcp.HTTPHandler(svc, "X-Memini-Namespace", "default", "X-Memini-Home", "", ks, nil)
+}
+
+// TestMCPReadOnlyKeyRefusedOnWriteTools is the MCP counterpart of the REST
+// enforcement matrix. MCP is mounted OUTSIDE rest.Mount's group, so the REST
+// middleware does not cover it — without this gate a read-only credential could
+// simply write over MCP instead.
+func TestMCPReadOnlyKeyRefusedOnWriteTools(t *testing.T) {
+	h := newReadOnlyMCP(t)
+	ctx := context.Background()
+	cs, err := connectHTTP(t, h, "acme", "", "tok-ci")
+	if err != nil {
+		t.Fatalf("connect with read-only key: %v", err)
+	}
+	for _, call := range mcpWriteToolCalls {
+		res, err := cs.CallTool(ctx, &call)
+		// The refusal must arrive as an error tool RESULT, not a protocol error.
+		// A protocol error reads to an agent as "the call broke" and invites a
+		// retry; an error result is output the model sees and adapts to. Asserting
+		// err == nil is what pins that distinction — do not relax it to "either
+		// shape is fine", or the retry-forever behavior this prevents comes back.
+		if err != nil {
+			t.Errorf("%s: want an error tool result, got a protocol error: %v", call.Name, err)
+			continue
+		}
+		if !res.IsError {
+			t.Errorf("%s with a read-only key: want a refusal, got success %+v", call.Name, res)
+			continue
+		}
+		text := strings.ToLower(resultText(res))
+		if !strings.Contains(text, "read-only") {
+			t.Errorf("%s refusal must say why; got %q", call.Name, resultText(res))
+		}
+		if !strings.Contains(text, "do not retry") {
+			t.Errorf("%s refusal must tell the agent not to retry; got %q", call.Name, resultText(res))
+		}
+	}
+}
+
+// TestMCPReadOnlyKeyAllowedOnReadTools: the same session must still recall, or
+// the credential is useless rather than merely unprivileged.
+func TestMCPReadOnlyKeyAllowedOnReadTools(t *testing.T) {
+	h := newReadOnlyMCP(t)
+	ctx := context.Background()
+	cs, err := connectHTTP(t, h, "acme", "", "tok-ci")
+	if err != nil {
+		t.Fatalf("connect with read-only key: %v", err)
+	}
+	for _, call := range []mcpsdk.CallToolParams{
+		{Name: "memory_recall", Arguments: map[string]any{"query": "anything"}},
+		{Name: "memory_briefing", Arguments: map[string]any{}},
+		{Name: "memory_list", Arguments: map[string]any{}},
+	} {
+		res, err := cs.CallTool(ctx, &call)
+		if err != nil {
+			t.Errorf("%s with a read-only key: unexpected transport error %v", call.Name, err)
+			continue
+		}
+		if res.IsError && strings.Contains(strings.ToLower(resultText(res)), "read-only") {
+			t.Errorf("%s must not be refused for a read-only key; got %q", call.Name, resultText(res))
+		}
+	}
+}
+
+// TestMCPReadWriteKeyStillWrites guards against the gate leaking onto every
+// named key rather than only read-only ones.
+func TestMCPReadWriteKeyStillWrites(t *testing.T) {
+	h := newReadOnlyMCP(t)
+	ctx := context.Background()
+	cs, err := connectHTTP(t, h, "acme", "", "tok-bot")
+	if err != nil {
+		t.Fatalf("connect with read-write key: %v", err)
+	}
+	res, err := cs.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name:      "memory_remember",
+		Arguments: map[string]any{"content": "an ordinary mcp write", "tier": "semantic"},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("memory_remember with a read-write key: err=%v res=%q", err, resultText(res))
+	}
+}
+
+// TestMCPWriteToolsStayVisibleToReadOnlySession pins the deliberate choice to
+// reject at call time rather than hide the tools: the tool list is identical for
+// a read-only and a read-write session. Hiding them would be a reasonable design
+// too, but it is NOT the one taken here, and silently switching would change the
+// agent-visible contract.
+func TestMCPWriteToolsStayVisibleToReadOnlySession(t *testing.T) {
+	h := newReadOnlyMCP(t)
+	ctx := context.Background()
+
+	listFor := func(token string) []string {
+		cs, err := connectHTTP(t, h, "acme", "", token)
+		if err != nil {
+			t.Fatalf("connect %s: %v", token, err)
+		}
+		res, err := cs.ListTools(ctx, nil)
+		if err != nil {
+			t.Fatalf("ListTools %s: %v", token, err)
+		}
+		names := make([]string, 0, len(res.Tools))
+		for _, tool := range res.Tools {
+			names = append(names, tool.Name)
+		}
+		sort.Strings(names)
+		return names
+	}
+
+	ro, rw := listFor("tok-ci"), listFor("tok-bot")
+	if strings.Join(ro, ",") != strings.Join(rw, ",") {
+		t.Fatalf("read-only session tool list %v differs from read-write %v; "+
+			"this build rejects write tools at call time and does not hide them", ro, rw)
+	}
+	for _, call := range mcpWriteToolCalls {
+		found := false
+		for _, n := range ro {
+			if n == call.Name {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s missing from a read-only session's tool list", call.Name)
+		}
+	}
+}
+
+// TestMCPReadToolAllowlistMatchesAnnotations is the fail-closed gate for the MCP
+// surface, the counterpart of the spec-derived test on the REST side.
+//
+// Every tool is already annotated readOnly / additive / destructive at
+// registration, and cmd/gendocs treats those annotations as authoritative when
+// it labels the tool reference. This asserts the enforcement allowlist agrees
+// with them exactly: a tool annotated read-only must be callable by a read-only
+// session, and a tool that is not must be refused.
+//
+// So adding a write tool without allowlisting it is caught here rather than
+// becoming a silent hole — and the default for an unlisted tool is refusal.
+func TestMCPReadToolAllowlistMatchesAnnotations(t *testing.T) {
+	h := newReadOnlyMCP(t)
+	ctx := context.Background()
+	cs, err := connectHTTP(t, h, "acme", "", "tok-ci")
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	res, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(res.Tools) == 0 {
+		t.Fatalf("no tools registered — this gate would be checking nothing")
+	}
+	for _, tool := range res.Tools {
+		annotatedRead := tool.Annotations != nil && tool.Annotations.ReadOnlyHint
+		allowed := meminimcp.IsReadTool(tool.Name)
+		if allowed != annotatedRead {
+			t.Errorf("tool %q: allowlist says read=%v but its ReadOnlyHint annotation says read=%v — "+
+				"a new tool must be classified in BOTH places, and they must agree",
+				tool.Name, allowed, annotatedRead)
+		}
+	}
+}
+
+// resultText flattens a tool result's text content for assertions.
+func resultText(res *mcpsdk.CallToolResult) string {
+	if res == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcpsdk.TextContent); ok {
+			b.WriteString(tc.Text)
+		}
+	}
+	return b.String()
+}

--- a/internal/api/rest/api.gen.go
+++ b/internal/api/rest/api.gen.go
@@ -679,6 +679,9 @@ type ApiKey struct {
 	Home *string `json:"home,omitempty"`
 	Name string  `json:"name"`
 
+	// ReadOnly Whether this key is a read-only credential: it may issue reads (GET/HEAD, plus the read-shaped POSTs /v1/search, /v1/answer and /v1/handshake) and every mutating request is refused with 403, across both the REST and MCP surfaces. Independent of admin — an admin key that is also read_only may enumerate keys but not change them. Note this bounds what the key may CHANGE, not what it may SEE: a read-only key can still name any namespace and read it.
+	ReadOnly bool `json:"read_only"`
+
 	// Settings Per-key behavioral settings override; fields left unset inherit the server's global defaults.
 	Settings *ClientSettings `json:"settings,omitempty"`
 
@@ -704,6 +707,9 @@ type ApiKeyWithSecret struct {
 	// Home Bound home namespace; omitted/empty means unbound.
 	Home *string `json:"home,omitempty"`
 	Name string  `json:"name"`
+
+	// ReadOnly Whether this key is a read-only credential: it may issue reads (GET/HEAD, plus the read-shaped POSTs /v1/search, /v1/answer and /v1/handshake) and every mutating request is refused with 403, across both the REST and MCP surfaces. Independent of admin — an admin key that is also read_only may enumerate keys but not change them. Note this bounds what the key may CHANGE, not what it may SEE: a read-only key can still name any namespace and read it.
+	ReadOnly bool `json:"read_only"`
 
 	// Secret The plaintext credential, shown exactly once, here — it is never stored (only its SHA-256 hash is) and cannot be recovered or displayed again.
 	Secret string `json:"secret"`
@@ -786,6 +792,9 @@ type CallerIdentity struct {
 
 	// KeyName Name of the API key that authenticated the request; absent for the admin key or dev mode (no named principal).
 	KeyName *string `json:"key_name,omitempty"`
+
+	// ReadOnly Effective read-only capability: true only for a named key with read_only=true. False for the admin env key and dev mode, which authenticate with no named principal and so carry no capability bits. When true, every mutating request is refused with 403 — clients should skip writes rather than attempt and log them.
+	ReadOnly bool `json:"read_only"`
 }
 
 // ClientSettings Behavioral/injection settings, resolved by merging built-in defaults with any server global defaults and any per-key override. Every field is optional in the schema — absent means "inherit from the next layer down" — but a fully resolved ClientSettings (as returned by /v1/handshake, /v1/self, and GET /v1/settings/defaults) always carries every field.
@@ -914,6 +923,9 @@ type CreateApiKeyRequest struct {
 	// Home Bind the key to a home namespace.
 	Home *string `json:"home,omitempty"`
 	Name string  `json:"name"`
+
+	// ReadOnly Create the key as a read-only credential (see ApiKey.read_only). Defaults to false — a key that may write.
+	ReadOnly *bool `json:"read_only,omitempty"`
 }
 
 // DedupReport defines model for DedupReport.
@@ -1538,6 +1550,9 @@ type UpdateApiKeyRequest struct {
 	// Home Omit to leave the current binding unchanged; an explicit empty string clears it.
 	Home *string `json:"home,omitempty"`
 
+	// ReadOnly Omit to leave the current read-only capability unchanged; impose it with true, lift it with false. A named key cannot impose read_only on itself (read_only=true targeting the key that authenticated the request) — that returns 409, because a read-only credential can no longer reach this endpoint to undo it; use the admin env key, another admin key, or the CLI.
+	ReadOnly *bool `json:"read_only,omitempty"`
+
 	// Settings Omit to leave the key's settings override unchanged; present fields replace the corresponding stored value (fields left unset within it continue to inherit the server's global defaults).
 	Settings *ClientSettings `json:"settings,omitempty"`
 }
@@ -1955,7 +1970,7 @@ type ServerInterface interface {
 	// Resolve namespace, identity, and behavioral settings from client-supplied project facts
 	// (POST /v1/handshake)
 	Handshake(w http.ResponseWriter, r *http.Request)
-	// List API keys (name/home/default namespace/created/disabled/admin/source — never a secret or hash)
+	// List API keys (name/home/default namespace/created/disabled/admin/read_only/source — never a secret or hash)
 	// (GET /v1/keys)
 	ListApiKeys(w http.ResponseWriter, r *http.Request)
 	// Create a new API key, returning its secret exactly once
@@ -1964,7 +1979,7 @@ type ServerInterface interface {
 	// Delete an API key
 	// (DELETE /v1/keys/{name})
 	DeleteApiKey(w http.ResponseWriter, r *http.Request, name string)
-	// Update an API key's home namespace, default namespace, disabled state, admin capability, and/or per-key settings
+	// Update an API key's home namespace, default namespace, disabled state, admin capability, read-only capability, and/or per-key settings
 	// (PATCH /v1/keys/{name})
 	UpdateApiKey(w http.ResponseWriter, r *http.Request, name string)
 	// Rotate an API key's secret, returning the new secret exactly once
@@ -2093,7 +2108,7 @@ func (_ Unimplemented) Handshake(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// List API keys (name/home/default namespace/created/disabled/admin/source — never a secret or hash)
+// List API keys (name/home/default namespace/created/disabled/admin/read_only/source — never a secret or hash)
 // (GET /v1/keys)
 func (_ Unimplemented) ListApiKeys(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
@@ -2111,7 +2126,7 @@ func (_ Unimplemented) DeleteApiKey(w http.ResponseWriter, r *http.Request, name
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// Update an API key's home namespace, default namespace, disabled state, admin capability, and/or per-key settings
+// Update an API key's home namespace, default namespace, disabled state, admin capability, read-only capability, and/or per-key settings
 // (PATCH /v1/keys/{name})
 func (_ Unimplemented) UpdateApiKey(w http.ResponseWriter, r *http.Request, name string) {
 	w.WriteHeader(http.StatusNotImplemented)

--- a/internal/api/rest/apikeys.go
+++ b/internal/api/rest/apikeys.go
@@ -51,7 +51,7 @@ func requireAdmin(w http.ResponseWriter, r *http.Request) bool {
 // row), so emitting the Go zero time would render as a nonsensical
 // "0001-01-01" in the UI rather than being recognizably absent.
 func apiKeyModel(k store.APIKey, source ApiKeySource) ApiKey {
-	out := ApiKey{Name: k.Name, Disabled: k.Disabled, Admin: k.Admin, Source: source}
+	out := ApiKey{Name: k.Name, Disabled: k.Disabled, Admin: k.Admin, ReadOnly: k.ReadOnly, Source: source}
 	if !k.CreatedAt.IsZero() {
 		out.CreatedAt = &k.CreatedAt
 	}
@@ -76,7 +76,7 @@ func apiKeyModel(k store.APIKey, source ApiKeySource) ApiKey {
 // always non-zero here — but the same nil-when-zero guard is applied for
 // consistency with apiKeyModel.
 func apiKeyWithSecretModel(k store.APIKey, source ApiKeySource, secret string) ApiKeyWithSecret {
-	out := ApiKeyWithSecret{Name: k.Name, Disabled: k.Disabled, Admin: k.Admin, Source: source, Secret: secret}
+	out := ApiKeyWithSecret{Name: k.Name, Disabled: k.Disabled, Admin: k.Admin, ReadOnly: k.ReadOnly, Source: source, Secret: secret}
 	if !k.CreatedAt.IsZero() {
 		out.CreatedAt = &k.CreatedAt
 	}
@@ -223,6 +223,7 @@ func (h *Server) CreateApiKey(w http.ResponseWriter, r *http.Request) {
 		DefaultNS: defaultNS,
 		Disabled:  deref(req.Disabled),
 		Admin:     deref(req.Admin),
+		ReadOnly:  deref(req.ReadOnly),
 		// CreatedAt intentionally left zero: PutAPIKey stamps "now" for a
 		// brand-new row (store.APIKeyStore.PutAPIKey's doc).
 	}
@@ -238,7 +239,12 @@ func (h *Server) CreateApiKey(w http.ResponseWriter, r *http.Request) {
 	// Minting an admin credential is a privileged act worth auditing, the same
 	// way a settings edit is; a plain key carries no such event.
 	if key.Admin {
-		h.logAdminFlagEvent(r.Context(), name, true)
+		h.logCapabilityEvent(r.Context(), name, eventDetailAdmin, true)
+	}
+	// Likewise for read-only: an operator auditing "when did this credential
+	// stop being able to write" needs the grant recorded, not just the revoke.
+	if key.ReadOnly {
+		h.logCapabilityEvent(r.Context(), name, eventDetailReadOnly, true)
 	}
 	stored, err := ks.GetAPIKeyByHash(r.Context(), key.Hash)
 	if err != nil {
@@ -252,13 +258,14 @@ func (h *Server) CreateApiKey(w http.ResponseWriter, r *http.Request) {
 	httputil.JSON(w, http.StatusCreated, apiKeyWithSecretModel(*stored, Db, secret))
 }
 
-// logAdminFlagEvent records an admin-capability change as a store.EventSettings
-// activity entry (no new EventKind — same reuse as the per-key settings edit
-// above at UpdateApiKey), with detail {key_name, admin}. Called only when a
-// create grants admin or an update flips the flag, so the activity log carries
-// an audit trail of who became (or stopped being) an admin key.
-func (h *Server) logAdminFlagEvent(ctx context.Context, name string, admin bool) {
-	h.svc.LogConfigEvent(ctx, store.EventSettings, "", map[string]any{eventDetailKeyName: name, eventDetailAdmin: admin})
+// logCapabilityEvent records a per-key authorization change as a
+// store.EventSettings activity entry (no new EventKind — the same reuse as the
+// per-key settings edit at UpdateApiKey), with detail {key_name, <field>: value}
+// where field is eventDetailAdmin or eventDetailReadOnly. Called only when a
+// create grants a capability or an update flips one, so the activity log carries
+// an audit trail of every change to what a credential may do.
+func (h *Server) logCapabilityEvent(ctx context.Context, name, field string, value bool) {
+	h.svc.LogConfigEvent(ctx, store.EventSettings, "", map[string]any{eventDetailKeyName: name, field: value})
 }
 
 // UpdateApiKey implements PATCH /v1/keys/{name}: preserve-unspecified
@@ -312,6 +319,17 @@ func (h *Server) UpdateApiKey(w http.ResponseWriter, r *http.Request, name strin
 				"api key %q cannot demote or disable itself; use the admin env key (MEMINI_API_KEY) or another admin key", name))
 			return
 		}
+		// Imposing read_only on itself is the same class of self-inflicted
+		// lockout, and strictly worse to recover from: once the flag is set, the
+		// read-only gate refuses this very endpoint, so the key can never lift
+		// it. Lifting read_only from itself is allowed — that direction is a
+		// restoration, and is only reachable while the key is still writable.
+		if req.ReadOnly != nil && *req.ReadOnly {
+			httputil.Error(w, http.StatusConflict, fmt.Sprintf(
+				"api key %q cannot make itself read-only; a read-only credential cannot reach this endpoint to undo it, "+
+					"so use the admin env key (MEMINI_API_KEY), another admin key, or `memini key add %s --read-only`", name, name))
+			return
+		}
 	}
 	updated := *existing
 	if req.Home != nil {
@@ -336,10 +354,14 @@ func (h *Server) UpdateApiKey(w http.ResponseWriter, r *http.Request, name strin
 	if req.Admin != nil {
 		updated.Admin = *req.Admin
 	}
+	if req.ReadOnly != nil {
+		updated.ReadOnly = *req.ReadOnly
+	}
 	// Whether this PATCH actually flipped the admin capability (grant or
 	// revoke), used below to emit an audit event only on a real change — a
 	// no-op admin=true against an already-admin key writes nothing.
 	adminFlipped := updated.Admin != existing.Admin
+	readOnlyFlipped := updated.ReadOnly != existing.ReadOnly
 	// Settings: absent (nil) preserves the existing blob untouched (the same
 	// preserve-unspecified convention as home/default_namespace/disabled
 	// above); present REPLACES it wholesale -- full-replace, not a merge, so
@@ -374,7 +396,10 @@ func (h *Server) UpdateApiKey(w http.ResponseWriter, r *http.Request, name strin
 		h.svc.LogConfigEvent(r.Context(), store.EventSettings, "", map[string]any{eventDetailKeyName: name, eventDetailLayer: settingsSourceKey})
 	}
 	if adminFlipped {
-		h.logAdminFlagEvent(r.Context(), name, updated.Admin)
+		h.logCapabilityEvent(r.Context(), name, eventDetailAdmin, updated.Admin)
+	}
+	if readOnlyFlipped {
+		h.logCapabilityEvent(r.Context(), name, eventDetailReadOnly, updated.ReadOnly)
 	}
 	httputil.JSON(w, http.StatusOK, apiKeyModel(updated, Db))
 }
@@ -423,8 +448,13 @@ func (h *Server) DeleteApiKey(w http.ResponseWriter, r *http.Request, name strin
 		return
 	}
 	if existing != nil && existing.Admin {
-		h.logAdminFlagEvent(r.Context(), name, false)
+		h.logCapabilityEvent(r.Context(), name, eventDetailAdmin, false)
 	}
+	// Deliberately no read_only counterpart here. Deleting an admin key removes
+	// a privilege and is worth recording; deleting a read-only key removes a
+	// RESTRICTION on a credential that no longer exists, so a "read_only: false"
+	// event would read as "this key became writable" — the opposite of what
+	// happened.
 	// Invalidate immediately: deleting the last row must relax the
 	// table-emptiness reading back to dev mode right away when no admin key
 	// is configured — see apiauth.Config.Invalidate's doc. (In practice this

--- a/internal/api/rest/config_shared.go
+++ b/internal/api/rest/config_shared.go
@@ -48,6 +48,11 @@ const eventDetailKeyName = "key_name"
 // kept here next to its sibling so apikeys.go doesn't inline the literal.
 const eventDetailAdmin = "admin"
 
+// eventDetailReadOnly is eventDetailAdmin's sibling for the read-only
+// capability: the LogConfigEvent detail key carrying the new read_only state
+// (bool) on a grant/revoke, alongside eventDetailKeyName.
+const eventDetailReadOnly = "read_only"
+
 // pinStore type-asserts the backing store to store.PinStore, the
 // optional capability the pins surface needs (keyStore/linkStore's
 // precedent). Returns false — a 501 to the caller — for a driver that predates
@@ -164,7 +169,7 @@ func principalPtr(ctx context.Context) *apiauth.Principal {
 // dev mode (no bearer) does not.
 func (h *Server) identityFor(r *http.Request) CallerIdentity {
 	if p, ok := principalFromContext(r.Context()); ok {
-		id := CallerIdentity{Authenticated: true, Admin: p.Admin}
+		id := CallerIdentity{Authenticated: true, Admin: p.Admin, ReadOnly: p.ReadOnly}
 		name := p.Name
 		id.KeyName = &name
 		if p.HomeNS != "" {
@@ -177,7 +182,10 @@ func (h *Server) identityFor(r *http.Request) CallerIdentity {
 		}
 		return id
 	}
-	return CallerIdentity{Authenticated: bearerPresent(r), Admin: true}
+	// ReadOnly is false here by construction: the env key and dev mode
+	// authenticate with no principal, so they carry no per-key capability bits
+	// and are never read-only.
+	return CallerIdentity{Authenticated: bearerPresent(r), Admin: true, ReadOnly: false}
 }
 
 // bearerPresent reports whether the request carried a non-empty bearer token —

--- a/internal/api/rest/readonly.go
+++ b/internal/api/rest/readonly.go
@@ -1,0 +1,97 @@
+package rest
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/eleboucher/memini/internal/httputil"
+)
+
+// readShapedPaths are the /v1 endpoints whose HTTP method does not identify
+// them as reads: each is a query that needs a request body, so it is a POST
+// despite mutating nothing.
+//
+//   - /v1/search and /v1/answer are retrieval. /v1/answer spends LLM tokens,
+//     but spending tokens is not mutating stored state.
+//   - /v1/handshake is deliberately side-effect-free (see Server.Handshake) and
+//     is what every client calls to resolve its namespace before doing anything
+//     else. Denying it would make a read-only credential unusable rather than
+//     merely unprivileged.
+//
+// Entries must be parameter-free: isReadRequest matches a concrete request path
+// literally, and chi has not resolved the route pattern yet (see below).
+var readShapedPaths = map[string]bool{
+	"/v1/search":    true,
+	"/v1/answer":    true,
+	"/v1/handshake": true,
+}
+
+// isReadRequest reports whether (method, path) is a read, and is deliberately
+// an ALLOWLIST: safe methods, plus the handful of read-shaped POSTs above.
+// Everything else — including a path this function has never heard of — is a
+// write.
+//
+// That default is the point. A mutating endpoint added later is refused for
+// read-only credentials until someone consciously classifies it, so the failure
+// mode of forgetting is an over-restriction (a loud 403 on something that should
+// have been readable) rather than a silent grant of write access. The
+// spec-derived test in readonly_test.go turns "someone forgot" into a CI
+// failure rather than a latent hole.
+//
+// It matches on the request path rather than chi's route pattern because chi
+// resolves routes AFTER the middleware chain runs, so RouteContext().RoutePattern()
+// is still empty here. Hence the parameter-free constraint on readShapedPaths.
+func isReadRequest(method, path string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	}
+	return readShapedPaths[strings.TrimSuffix(path, "/")]
+}
+
+// readOnlyMiddleware enforces store.APIKey.ReadOnly: a request authenticated by
+// a read-only credential may only issue reads (isReadRequest), and is refused
+// 403 otherwise.
+//
+// It runs immediately after authMiddleware so a refused write does no further
+// work — no attribution, no namespace resolution, no handler.
+//
+// A caller with NO principal on the context is never read-only: that is the
+// admin env key or dev/bootstrap mode, both of which authenticate without a
+// principal and so cannot carry per-key capability bits. This mirrors
+// requireAdmin's treatment of the nil principal exactly.
+//
+// Enforcing here rather than per-handler is what makes the gate hold as the API
+// grows: there is one choke point every /v1 route passes through, instead of ~20
+// call sites a new endpoint can forget to join.
+//
+// Mount registers those routes inside a chi Group, and a Group's middleware runs
+// only for paths matching a route registered in that group — so an unknown path
+// 404s from the parent router without reaching this gate. That is deliberate:
+// the gate never manufactures a 403 for an endpoint that does not exist, so it
+// cannot mask a routing bug (see TestReadOnlyGateDoesNotMaskRouting).
+//
+// Reads still reinforce (access counts, last_accessed_at) and still append to
+// the activity log. That is internal relevance bookkeeping, not caller-facing
+// mutation: "read-only" bounds what the CALLER can change, not whether serving
+// a read leaves a trace. Do not "fix" this into suppressing reinforcement — it
+// would quietly degrade ranking for every read-only consumer.
+func (a AuthConfig) readOnlyMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p, ok := principalFromContext(r.Context())
+		if !ok || !p.ReadOnly || isReadRequest(r.Method, r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		// Debug, not warn: for a read-only credential this is expected steady
+		// state, not an anomaly, and an unattended agent whose hooks still
+		// attempt writes would emit one line per turn at a louder level. The
+		// 403 body already tells the caller why.
+		slog.DebugContext(r.Context(), "read-only credential refused a mutating request",
+			"key", p.Name, "method", r.Method, "path", r.URL.Path)
+		httputil.Error(w, http.StatusForbidden, fmt.Sprintf(
+			"read-only credential: API key %q has read_only=true and cannot perform mutating requests", p.Name))
+	})
+}

--- a/internal/api/rest/readonly_export_test.go
+++ b/internal/api/rest/readonly_export_test.go
@@ -1,0 +1,8 @@
+package rest
+
+// IsReadRequest exposes isReadRequest to the external rest_test package, where
+// the spec-derived classification gate lives alongside the request-level
+// enforcement tests that need rest_test's server fixtures. The classifier stays
+// unexported in the production API: it encodes this package's own read/write
+// policy and has no caller outside it.
+var IsReadRequest = isReadRequest

--- a/internal/api/rest/readonly_test.go
+++ b/internal/api/rest/readonly_test.go
@@ -1,0 +1,546 @@
+package rest_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/eleboucher/memini/internal/api/rest"
+	"github.com/eleboucher/memini/internal/store"
+)
+
+// --- The fail-closed classification gate ---------------------------------
+//
+// rest.IsReadRequest is an ALLOWLIST: a read-only credential may issue
+// GET/HEAD/OPTIONS plus a handful of read-shaped POSTs, and nothing else. The
+// test below derives the full endpoint set from api/openapi.yaml (the source of
+// truth every other artifact generates from) and asserts the classifier agrees
+// with expectedSpecReads for every one of them.
+//
+// The point is the direction of failure. Adding an endpoint to the spec without
+// touching expectedSpecReads fails this test, forcing a conscious read-or-write
+// call. If someone ignores that and ships anyway, the default is DENIAL — the
+// new endpoint is unreachable for read-only keys until it is allowlisted, which
+// is a loud 403 rather than a silent write capability.
+
+// expectedSpecReads is every /v1 endpoint a read-only credential may reach,
+// keyed "METHOD /path" exactly as api/openapi.yaml spells it. Everything else
+// in the spec must classify as a write.
+//
+// The three POSTs here are read-shaped despite their verb:
+//   - /v1/search and /v1/answer are queries that happen to need a request body
+//     (/v1/answer spends LLM tokens, but spending tokens is not mutating state).
+//   - /v1/handshake is documented side-effect-free (see Server.Handshake) and is
+//     what every client calls to bootstrap. Denying it would make a read-only
+//     credential unusable rather than merely unprivileged.
+var expectedSpecReads = map[string]bool{
+	"GET /v1/memories":              true,
+	"GET /v1/memories/{id}":         true,
+	"GET /v1/memories/{id}/history": true,
+	"POST /v1/search":               true,
+	"POST /v1/answer":               true,
+	"POST /v1/handshake":            true,
+	"GET /v1/namespaces":            true,
+	"GET /v1/namespaces/briefing":   true,
+	"GET /v1/namespaces/readset":    true,
+	"GET /v1/links":                 true,
+	"GET /v1/stats":                 true,
+	"GET /v1/activity":              true,
+	"GET /v1/self":                  true,
+	"GET /v1/pins":                  true,
+	"GET /v1/keys":                  true,
+	"GET /v1/settings/defaults":     true,
+}
+
+// specEndpoints parses api/openapi.yaml and returns every ("METHOD /path")
+// operation under /v1. Non-/v1 paths (/healthz, /readyz) are excluded: they opt
+// out of bearerAuth in the spec and are mounted outside rest.Mount's group, so
+// the read-only middleware never sees them.
+func specEndpoints(t *testing.T) []string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "api", "openapi.yaml"))
+	if err != nil {
+		t.Fatalf("read openapi.yaml: %v", err)
+	}
+	var doc struct {
+		Paths map[string]map[string]yaml.Node `yaml:"paths"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse openapi.yaml: %v", err)
+	}
+	if len(doc.Paths) == 0 {
+		t.Fatalf("openapi.yaml parsed to zero paths — the spec shape changed and this gate is no longer checking anything")
+	}
+	verbs := map[string]bool{
+		"get": true, "put": true, "post": true, "delete": true,
+		"patch": true, "head": true, "options": true,
+	}
+	var out []string
+	for path, ops := range doc.Paths {
+		if !strings.HasPrefix(path, "/v1/") {
+			continue
+		}
+		for verb := range ops {
+			if !verbs[strings.ToLower(verb)] {
+				continue // "parameters", "summary", etc. — not an operation
+			}
+			out = append(out, strings.ToUpper(verb)+" "+path)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// concretePath substitutes a value for every {param} placeholder, so the
+// classifier is exercised against paths shaped like real request URLs rather
+// than spec templates.
+func concretePath(specPath string) string {
+	out := specPath
+	for {
+		open := strings.Index(out, "{")
+		if open < 0 {
+			return out
+		}
+		closeIdx := strings.Index(out[open:], "}")
+		if closeIdx < 0 {
+			return out
+		}
+		out = out[:open] + "sample" + out[open+closeIdx+1:]
+	}
+}
+
+func TestIsReadRequestClassifiesEverySpecEndpoint(t *testing.T) {
+	endpoints := specEndpoints(t)
+	if len(endpoints) == 0 {
+		t.Fatalf("no /v1 endpoints found in the spec")
+	}
+	seen := map[string]bool{}
+	for _, ep := range endpoints {
+		seen[ep] = true
+		method, specPath, ok := strings.Cut(ep, " ")
+		if !ok {
+			t.Fatalf("malformed endpoint key %q", ep)
+		}
+		want := expectedSpecReads[ep]
+		got := rest.IsReadRequest(method, concretePath(specPath))
+		if got != want {
+			verdict := map[bool]string{true: "read", false: "write"}
+			t.Errorf("%s classified as %s, want %s — if this endpoint is new, "+
+				"decide deliberately whether a read-only credential may call it and "+
+				"update expectedSpecReads (and isReadRequest's allowlist for a read-shaped POST)",
+				ep, verdict[got], verdict[want])
+		}
+	}
+	// Catch stale entries: an allowlisted endpoint that no longer exists in the
+	// spec is a typo or a leftover, and would silently stop protecting anything.
+	for ep := range expectedSpecReads {
+		if !seen[ep] {
+			t.Errorf("expectedSpecReads names %q, which is not in api/openapi.yaml (renamed or removed?)", ep)
+		}
+	}
+}
+
+// TestIsReadRequestDeniesUnknownMutatingPaths pins the fail-closed default: a
+// path the allowlist has never heard of is a write, so a future endpoint is
+// denied until someone opts it in.
+func TestIsReadRequestDeniesUnknownMutatingPaths(t *testing.T) {
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodPost, "/v1/some-future-endpoint"},
+		{http.MethodPut, "/v1/memories"},
+		{http.MethodDelete, "/v1/anything"},
+		{http.MethodPatch, "/v1/whatever"},
+	} {
+		if rest.IsReadRequest(tc.method, tc.path) {
+			t.Errorf("%s %s classified as a read; unknown mutating paths must default to write", tc.method, tc.path)
+		}
+	}
+}
+
+// TestIsReadRequestIgnoresTrailingSlash: the classifier matches on the request
+// path, so /v1/search/ must not slip past the allowlist comparison and be
+// mistaken for an unknown (and therefore denied) endpoint.
+func TestIsReadRequestIgnoresTrailingSlash(t *testing.T) {
+	if !rest.IsReadRequest(http.MethodPost, "/v1/search/") {
+		t.Errorf("POST /v1/search/ must classify as a read, same as without the trailing slash")
+	}
+}
+
+// --- Enforcement over real requests --------------------------------------
+
+// readOnlyWriteEndpoints is every mutating /v1 endpoint, as a request a
+// read-only credential might actually issue. Bodies are deliberately minimal:
+// the gate must reject before any handler validates the payload, so a 400 here
+// would itself be a failure.
+var readOnlyWriteEndpoints = []struct {
+	method, path string
+	body         any
+}{
+	{http.MethodPost, "/v1/memories", map[string]any{"content": "x", "tier": "semantic"}},
+	{http.MethodPatch, "/v1/memories/some-id", map[string]any{"content": "x"}},
+	{http.MethodDelete, "/v1/memories/some-id", nil},
+	{http.MethodDelete, "/v1/memories?tag=x", nil},
+	{http.MethodPost, "/v1/memories/some-id/supersede", map[string]any{"content": "x"}},
+	{http.MethodPost, "/v1/memories/some-id/reassign", map[string]any{"namespace": "other"}},
+	{http.MethodDelete, "/v1/namespaces", nil},
+	{http.MethodPost, "/v1/namespaces/move", map[string]any{"from": "a", "to": "b"}},
+	{http.MethodPost, "/v1/namespaces/split", map[string]any{"from": "a", "to": "b"}},
+	{http.MethodPost, "/v1/links", map[string]any{"src_ns": "a", "dst_ns": "b"}},
+	{http.MethodDelete, "/v1/links", nil},
+	{http.MethodPost, "/v1/fsck", nil},
+	{http.MethodPost, "/v1/dedup", nil},
+	{http.MethodPost, "/v1/activity/injected", map[string]any{"namespace": "a"}},
+	{http.MethodPut, "/v1/self/settings", map[string]any{}},
+	{http.MethodPut, "/v1/pins", map[string]any{"key": "k", "namespace": "a"}},
+	{http.MethodDelete, "/v1/pins", nil},
+	{http.MethodPost, "/v1/keys", map[string]any{"name": "n"}},
+	{http.MethodPatch, "/v1/keys/other", map[string]any{}},
+	{http.MethodDelete, "/v1/keys/other", nil},
+	{http.MethodPost, "/v1/keys/other/rotate", nil},
+	{http.MethodPut, "/v1/settings/defaults", map[string]any{}},
+}
+
+// newReadOnlyServer builds a REST server with two named keys: "ci" is
+// read-only, "bot" is an ordinary read-write key. adminKey may be "".
+func newReadOnlyServer(t *testing.T, adminKey string) http.Handler {
+	t.Helper()
+	h, ks := newServerWithKeyStore(t, adminKey)
+	ctx := context.Background()
+	if err := ks.PutAPIKey(ctx, store.APIKey{
+		Name: "ci", Hash: hashOf("tok-ci"), ReadOnly: true, Admin: true,
+	}); err != nil {
+		t.Fatalf("PutAPIKey(ci): %v", err)
+	}
+	if err := ks.PutAPIKey(ctx, store.APIKey{
+		Name: "bot", Hash: hashOf("tok-bot"), Admin: true,
+	}); err != nil {
+		t.Fatalf("PutAPIKey(bot): %v", err)
+	}
+	return h
+}
+
+// TestReadOnlyKeyDeniedOnEveryWriteEndpoint is the core enforcement matrix: the
+// read-only credential is also admin, so an admin gate can never be what
+// rejects it — only the read-only gate can.
+func TestReadOnlyKeyDeniedOnEveryWriteEndpoint(t *testing.T) {
+	h := newReadOnlyServer(t, "")
+	for _, ep := range readOnlyWriteEndpoints {
+		rec := do(t, h, ep.method, ep.path, "alice", "tok-ci", ep.body)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("%s %s with a read-only key: want 403, got %d (%s)",
+				ep.method, ep.path, rec.Code, strings.TrimSpace(rec.Body.String()))
+		}
+	}
+}
+
+// TestReadOnlyDenialNamesTheCredential: the 403 body must say why, or an
+// operator sees a bare Forbidden and reaches for the admin gate instead.
+func TestReadOnlyDenialNamesTheCredential(t *testing.T) {
+	h := newReadOnlyServer(t, "")
+	rec := do(t, h, http.MethodPost, "/v1/memories", "alice", "tok-ci",
+		map[string]any{"content": "x", "tier": "semantic"})
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d", rec.Code)
+	}
+	if !strings.Contains(strings.ToLower(rec.Body.String()), "read-only") {
+		t.Fatalf("403 body %q must name the read-only credential as the reason", rec.Body.String())
+	}
+}
+
+// TestReadOnlyKeyAllowedOnReads: the same credential must still read. A gate
+// that denied reads too would be indistinguishable from simply revoking the key.
+func TestReadOnlyKeyAllowedOnReads(t *testing.T) {
+	h := newReadOnlyServer(t, "")
+	for _, tc := range []struct {
+		method, path string
+		body         any
+	}{
+		{http.MethodGet, "/v1/memories", nil},
+		{http.MethodPost, "/v1/search", map[string]any{"query": "x"}},
+		{http.MethodGet, "/v1/namespaces", nil},
+		{http.MethodGet, "/v1/stats", nil},
+		{http.MethodGet, "/v1/self", nil},
+		{http.MethodGet, "/v1/activity", nil},
+		{http.MethodGet, "/v1/pins", nil},
+		{http.MethodGet, "/v1/keys", nil},
+		{http.MethodPost, "/v1/handshake", map[string]any{"project": map[string]any{"cwd_basename": "repo"}}},
+	} {
+		rec := do(t, h, tc.method, tc.path, "alice", "tok-ci", tc.body)
+		if rec.Code == http.StatusForbidden {
+			t.Errorf("%s %s with a read-only key: want it allowed, got 403 (%s)",
+				tc.method, tc.path, strings.TrimSpace(rec.Body.String()))
+		}
+	}
+}
+
+// TestNonReadOnlyNamedKeyStillWrites guards against the gate leaking onto every
+// named principal instead of only read-only ones.
+func TestNonReadOnlyNamedKeyStillWrites(t *testing.T) {
+	h := newReadOnlyServer(t, "")
+	rec := do(t, h, http.MethodPost, "/v1/memories", "alice", "tok-bot",
+		map[string]any{"content": "a normal write", "tier": "semantic"})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("read-write named key: want 201, got %d (%s)", rec.Code, rec.Body)
+	}
+}
+
+// TestEnvKeyUnaffectedByReadOnlyGate: the admin env key authenticates with NO
+// principal, so it can carry no capability bits and must stay fully privileged.
+func TestEnvKeyUnaffectedByReadOnlyGate(t *testing.T) {
+	h := newReadOnlyServer(t, "admin-secret")
+	rec := do(t, h, http.MethodPost, "/v1/memories", "alice", "admin-secret",
+		map[string]any{"content": "an env-key write", "tier": "semantic"})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("admin env key: want 201, got %d (%s)", rec.Code, rec.Body)
+	}
+}
+
+// TestDevModeUnaffectedByReadOnlyGate: dev mode — no admin key configured and
+// an empty key table — also resolves to a nil principal and must keep writing.
+func TestDevModeUnaffectedByReadOnlyGate(t *testing.T) {
+	// A key store that stays EMPTY is what makes this dev mode: the moment any
+	// row exists, table auth becomes mandatory (see apiauth.Config.Authenticate).
+	h, _ := newServerWithKeyStore(t, "")
+	rec := do(t, h, http.MethodPost, "/v1/memories", "alice", "",
+		map[string]any{"content": "a dev-mode write", "tier": "semantic"})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("dev mode: want 201, got %d (%s)", rec.Code, rec.Body)
+	}
+}
+
+// TestReadOnlyGateDoesNotMaskRouting pins how the gate composes with chi's
+// routing. rest.Mount registers the /v1 routes inside a chi Group, and a Group's
+// middleware runs only for paths that match a route registered IN that group —
+// so an unknown path 404s from the parent router without the gate ever seeing
+// it.
+//
+// That is the behavior we want: the gate never manufactures a 403 for an
+// endpoint that does not exist, so it cannot mask a routing bug or make
+// endpoint-probing responses differ from a normal key's. The security property
+// lives elsewhere — every route actually registered in the group passes through
+// the gate, which is what TestReadOnlyKeyDeniedOnEveryWriteEndpoint proves
+// across the full mutating surface.
+func TestReadOnlyGateDoesNotMaskRouting(t *testing.T) {
+	h := newReadOnlyServer(t, "")
+	rec := do(t, h, http.MethodPost, "/v1/no-such-endpoint", "alice", "tok-ci", map[string]any{})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unrouted POST with a read-only key: want 404 from routing, got %d (%s)",
+			rec.Code, strings.TrimSpace(rec.Body.String()))
+	}
+	// And it 404s identically for a read-write key — the gate introduces no
+	// observable difference for a nonexistent endpoint.
+	rec = do(t, h, http.MethodPost, "/v1/no-such-endpoint", "alice", "tok-bot", map[string]any{})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unrouted POST with a read-write key: want 404, got %d", rec.Code)
+	}
+}
+
+// --- Wire surface: the capability must be visible, settable and preserved ---
+
+// TestSelfReportsReadOnlyCapability: GET /v1/self is how a client learns it must
+// not attempt writes (see CallerIdentity.read_only). Getting this wrong makes an
+// unattended agent retry writes forever and log a 403 per turn.
+func TestSelfReportsReadOnlyCapability(t *testing.T) {
+	h := newReadOnlyServer(t, "admin-secret")
+	for _, tc := range []struct {
+		label, token string
+		wantReadOnly bool
+	}{
+		{"read-only named key", "tok-ci", true},
+		{"read-write named key", "tok-bot", false},
+		{"admin env key (no principal)", "admin-secret", false},
+	} {
+		rec := do(t, h, http.MethodGet, "/v1/self", "alice", tc.token, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: GET /v1/self want 200, got %d (%s)", tc.label, rec.Code, rec.Body)
+		}
+		var out struct {
+			Identity struct {
+				ReadOnly bool `json:"read_only"`
+			} `json:"identity"`
+		}
+		mustJSON(t, rec, &out)
+		if out.Identity.ReadOnly != tc.wantReadOnly {
+			t.Errorf("%s: identity.read_only = %v, want %v", tc.label, out.Identity.ReadOnly, tc.wantReadOnly)
+		}
+	}
+}
+
+// TestHandshakeReportsReadOnlyCapability: the handshake is the one call a client
+// makes before anything else, so the capability has to ride along with it — a
+// client that had to make a second call to learn it would race its own writes.
+func TestHandshakeReportsReadOnlyCapability(t *testing.T) {
+	h := newReadOnlyServer(t, "")
+	rec := do(t, h, http.MethodPost, "/v1/handshake", "alice", "tok-ci",
+		map[string]any{"project": map[string]any{"cwd_basename": "repo"}})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("handshake: want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+	var out struct {
+		Identity struct {
+			ReadOnly bool `json:"read_only"`
+		} `json:"identity"`
+	}
+	mustJSON(t, rec, &out)
+	if !out.Identity.ReadOnly {
+		t.Errorf("handshake identity.read_only = false, want true for a read-only credential")
+	}
+}
+
+// TestListApiKeysExposesReadOnly: an operator must be able to see which keys are
+// read-only, or the capability is unauditable.
+func TestListApiKeysExposesReadOnly(t *testing.T) {
+	h, ks := newKeysTestServer(t, "admin-secret", "")
+	ctx := context.Background()
+	if err := ks.PutAPIKey(ctx, store.APIKey{Name: "ci", Hash: hashOf("tok-ci"), ReadOnly: true}); err != nil {
+		t.Fatalf("seed ci: %v", err)
+	}
+	if err := ks.PutAPIKey(ctx, store.APIKey{Name: "bot", Hash: hashOf("tok-bot")}); err != nil {
+		t.Fatalf("seed bot: %v", err)
+	}
+	rec := do(t, h, http.MethodGet, "/v1/keys", "", "admin-secret", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list keys: want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+	var out struct {
+		Keys []struct {
+			Name     string `json:"name"`
+			ReadOnly bool   `json:"read_only"`
+		} `json:"keys"`
+	}
+	mustJSON(t, rec, &out)
+	got := map[string]bool{}
+	for _, k := range out.Keys {
+		got[k.Name] = k.ReadOnly
+	}
+	if !got["ci"] {
+		t.Errorf("list: ci read_only = false, want true")
+	}
+	if got["bot"] {
+		t.Errorf("list: bot read_only = true, want false")
+	}
+}
+
+// TestCreateApiKeyReadOnlyFlag covers POST /v1/keys honouring read_only, in both
+// directions and when omitted.
+func TestCreateApiKeyReadOnlyFlag(t *testing.T) {
+	h, ks := newKeysTestServer(t, "admin-secret", "")
+	for _, tc := range []struct {
+		name string
+		body map[string]any
+		want bool
+	}{
+		{"ro", map[string]any{"name": "ro", "read_only": true}, true},
+		{"rw", map[string]any{"name": "rw", "read_only": false}, false},
+		{"omitted", map[string]any{"name": "omitted"}, false},
+	} {
+		rec := do(t, h, http.MethodPost, "/v1/keys", "", "admin-secret", tc.body)
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("%s: create want 201, got %d (%s)", tc.name, rec.Code, rec.Body)
+		}
+		var out struct {
+			ReadOnly bool `json:"read_only"`
+		}
+		mustJSON(t, rec, &out)
+		if out.ReadOnly != tc.want {
+			t.Errorf("%s: response read_only = %v, want %v", tc.name, out.ReadOnly, tc.want)
+		}
+		if k := findKey(t, ks, tc.name); k.ReadOnly != tc.want {
+			t.Errorf("%s: stored ReadOnly = %v, want %v", tc.name, k.ReadOnly, tc.want)
+		}
+	}
+}
+
+// TestUpdateApiKeyReadOnlyPreserveAndSelfGuard covers PATCH /v1/keys/{name}:
+// preserve-unspecified in both directions, cross-key edits, and the self-guard.
+//
+// The self-guard matters more here than for admin: a key that imposes read_only
+// on ITSELF can no longer reach this endpoint to lift it (the read-only gate
+// refuses the PATCH), so it would be a one-way trip recoverable only out-of-band.
+func TestUpdateApiKeyReadOnlyPreserveAndSelfGuard(t *testing.T) {
+	h, ks := newKeysTestServer(t, "", "")
+	ctx := context.Background()
+	if err := ks.PutAPIKey(ctx, store.APIKey{Name: "boss", Hash: hashOf("tok-boss"), Admin: true}); err != nil {
+		t.Fatalf("seed boss: %v", err)
+	}
+	if err := ks.PutAPIKey(ctx, store.APIKey{Name: "worker", Hash: hashOf("tok-worker")}); err != nil {
+		t.Fatalf("seed worker: %v", err)
+	}
+
+	// Self-impose read_only → 409, and the key is untouched.
+	rec := do(t, h, http.MethodPatch, "/v1/keys/boss", "", "tok-boss", map[string]any{"read_only": true})
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("self-impose read_only: want 409, got %d (%s)", rec.Code, rec.Body)
+	}
+	if k := findKey(t, ks, "boss"); k.ReadOnly {
+		t.Fatalf("boss must be unchanged by the rejected self-edit, got ReadOnly=true")
+	}
+
+	// Cross-key: boss imposes read_only on worker, then lifts it.
+	rec = do(t, h, http.MethodPatch, "/v1/keys/worker", "", "tok-boss", map[string]any{"read_only": true})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("impose read_only on worker: want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+	if k := findKey(t, ks, "worker"); !k.ReadOnly {
+		t.Errorf("worker ReadOnly = false, want true after the patch")
+	}
+
+	// A patch that OMITS read_only must preserve it.
+	rec = do(t, h, http.MethodPatch, "/v1/keys/worker", "", "tok-boss", map[string]any{"home": "acme/w"})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("home-only patch: want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+	if k := findKey(t, ks, "worker"); !k.ReadOnly {
+		t.Errorf("read_only must survive a PATCH that omits it")
+	}
+
+	rec = do(t, h, http.MethodPatch, "/v1/keys/worker", "", "tok-boss", map[string]any{"read_only": false})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("lift read_only: want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+	if k := findKey(t, ks, "worker"); k.ReadOnly {
+		t.Errorf("worker ReadOnly = true, want false after lifting")
+	}
+
+	// A named key CAN lift read_only from itself — that direction is a
+	// restoration, not a lockout, and is only reachable because the key is not
+	// read-only yet at the time of the request.
+	rec = do(t, h, http.MethodPatch, "/v1/keys/boss", "", "tok-boss", map[string]any{"read_only": false})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("self-lift read_only (a no-op restoration): want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+}
+
+// TestRotateApiKeyPreservesReadOnly: rotation rewrites the secret, and must not
+// quietly restore write access while doing so.
+func TestRotateApiKeyPreservesReadOnly(t *testing.T) {
+	h, ks := newKeysTestServer(t, "admin-secret", "")
+	if err := ks.PutAPIKey(context.Background(), store.APIKey{
+		Name: "ci", Hash: hashOf("tok-ci"), ReadOnly: true,
+	}); err != nil {
+		t.Fatalf("seed ci: %v", err)
+	}
+	rec := do(t, h, http.MethodPost, "/v1/keys/ci/rotate", "", "admin-secret", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("rotate: want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+	var out struct {
+		ReadOnly bool   `json:"read_only"`
+		Secret   string `json:"secret"`
+	}
+	mustJSON(t, rec, &out)
+	if out.Secret == "" {
+		t.Fatalf("rotate must return the new secret")
+	}
+	if !out.ReadOnly {
+		t.Errorf("rotate response read_only = false, want true")
+	}
+	if k := findKey(t, ks, "ci"); !k.ReadOnly {
+		t.Errorf("stored ReadOnly = false after rotation, want true")
+	}
+}

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -59,6 +59,10 @@ func (h *Server) Mount(r chi.Router) {
 		// Authentication first: an unauthenticated caller gets 401, never a
 		// 400 that leaks namespace-validation behavior.
 		r.Use(h.auth.authMiddleware)
+		// Authorization second: a read-only credential's write is refused here,
+		// before attribution or namespace resolution does any work for a
+		// request that will never reach a handler.
+		r.Use(h.auth.readOnlyMiddleware)
 		// Attribution rides on the authenticated principal, so it runs right
 		// after auth and before the handlers that log activity events.
 		r.Use(h.auth.actorMiddleware)

--- a/internal/apiauth/apiauth.go
+++ b/internal/apiauth/apiauth.go
@@ -28,11 +28,17 @@ import (
 // resolution. Admin carries the key's per-key admin capability
 // (store.APIKey.Admin) — adminness is now a capability any named principal
 // can hold, no longer solely the nil-principal env key's exclusive property.
+// ReadOnly carries the key's per-key read-only capability
+// (store.APIKey.ReadOnly), the second and independent authorization bit: it
+// denies every mutating operation at the API edge while leaving reads alone.
+// Both bits are false for a nil principal (the env key and dev mode), which is
+// why those two remain fully privileged.
 type Principal struct {
 	Name      string
 	HomeNS    string
 	DefaultNS string
 	Admin     bool
+	ReadOnly  bool
 }
 
 // keyTableCacheTTL bounds how stale the "does the api_keys table hold any
@@ -146,7 +152,7 @@ func (c Config) Authenticate(ctx context.Context, token string) (p *Principal, o
 			if key.Disabled {
 				return nil, false, nil
 			}
-			return &Principal{Name: key.Name, HomeNS: key.HomeNS, DefaultNS: key.DefaultNS, Admin: key.Admin}, true, nil
+			return &Principal{Name: key.Name, HomeNS: key.HomeNS, DefaultNS: key.DefaultNS, Admin: key.Admin, ReadOnly: key.ReadOnly}, true, nil
 		}
 	}
 	if token != "" && c.KeyStore != nil {
@@ -155,7 +161,7 @@ func (c Config) Authenticate(ctx context.Context, token string) (p *Principal, o
 			return nil, false, gerr
 		}
 		if key != nil && !key.Disabled {
-			return &Principal{Name: key.Name, HomeNS: key.HomeNS, DefaultNS: key.DefaultNS, Admin: key.Admin}, true, nil
+			return &Principal{Name: key.Name, HomeNS: key.HomeNS, DefaultNS: key.DefaultNS, Admin: key.Admin, ReadOnly: key.ReadOnly}, true, nil
 		}
 		return nil, false, nil
 	}

--- a/internal/apiauth/apiauth_test.go
+++ b/internal/apiauth/apiauth_test.go
@@ -141,6 +141,79 @@ func TestAuthenticateTableKeyAdminFalsePropagates(t *testing.T) {
 	}
 }
 
+// TestAuthenticateTableKeyReadOnlyTruePropagates: a table key with
+// ReadOnly=true yields a Principal with ReadOnly=true — the second
+// authorization bit, carried alongside Admin rather than replacing it.
+func TestAuthenticateTableKeyReadOnlyTruePropagates(t *testing.T) {
+	ks := openKeyStore(t)
+	ctx := context.Background()
+	if err := ks.PutAPIKey(ctx, store.APIKey{
+		Name: "ci-bot", Hash: hashOf("tok-ci"), CreatedAt: time.Now().UTC(), ReadOnly: true,
+	}); err != nil {
+		t.Fatalf("PutAPIKey: %v", err)
+	}
+	cfg := apiauth.New("", ks)
+	p, ok, err := cfg.Authenticate(ctx, "tok-ci")
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if !ok {
+		t.Fatalf("table key: want authenticated")
+	}
+	if p == nil || !p.ReadOnly {
+		t.Fatalf("table key read_only=true: want Principal.ReadOnly=true, got %+v", p)
+	}
+}
+
+// TestAuthenticateTableKeyReadOnlyFalsePropagates: a table key with
+// ReadOnly=false (the default) yields a Principal with ReadOnly=false, so an
+// existing key keeps write access after the column is added.
+func TestAuthenticateTableKeyReadOnlyFalsePropagates(t *testing.T) {
+	ks := openKeyStore(t)
+	ctx := context.Background()
+	if err := ks.PutAPIKey(ctx, store.APIKey{
+		Name: "rw-bot", Hash: hashOf("tok-rw"), CreatedAt: time.Now().UTC(), ReadOnly: false,
+	}); err != nil {
+		t.Fatalf("PutAPIKey: %v", err)
+	}
+	cfg := apiauth.New("", ks)
+	p, ok, err := cfg.Authenticate(ctx, "tok-rw")
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if !ok {
+		t.Fatalf("table key: want authenticated")
+	}
+	if p == nil || p.ReadOnly {
+		t.Fatalf("table key read_only=false: want Principal.ReadOnly=false, got %+v", p)
+	}
+}
+
+// TestAuthenticateTableKeyAdminAndReadOnlyAreIndependent: admin and read_only
+// are two separate bits on one principal, so an admin key can also be
+// read-only (it may enumerate keys but not mutate anything).
+func TestAuthenticateTableKeyAdminAndReadOnlyAreIndependent(t *testing.T) {
+	ks := openKeyStore(t)
+	ctx := context.Background()
+	if err := ks.PutAPIKey(ctx, store.APIKey{
+		Name: "auditor", Hash: hashOf("tok-auditor"), CreatedAt: time.Now().UTC(),
+		Admin: true, ReadOnly: true,
+	}); err != nil {
+		t.Fatalf("PutAPIKey: %v", err)
+	}
+	cfg := apiauth.New("", ks)
+	p, ok, err := cfg.Authenticate(ctx, "tok-auditor")
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if !ok {
+		t.Fatalf("table key: want authenticated")
+	}
+	if p == nil || !p.Admin || !p.ReadOnly {
+		t.Fatalf("admin+read_only key: want Principal{Admin:true, ReadOnly:true}, got %+v", p)
+	}
+}
+
 // TestAuthenticateAdminKeyStaysNilPrincipal: the env admin key still resolves
 // to a nil Principal (never a named admin principal) — adminness for the env
 // key is expressed entirely by principal-nil-ness, unchanged by this

--- a/internal/apiauth/filekeys.go
+++ b/internal/apiauth/filekeys.go
@@ -35,6 +35,12 @@ type fileKeyEntry struct {
 	// Admin marks this key as an admin credential (store.APIKey.Admin's doc);
 	// defaults to false when omitted.
 	Admin bool `yaml:"admin"`
+	// ReadOnly marks this key as a read-only credential (store.APIKey.ReadOnly's
+	// doc); defaults to false when omitted, so an existing file keeps every key
+	// read-write across the upgrade. This file is the primary provisioning path
+	// for an unattended credential (a mounted Secret in CI), which is why the
+	// capability has to be expressible declaratively and not only over the API.
+	ReadOnly bool `yaml:"read_only"`
 	// Settings is an optional per-key ClientSettings override (config-handshake
 	// redesign), decoded as a generic map here and bridged to the JSON-tagged
 	// store.ClientSettings in validateFileKeyEntry — see clientSettingsFromYAML
@@ -171,6 +177,7 @@ func validateFileKeyEntry(idx int, e fileKeyEntry) (store.APIKey, error) {
 		DefaultNS: defNS,
 		Disabled:  e.Disabled,
 		Admin:     e.Admin,
+		ReadOnly:  e.ReadOnly,
 		Settings:  settings,
 	}, nil
 }

--- a/internal/apiauth/filekeys_auth_test.go
+++ b/internal/apiauth/filekeys_auth_test.go
@@ -112,6 +112,53 @@ keys:
 	}
 }
 
+// TestAuthenticateFileKeyReadOnlyPropagates: a file entry with read_only: true
+// yields a Principal with ReadOnly=true, the same per-key capability a table
+// key gets. This is the path a CI credential actually arrives on.
+func TestAuthenticateFileKeyReadOnlyPropagates(t *testing.T) {
+	path := writeKeysFile(t, `
+keys:
+  - name: ci-agent
+    secret: "tok-ci-agent"
+    read_only: true
+`)
+	fk, err := apiauth.LoadFileKeys(path)
+	if err != nil {
+		t.Fatalf("LoadFileKeys: %v", err)
+	}
+	cfg := apiauth.New("", nil).WithFileKeys(fk)
+	p, ok, err := cfg.Authenticate(context.Background(), "tok-ci-agent")
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if !ok || p == nil || !p.ReadOnly {
+		t.Fatalf("file key read_only=true: want authenticated with Principal.ReadOnly=true, got (%+v, %v, %v)", p, ok, err)
+	}
+}
+
+// TestAuthenticateFileKeyReadOnlyDefaultsFalse: a file entry with no read_only
+// field yields a Principal with ReadOnly=false, so existing declarative keys
+// keep write access across the upgrade.
+func TestAuthenticateFileKeyReadOnlyDefaultsFalse(t *testing.T) {
+	path := writeKeysFile(t, `
+keys:
+  - name: plain-alex
+    secret: "tok-plain-alex-ro"
+`)
+	fk, err := apiauth.LoadFileKeys(path)
+	if err != nil {
+		t.Fatalf("LoadFileKeys: %v", err)
+	}
+	cfg := apiauth.New("", nil).WithFileKeys(fk)
+	p, ok, err := cfg.Authenticate(context.Background(), "tok-plain-alex-ro")
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if !ok || p == nil || p.ReadOnly {
+		t.Fatalf("file key with no read_only field: want authenticated with Principal.ReadOnly=false, got (%+v, %v, %v)", p, ok, err)
+	}
+}
+
 func TestAuthenticateFileKeyHashVariantResolvesSameAsSecret(t *testing.T) {
 	path := writeKeysFile(t, `
 keys:

--- a/internal/apiauth/filekeys_test.go
+++ b/internal/apiauth/filekeys_test.go
@@ -109,6 +109,37 @@ keys:
 	}
 }
 
+// TestLoadFileKeysParsesReadOnly covers the read_only YAML field parsing into
+// store.APIKey.ReadOnly, both explicitly true and the false-by-default case.
+// The declarative file is the primary provisioning path for a CI credential
+// (a mounted Secret), so silently dropping the field here would hand that
+// credential write access.
+func TestLoadFileKeysParsesReadOnly(t *testing.T) {
+	path := writeKeysFile(t, `
+keys:
+  - name: ci-agent
+    hash: "`+hashOf("tok-ci-agent")+`"
+    read_only: true
+  - name: plain-bob
+    hash: "`+hashOf("tok-plain-bob-ro")+`"
+`)
+	fk, err := apiauth.LoadFileKeys(path)
+	if err != nil {
+		t.Fatalf("LoadFileKeys: %v", err)
+	}
+	keys := fk.FileKeys()
+	byName := map[string]bool{}
+	for _, k := range keys {
+		byName[k.Name] = k.ReadOnly
+	}
+	if ro, ok := byName["ci-agent"]; !ok || !ro {
+		t.Fatalf("ci-agent: want read_only=true, got %+v", keys)
+	}
+	if ro, ok := byName["plain-bob"]; !ok || ro {
+		t.Fatalf("plain-bob (no read_only field): want read_only=false, got %+v", keys)
+	}
+}
+
 func TestLoadFileKeysDisabledEntry(t *testing.T) {
 	path := writeKeysFile(t, `
 keys:

--- a/internal/store/postgres/helpers.go
+++ b/internal/store/postgres/helpers.go
@@ -268,11 +268,11 @@ func scanAPIKeys(rs rows) ([]store.APIKey, error) {
 }
 
 // scanAPIKey scans a single (name, key_hash, home_ns, default_ns,
-// created_at, disabled, settings, admin) row.
+// created_at, disabled, settings, admin, read_only) row.
 func scanAPIKey(s rowScanner) (store.APIKey, error) {
 	var k store.APIKey
 	var settingsBytes []byte
-	if err := s.Scan(&k.Name, &k.Hash, &k.HomeNS, &k.DefaultNS, &k.CreatedAt, &k.Disabled, &settingsBytes, &k.Admin); err != nil {
+	if err := s.Scan(&k.Name, &k.Hash, &k.HomeNS, &k.DefaultNS, &k.CreatedAt, &k.Disabled, &settingsBytes, &k.Admin, &k.ReadOnly); err != nil {
 		return k, err
 	}
 	k.CreatedAt = k.CreatedAt.UTC()

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -164,7 +164,8 @@ func migrate(ctx context.Context, conn *pgx.Conn, dims int) error {
 			default_ns text NOT NULL DEFAULT '',
 			created_at timestamptz NOT NULL,
 			disabled   boolean NOT NULL DEFAULT false,
-			admin      boolean NOT NULL DEFAULT false
+			admin      boolean NOT NULL DEFAULT false,
+			read_only  boolean NOT NULL DEFAULT false
 		)`,
 		// Backfill default_ns on databases whose api_keys table predates it.
 		`ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS default_ns text NOT NULL DEFAULT ''`,
@@ -174,6 +175,10 @@ func migrate(ctx context.Context, conn *pgx.Conn, dims int) error {
 		// api_keys.admin holds the per-key admin capability (admin-keys
 		// redesign); see store.APIKey.Admin's doc.
 		`ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS admin boolean NOT NULL DEFAULT false`,
+		// api_keys.read_only holds the per-key read-only capability (see
+		// store.APIKey.ReadOnly). Defaulting to false is what keeps every
+		// pre-existing key read-write across the upgrade.
+		`ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS read_only boolean NOT NULL DEFAULT false`,
 		// memory_events is the activity log (see store.EventLogStore): one row
 		// per (operation, memory), rows of one operation sharing op_id. The
 		// memory_* columns are a snapshot, not a join — they keep the feed a
@@ -1053,12 +1058,13 @@ func (s *Store) PutAPIKey(ctx context.Context, k store.APIKey) error {
 		return fmt.Errorf("postgres: marshal api key settings: %w", err)
 	}
 	_, err = tx.Exec(ctx,
-		`INSERT INTO api_keys (name, key_hash, home_ns, default_ns, created_at, disabled, settings, admin)
-		VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8)
+		`INSERT INTO api_keys (name, key_hash, home_ns, default_ns, created_at, disabled, settings, admin, read_only)
+		VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8,$9)
 		ON CONFLICT (name) DO UPDATE SET
 			key_hash=EXCLUDED.key_hash, home_ns=EXCLUDED.home_ns, default_ns=EXCLUDED.default_ns,
-			created_at=EXCLUDED.created_at, disabled=EXCLUDED.disabled, settings=EXCLUDED.settings, admin=EXCLUDED.admin`,
-		k.Name, k.Hash, k.HomeNS, k.DefaultNS, created, k.Disabled, string(settingsJSON), k.Admin)
+			created_at=EXCLUDED.created_at, disabled=EXCLUDED.disabled, settings=EXCLUDED.settings, admin=EXCLUDED.admin,
+			read_only=EXCLUDED.read_only`,
+		k.Name, k.Hash, k.HomeNS, k.DefaultNS, created, k.Disabled, string(settingsJSON), k.Admin, k.ReadOnly)
 	if err != nil {
 		return fmt.Errorf("postgres: put api key: %w", err)
 	}
@@ -1078,7 +1084,7 @@ func (s *Store) DeleteAPIKey(ctx context.Context, name string) (bool, error) {
 // ListAPIKeys returns every key ordered by name.
 func (s *Store) ListAPIKeys(ctx context.Context) ([]store.APIKey, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT name, key_hash, home_ns, default_ns, created_at, disabled, settings, admin FROM api_keys ORDER BY name`)
+		`SELECT name, key_hash, home_ns, default_ns, created_at, disabled, settings, admin, read_only FROM api_keys ORDER BY name`)
 	if err != nil {
 		return nil, fmt.Errorf("postgres: list api keys: %w", err)
 	}
@@ -1089,7 +1095,7 @@ func (s *Store) ListAPIKeys(ctx context.Context) ([]store.APIKey, error) {
 // does.
 func (s *Store) GetAPIKeyByHash(ctx context.Context, hash string) (*store.APIKey, error) {
 	row := s.pool.QueryRow(ctx,
-		`SELECT name, key_hash, home_ns, default_ns, created_at, disabled, settings, admin FROM api_keys WHERE key_hash=$1`, hash)
+		`SELECT name, key_hash, home_ns, default_ns, created_at, disabled, settings, admin, read_only FROM api_keys WHERE key_hash=$1`, hash)
 	k, err := scanAPIKey(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil

--- a/internal/store/sqlitevec/helpers.go
+++ b/internal/store/sqlitevec/helpers.go
@@ -304,12 +304,12 @@ func scanAPIKeys(rows *sql.Rows) ([]store.APIKey, error) {
 }
 
 // scanAPIKey scans a single (name, key_hash, home_ns, default_ns,
-// created_at, disabled, settings, admin) row.
+// created_at, disabled, settings, admin, read_only) row.
 func scanAPIKey(s scanner) (store.APIKey, error) {
 	var k store.APIKey
 	var created, settingsJSON string
-	var disabled, admin int
-	if err := s.Scan(&k.Name, &k.Hash, &k.HomeNS, &k.DefaultNS, &created, &disabled, &settingsJSON, &admin); err != nil {
+	var disabled, admin, readOnly int
+	if err := s.Scan(&k.Name, &k.Hash, &k.HomeNS, &k.DefaultNS, &created, &disabled, &settingsJSON, &admin, &readOnly); err != nil {
 		return k, err
 	}
 	t, err := time.Parse(time.RFC3339Nano, created)
@@ -319,6 +319,7 @@ func scanAPIKey(s scanner) (store.APIKey, error) {
 	k.CreatedAt = t.UTC()
 	k.Disabled = disabled != 0
 	k.Admin = admin != 0
+	k.ReadOnly = readOnly != 0
 	// Tolerant decode: unknown fields in an older/newer writer's blob are
 	// ignored (json.Unmarshal's default behavior) — strict validation is the
 	// REST boundary's job, not the store's. An empty column value (a raw or

--- a/internal/store/sqlitevec/store.go
+++ b/internal/store/sqlitevec/store.go
@@ -175,7 +175,8 @@ func (s *Store) migrate(ctx context.Context) error {
 			default_ns TEXT NOT NULL DEFAULT '',
 			created_at TEXT NOT NULL,
 			disabled   INTEGER NOT NULL DEFAULT 0,
-			admin      INTEGER NOT NULL DEFAULT 0
+			admin      INTEGER NOT NULL DEFAULT 0,
+			read_only  INTEGER NOT NULL DEFAULT 0
 		)`,
 		// memory_events is the activity log (see store.EventLogStore): one row
 		// per (operation, memory), rows of one operation sharing op_id. The
@@ -245,6 +246,12 @@ func (s *Store) migrate(ctx context.Context) error {
 	// api_keys.admin holds the per-key admin capability (admin-keys redesign);
 	// see store.APIKey.Admin's doc.
 	if err := s.addColumnIfMissing(ctx, "api_keys", "admin", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
+	}
+	// api_keys.read_only holds the per-key read-only capability (see
+	// store.APIKey.ReadOnly). Defaulting to 0 is what keeps every pre-existing
+	// key read-write across the upgrade.
+	if err := s.addColumnIfMissing(ctx, "api_keys", "read_only", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return err
 	}
 	// memory_events.actor/actor_kind carry activity attribution (admin-keys T5):
@@ -1338,12 +1345,14 @@ func (s *Store) PutAPIKey(ctx context.Context, k store.APIKey) error {
 		return fmt.Errorf("sqlitevec: marshal api key settings: %w", err)
 	}
 	_, err = tx.ExecContext(ctx,
-		`INSERT INTO api_keys (name, key_hash, home_ns, default_ns, created_at, disabled, settings, admin)
-		VALUES (?,?,?,?,?,?,?,?)
+		`INSERT INTO api_keys (name, key_hash, home_ns, default_ns, created_at, disabled, settings, admin, read_only)
+		VALUES (?,?,?,?,?,?,?,?,?)
 		ON CONFLICT(name) DO UPDATE SET
 			key_hash=excluded.key_hash, home_ns=excluded.home_ns, default_ns=excluded.default_ns,
-			created_at=excluded.created_at, disabled=excluded.disabled, settings=excluded.settings, admin=excluded.admin`,
-		k.Name, k.Hash, k.HomeNS, k.DefaultNS, created.Format(time.RFC3339Nano), boolToInt(k.Disabled), string(settingsJSON), boolToInt(k.Admin))
+			created_at=excluded.created_at, disabled=excluded.disabled, settings=excluded.settings, admin=excluded.admin,
+			read_only=excluded.read_only`,
+		k.Name, k.Hash, k.HomeNS, k.DefaultNS, created.Format(time.RFC3339Nano),
+		boolToInt(k.Disabled), string(settingsJSON), boolToInt(k.Admin), boolToInt(k.ReadOnly))
 	if err != nil {
 		return fmt.Errorf("sqlitevec: put api key: %w", err)
 	}
@@ -1367,7 +1376,7 @@ func (s *Store) DeleteAPIKey(ctx context.Context, name string) (bool, error) {
 // ListAPIKeys returns every key ordered by name.
 func (s *Store) ListAPIKeys(ctx context.Context) ([]store.APIKey, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT name, key_hash, home_ns, default_ns, created_at, disabled, settings, admin FROM api_keys ORDER BY name`)
+		`SELECT name, key_hash, home_ns, default_ns, created_at, disabled, settings, admin, read_only FROM api_keys ORDER BY name`)
 	if err != nil {
 		return nil, fmt.Errorf("sqlitevec: list api keys: %w", err)
 	}
@@ -1378,7 +1387,7 @@ func (s *Store) ListAPIKeys(ctx context.Context) ([]store.APIKey, error) {
 // does.
 func (s *Store) GetAPIKeyByHash(ctx context.Context, hash string) (*store.APIKey, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT name, key_hash, home_ns, default_ns, created_at, disabled, settings, admin FROM api_keys WHERE key_hash=?`, hash)
+		`SELECT name, key_hash, home_ns, default_ns, created_at, disabled, settings, admin, read_only FROM api_keys WHERE key_hash=?`, hash)
 	k, err := scanAPIKey(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -837,6 +837,19 @@ type APIKey struct {
 	// capability through storage and auth. Preserved by rotation, same as
 	// every other field CLI/REST rotation does not explicitly change.
 	Admin bool
+	// ReadOnly marks this key as a read-only credential, the second
+	// authorization bit and a sibling to Admin above. It denies every mutating
+	// operation across both HTTP surfaces (REST and MCP) while leaving reads
+	// untouched — the enforcement itself lives at the API edge, not here; this
+	// field only carries the capability through storage and auth. It is
+	// INDEPENDENT of Admin: admin+read_only is a legitimate combination (an
+	// auditor who may enumerate keys but mutate nothing). Preserved by
+	// rotation, same as every other field CLI/REST rotation does not explicitly
+	// change — a rotation that dropped it would silently grant write access.
+	//
+	// Note this is "cannot mutate", not "cannot see": a read-only key can still
+	// name any namespace it likes and read it. Read scoping is a separate axis.
+	ReadOnly bool
 	// Settings is this key's per-key ClientSettings override, merged over the
 	// server's global defaults (ClientSettingsStore) and the built-in
 	// defaults (DefaultClientSettings) by MergeClientSettings. The zero value

--- a/internal/store/storetest/conformance.go
+++ b/internal/store/storetest/conformance.go
@@ -2419,43 +2419,69 @@ func testAPIKeys(t *testing.T, st store.Store, dims int) {
 	t.Run("DuplicateHashDifferentNameErrors", func(t *testing.T) { testAPIKeyDuplicateHash(t, ks, ns) })
 	t.Run("DefaultNSRoundTrip", func(t *testing.T) { testAPIKeyDefaultNSRoundTrip(t, ks, ns) })
 	t.Run("RenameNamespaces", func(t *testing.T) { testAPIKeyRenameNamespaces(t, ks, ns) })
-	t.Run("AdminRoundTrip", func(t *testing.T) { testAPIKeyAdminRoundTrip(t, ks, ns) })
-	t.Run("AdminSurvivesRenameNamespaces", func(t *testing.T) { testAPIKeyAdminSurvivesRename(t, ks, ns) })
-	t.Run("AdminPreservedOnUpsertWithZeroCreatedAt", func(t *testing.T) { testAPIKeyAdminPreservedOnUpsert(t, ks, ns) })
+	for _, f := range apiKeyFlags {
+		t.Run(f.Label+"RoundTrip", func(t *testing.T) { testAPIKeyFlagRoundTrip(t, ks, ns, f) })
+		t.Run(f.Label+"SurvivesRenameNamespaces", func(t *testing.T) { testAPIKeyFlagSurvivesRename(t, ks, ns, f) })
+		t.Run(f.Label+"PreservedOnUpsertWithZeroCreatedAt", func(t *testing.T) { testAPIKeyFlagPreservedOnUpsert(t, ks, ns, f) })
+	}
+	t.Run("ReadOnlyIndependentOfAdmin", func(t *testing.T) { testAPIKeyReadOnlyIndependentOfAdmin(t, ks, ns) })
 }
 
-// testAPIKeyAdminRoundTrip covers store.APIKey.Admin round-tripping through
-// PutAPIKey/GetAPIKeyByHash/ListAPIKeys for both values — true (the key
-// authenticates the /v1/keys and /v1/settings/defaults surfaces) and false
-// (the sibling case to Disabled's own false-by-default round trip).
-func testAPIKeyAdminRoundTrip(t *testing.T, ks store.APIKeyStore, ns string) {
+// apiKeyFlag describes one boolean capability column on store.APIKey. The
+// storage contract for every such bit is identical — round-trip through
+// Put/Get/List, survive a namespace rename, survive a zero-CreatedAt upsert
+// (rotation) in both directions — so the coverage is written once here and run
+// per flag rather than copy-pasted per flag. A future third bit gets the full
+// suite by appending one entry.
+type apiKeyFlag struct {
+	// Label names the field in failure messages and prefixes the sub-test
+	// name, so changing it renames the sub-test.
+	Label string
+	// Slug is a filename-safe token mixed into generated key names so two
+	// flags' fixtures cannot collide within one namespace.
+	Slug string
+	Set  func(*store.APIKey, bool)
+	Get  func(store.APIKey) bool
+}
+
+// apiKeyFlags is every boolean capability the store must persist. Admin gates
+// the /v1/keys and /v1/settings/defaults surfaces; ReadOnly denies mutation
+// across both HTTP surfaces. They are independent — see
+// testAPIKeyReadOnlyIndependentOfAdmin.
+var apiKeyFlags = []apiKeyFlag{
+	{
+		Label: "Admin", Slug: "admin",
+		Set: func(k *store.APIKey, v bool) { k.Admin = v },
+		Get: func(k store.APIKey) bool { return k.Admin },
+	},
+	{
+		Label: "ReadOnly", Slug: "readonly",
+		Set: func(k *store.APIKey, v bool) { k.ReadOnly = v },
+		Get: func(k store.APIKey) bool { return k.ReadOnly },
+	},
+}
+
+// testAPIKeyFlagRoundTrip covers f round-tripping through
+// PutAPIKey/GetAPIKeyByHash/ListAPIKeys for both values — true and false (the
+// default, the sibling case to Disabled's own false-by-default round trip).
+func testAPIKeyFlagRoundTrip(t *testing.T, ks store.APIKeyStore, ns string, f apiKeyFlag) {
 	ctx := context.Background()
 	now := time.Now().UTC().Truncate(time.Millisecond)
 
-	adminName := ns + "-admin-true"
-	admin := store.APIKey{Name: adminName, Hash: apiKeyHash(adminName), CreatedAt: now, Admin: true}
-	if err := ks.PutAPIKey(ctx, admin); err != nil {
-		t.Fatalf("put admin=true: %v", err)
-	}
-	got, err := ks.GetAPIKeyByHash(ctx, admin.Hash)
-	if err != nil {
-		t.Fatalf("get by hash (admin=true): %v", err)
-	}
-	if got == nil || !got.Admin {
-		t.Fatalf("admin=true round-trip = %+v, want Admin=true", got)
-	}
-
-	nonAdminName := ns + "-admin-false"
-	nonAdmin := store.APIKey{Name: nonAdminName, Hash: apiKeyHash(nonAdminName), CreatedAt: now, Admin: false}
-	if err := ks.PutAPIKey(ctx, nonAdmin); err != nil {
-		t.Fatalf("put admin=false: %v", err)
-	}
-	got, err = ks.GetAPIKeyByHash(ctx, nonAdmin.Hash)
-	if err != nil {
-		t.Fatalf("get by hash (admin=false): %v", err)
-	}
-	if got == nil || got.Admin {
-		t.Fatalf("admin=false round-trip = %+v, want Admin=false", got)
+	names := map[bool]string{true: ns + "-" + f.Slug + "-true", false: ns + "-" + f.Slug + "-false"}
+	for _, want := range []bool{true, false} {
+		k := store.APIKey{Name: names[want], Hash: apiKeyHash(names[want]), CreatedAt: now}
+		f.Set(&k, want)
+		if err := ks.PutAPIKey(ctx, k); err != nil {
+			t.Fatalf("put %s=%v: %v", f.Label, want, err)
+		}
+		got, err := ks.GetAPIKeyByHash(ctx, k.Hash)
+		if err != nil {
+			t.Fatalf("get by hash (%s=%v): %v", f.Label, want, err)
+		}
+		if got == nil || f.Get(*got) != want {
+			t.Fatalf("%s=%v round-trip = %+v, want %s=%v", f.Label, want, got, f.Label, want)
+		}
 	}
 
 	// ListAPIKeys carries it too.
@@ -2463,42 +2489,39 @@ func testAPIKeyAdminRoundTrip(t *testing.T, ks store.APIKeyStore, ns string) {
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
-	seen := map[string]bool{}
+	seen := map[bool]bool{}
 	for _, k := range all {
-		switch k.Name {
-		case adminName:
-			seen[adminName] = true
-			if !k.Admin {
-				t.Fatalf("list: %q admin = false, want true", adminName)
+		for _, want := range []bool{true, false} {
+			if k.Name != names[want] {
+				continue
 			}
-		case nonAdminName:
-			seen[nonAdminName] = true
-			if k.Admin {
-				t.Fatalf("list: %q admin = true, want false", nonAdminName)
+			seen[want] = true
+			if f.Get(k) != want {
+				t.Fatalf("list: %q %s = %v, want %v", k.Name, f.Label, f.Get(k), want)
 			}
 		}
 	}
-	if !seen[adminName] || !seen[nonAdminName] {
-		t.Fatalf("list missing one of the admin round-trip keys: %+v", all)
+	if !seen[true] || !seen[false] {
+		t.Fatalf("list missing one of the %s round-trip keys: %+v", f.Label, all)
 	}
 }
 
-// testAPIKeyAdminSurvivesRename covers store.APIKey.Admin surviving
-// RenameAPIKeyNamespaces (which only touches HomeNS/DefaultNS) — the same
-// precedent as testAPIKeySettingsSurviveRename for the per-key Settings
-// override.
-func testAPIKeyAdminSurvivesRename(t *testing.T, ks store.APIKeyStore, ns string) {
+// testAPIKeyFlagSurvivesRename covers f surviving RenameAPIKeyNamespaces
+// (which only touches HomeNS/DefaultNS) — the same precedent as
+// testAPIKeySettingsSurviveRename for the per-key Settings override. A rename
+// that silently cleared ReadOnly would hand a CI credential write access.
+func testAPIKeyFlagSurvivesRename(t *testing.T, ks store.APIKeyStore, ns string, f apiKeyFlag) {
 	ctx := context.Background()
-	name := ns + "-admin-rename"
-	from := ns + "-admin-rename-old"
-	to := ns + "-admin-rename-new"
+	name := ns + "-" + f.Slug + "-rename"
+	from := name + "-old"
+	to := name + "-new"
 	k := store.APIKey{
 		Name:      name,
 		Hash:      apiKeyHash(name),
 		HomeNS:    from,
 		CreatedAt: time.Now().UTC().Truncate(time.Millisecond),
-		Admin:     true,
 	}
+	f.Set(&k, true)
 	if err := ks.PutAPIKey(ctx, k); err != nil {
 		t.Fatalf("put: %v", err)
 	}
@@ -2515,61 +2538,89 @@ func testAPIKeyAdminSurvivesRename(t *testing.T, ks store.APIKeyStore, ns string
 	if got.HomeNS != to {
 		t.Fatalf("home_ns after rename = %q, want %q", got.HomeNS, to)
 	}
-	if !got.Admin {
-		t.Fatalf("admin did not survive rename: %+v, want Admin=true", got)
+	if !f.Get(*got) {
+		t.Fatalf("%s did not survive rename: %+v, want %s=true", f.Label, got, f.Label)
 	}
 }
 
-// testAPIKeyAdminPreservedOnUpsert covers store.APIKey.Admin round-tripping
-// through the upsert-with-zero-CreatedAt path (rotation): the manual
+// testAPIKeyFlagPreservedOnUpsert covers f round-tripping through the
+// upsert-with-zero-CreatedAt path (rotation): the manual
 // read-then-conditional-write CreatedAt-preserve logic must not accidentally
-// drop Admin from the INSERT/ON CONFLICT column list, in either direction
-// (false->true and true->false), while CreatedAt itself is preserved from
-// the original row.
-func testAPIKeyAdminPreservedOnUpsert(t *testing.T, ks store.APIKeyStore, ns string) {
+// drop the column from the INSERT/ON CONFLICT list, in either direction, while
+// CreatedAt itself is preserved from the original row. A rotation that dropped
+// ReadOnly would silently promote a read-only credential to read-write.
+func testAPIKeyFlagPreservedOnUpsert(t *testing.T, ks store.APIKeyStore, ns string, f apiKeyFlag) {
 	ctx := context.Background()
 	now := time.Now().UTC().Truncate(time.Millisecond)
 
-	// false -> true across a zero-CreatedAt upsert.
-	nameA := ns + "-admin-upsert-a"
-	original := store.APIKey{Name: nameA, Hash: apiKeyHash(nameA + "-v1"), CreatedAt: now, Admin: false}
-	if err := ks.PutAPIKey(ctx, original); err != nil {
-		t.Fatalf("put original (a): %v", err)
+	for _, tc := range []struct {
+		suffix   string
+		from, to bool
+	}{
+		{"a", false, true},
+		{"b", true, false},
+	} {
+		name := ns + "-" + f.Slug + "-upsert-" + tc.suffix
+		original := store.APIKey{Name: name, Hash: apiKeyHash(name + "-v1"), CreatedAt: now}
+		f.Set(&original, tc.from)
+		if err := ks.PutAPIKey(ctx, original); err != nil {
+			t.Fatalf("put original (%s): %v", tc.suffix, err)
+		}
+		// Zero CreatedAt is what rotation writes: the driver must look the
+		// existing row's timestamp up rather than stamping a new one.
+		rotated := store.APIKey{Name: name, Hash: apiKeyHash(name + "-v2")}
+		f.Set(&rotated, tc.to)
+		if err := ks.PutAPIKey(ctx, rotated); err != nil {
+			t.Fatalf("put rotated (%s): %v", tc.suffix, err)
+		}
+		got, err := ks.GetAPIKeyByHash(ctx, rotated.Hash)
+		if err != nil {
+			t.Fatalf("get by hash after rotation (%s): %v", tc.suffix, err)
+		}
+		if got == nil || f.Get(*got) != tc.to {
+			t.Fatalf("%s after %v->%v upsert = %+v, want %s=%v", f.Label, tc.from, tc.to, got, f.Label, tc.to)
+		}
+		if !got.CreatedAt.Equal(now) {
+			t.Fatalf("created_at after rotation (%s) = %v, want preserved %v", tc.suffix, got.CreatedAt, now)
+		}
 	}
-	rotatedA := store.APIKey{Name: nameA, Hash: apiKeyHash(nameA + "-v2"), Admin: true}
-	if err := ks.PutAPIKey(ctx, rotatedA); err != nil {
-		t.Fatalf("put rotated (a): %v", err)
-	}
-	got, err := ks.GetAPIKeyByHash(ctx, rotatedA.Hash)
-	if err != nil {
-		t.Fatalf("get by hash after rotation (a): %v", err)
-	}
-	if got == nil || !got.Admin {
-		t.Fatalf("admin after false->true upsert = %+v, want Admin=true", got)
-	}
-	if !got.CreatedAt.Equal(now) {
-		t.Fatalf("created_at after rotation (a) = %v, want preserved %v", got.CreatedAt, now)
-	}
+}
 
-	// true -> false across a zero-CreatedAt upsert.
-	nameB := ns + "-admin-upsert-b"
-	originalB := store.APIKey{Name: nameB, Hash: apiKeyHash(nameB + "-v1"), CreatedAt: now, Admin: true}
-	if err := ks.PutAPIKey(ctx, originalB); err != nil {
-		t.Fatalf("put original (b): %v", err)
-	}
-	rotatedB := store.APIKey{Name: nameB, Hash: apiKeyHash(nameB + "-v2"), Admin: false}
-	if err := ks.PutAPIKey(ctx, rotatedB); err != nil {
-		t.Fatalf("put rotated (b): %v", err)
-	}
-	got, err = ks.GetAPIKeyByHash(ctx, rotatedB.Hash)
-	if err != nil {
-		t.Fatalf("get by hash after rotation (b): %v", err)
-	}
-	if got == nil || got.Admin {
-		t.Fatalf("admin after true->false upsert = %+v, want Admin=false", got)
-	}
-	if !got.CreatedAt.Equal(now) {
-		t.Fatalf("created_at after rotation (b) = %v, want preserved %v", got.CreatedAt, now)
+// testAPIKeyReadOnlyIndependentOfAdmin pins that ReadOnly and Admin are two
+// independent bits rather than one collapsed capability: admin+read_only is a
+// legitimate combination (a read-only auditor who can still enumerate keys),
+// so a column mix-up that aliased one onto the other must fail here.
+func testAPIKeyReadOnlyIndependentOfAdmin(t *testing.T, ks store.APIKeyStore, ns string) {
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	for _, tc := range []struct {
+		label           string
+		admin, readOnly bool
+	}{
+		{"admin-rw", true, false},
+		{"admin-ro", true, true},
+		{"named-rw", false, false},
+		{"named-ro", false, true},
+	} {
+		name := ns + "-combo-" + tc.label
+		k := store.APIKey{
+			Name: name, Hash: apiKeyHash(name), CreatedAt: now,
+			Admin: tc.admin, ReadOnly: tc.readOnly,
+		}
+		if err := ks.PutAPIKey(ctx, k); err != nil {
+			t.Fatalf("%s: put: %v", tc.label, err)
+		}
+		got, err := ks.GetAPIKeyByHash(ctx, k.Hash)
+		if err != nil {
+			t.Fatalf("%s: get by hash: %v", tc.label, err)
+		}
+		if got == nil {
+			t.Fatalf("%s: key not found after put", tc.label)
+		}
+		if got.Admin != tc.admin || got.ReadOnly != tc.readOnly {
+			t.Fatalf("%s: got Admin=%v ReadOnly=%v, want Admin=%v ReadOnly=%v",
+				tc.label, got.Admin, got.ReadOnly, tc.admin, tc.readOnly)
+		}
 	}
 }
 

--- a/packages/memini-client/src/handshake.ts
+++ b/packages/memini-client/src/handshake.ts
@@ -36,6 +36,14 @@ export interface HandshakeResult {
     key_name?: string;
     home?: string;
     default_namespace?: string;
+    /**
+     * True when the credential is read-only: the server refuses every mutating
+     * request with 403, so a client should skip writes rather than attempt and
+     * log them. Optional because a server older than this field simply omits
+     * it — absent must be read as "writable", never as "skip", or a client
+     * would silently stop saving against an older server.
+     */
+    read_only?: boolean;
   };
   /** Fully resolved ClientSettings — every field present. */
   settings: Record<string, unknown>;

--- a/plugin/scripts/_shared.mjs
+++ b/plugin/scripts/_shared.mjs
@@ -182,6 +182,12 @@ export async function getSessionContext({ cwd, ppid, allowNetwork = "on-miss", t
   // MEMINI_TIMEOUT_MS > server > built-in default.
   requestTimeoutMs = setting("request_timeout_ms").value;
 
+  // Same module-level-state rationale as requestTimeoutMs above: one hook
+  // process, one session context, and getSessionContext is the documented single
+  // entry point every hook calls before any REST call. `=== true` is deliberate
+  // — a handshake that omits the field (an older server) must leave this false.
+  readOnlyCredential = hs?.identity?.read_only === true;
+
   return {
     namespace: resolved.namespace,
     source: resolved.source,
@@ -239,6 +245,35 @@ function authHeaders(extra) {
   return h;
 }
 
+// --- Read-only credential ------------------------------------------------
+//
+// Set from the handshake identity by getSessionContext. This is NOISE CONTROL,
+// not a security boundary: the server refuses a read-only credential's writes
+// with 403 no matter what this says. Skipping them here is what keeps an
+// unattended agent from POSTing a capture every turn, eating a 403, and logging
+// it to stderr forever — which reads to an operator as "memory is broken".
+//
+// Defaults to false, and a handshake that omits identity.read_only leaves it
+// false: absent means "writable", never "skip". Guessing the other way would
+// make the client silently stop saving against a server older than the field.
+let readOnlyCredential = false;
+
+// Read-shaped POSTs, mirroring isReadRequest's allowlist in
+// internal/api/rest/readonly.go. Kept in sync by hand — the cost of drifting is
+// only that a permitted read gets skipped locally (a visible loss of results),
+// never that a write escapes, because the server gate is authoritative.
+const READ_SHAPED_POSTS = new Set(["/v1/search", "/v1/answer", "/v1/handshake"]);
+
+/**
+ * Whether a POST to `path` must be skipped because this session's credential is
+ * read-only. Compares the path without query string or trailing slash.
+ */
+function skipAsReadOnly(path) {
+  if (!readOnlyCredential) return false;
+  const clean = String(path).split("?")[0].replace(/\/+$/, "");
+  return !READ_SHAPED_POSTS.has(clean);
+}
+
 /**
  * POST JSON to memini, reporting the HTTP status alongside the parsed body so
  * a caller can tell "the server rejected this request shape" (a 400 — worth
@@ -246,6 +281,14 @@ function authHeaders(extra) {
  * `json` is null on any non-2xx or error. Never throws.
  */
 async function postJSONStatus(path, body, namespace, timeoutMs = requestTimeoutMs) {
+  if (skipAsReadOnly(path)) {
+    // Deliberately silent at default verbosity: for a read-only credential this
+    // is expected steady state, and one line per turn is exactly the noise this
+    // exists to remove. Status 0 matches the transport-failure shape callers
+    // already handle, so no caller needs to learn a new outcome.
+    if (DEBUG) console.error(`[memini] skipping POST ${path}: read-only credential`);
+    return { status: 0, json: null };
+  }
   try {
     assertBearerTransportSafe(boot.baseUrl, boot.apiKey);
     const res = await fetch(`${boot.baseUrl}${path}`, {
@@ -541,6 +584,14 @@ export const INJECTED_BEACON_TIMEOUT_MS = 500;
  */
 export async function postInjected(report, { namespace, timeoutMs = INJECTED_BEACON_TIMEOUT_MS } = {}) {
   if (!report || !report.session_id) return;
+  // /v1/activity/injected is a write, and this helper builds its own fetch
+  // rather than going through postJSONStatus, so it needs the gate explicitly.
+  // Telemetry is the most per-turn-chatty write there is, which makes it the
+  // single biggest source of 403 noise for a read-only credential.
+  if (skipAsReadOnly("/v1/activity/injected")) {
+    if (DEBUG) console.error("[memini] skipping POST /v1/activity/injected: read-only credential");
+    return;
+  }
   const suppressedAny =
     report.suppressed && Object.values(report.suppressed).some((v) => Number.isFinite(v) && v > 0);
   if ((!Array.isArray(report.injected_ids) || report.injected_ids.length === 0) && !suppressedAny) return;

--- a/plugin/scripts/_test.mjs
+++ b/plugin/scripts/_test.mjs
@@ -7030,3 +7030,174 @@ test("user-prompt-submit.mjs: a 400 on max_tokens strips it FIRST (newest field)
     await close();
   }
 });
+
+// ─── Read-only credential: skip writes instead of 403-ing every turn ───────
+//
+// The server refuses a read-only credential's writes with 403 regardless, so
+// none of this is a security boundary — it is noise control. Without it an
+// unattended CI agent POSTs a capture every turn, eats a 403, and logs
+// "[memini] POST /v1/memories -> 403" to stderr forever, which reads to an
+// operator as "memory is broken".
+
+test("read-only credential: writes are skipped locally, reads still go out", async () => {
+  const seen = [];
+  const { url, close } = await startMockServer((req, res) => {
+    seen.push(req.url);
+    res.statusCode = req.url === "/v1/handshake" ? 200 : 201;
+    res.setHeader("Content-Type", "application/json");
+    if (req.url === "/v1/handshake") {
+      res.end(
+        JSON.stringify({
+          namespace: "memini",
+          namespace_source: "derived",
+          identity: { authenticated: true, admin: false, read_only: true, key_name: "ci" },
+          settings: {},
+          settings_sources: {},
+          read_set: [],
+          server: { version: "test", default_namespace: "default" },
+        }),
+      );
+      return;
+    }
+    res.end(JSON.stringify({ id: "m1" }));
+  });
+  const prevUrl = process.env.MEMINI_BASE_URL;
+  process.env.MEMINI_BASE_URL = url;
+  try {
+    const mod = await import("./_shared.mjs?cb=ro-skip-" + Date.now());
+    await mod.getSessionContext({ cwd: process.cwd(), ppid: 1, allowNetwork: "always", noPersist: true });
+
+    const wrote = await mod.postRemember("a fact the CI agent tried to save", "memini", {});
+    assert.equal(wrote, null, "a write must resolve null without touching the network");
+    assert.ok(
+      !seen.includes("/v1/memories"),
+      `no write request may leave the client; saw ${JSON.stringify(seen)}`,
+    );
+
+    // A read-shaped POST must still go out — the credential can read.
+    await mod.postJSON("/v1/search", { query: "x" }, "memini");
+    assert.ok(seen.includes("/v1/search"), `search must still be sent; saw ${JSON.stringify(seen)}`);
+  } finally {
+    if (prevUrl === undefined) delete process.env.MEMINI_BASE_URL;
+    else process.env.MEMINI_BASE_URL = prevUrl;
+    await close();
+  }
+});
+
+test("read-only credential: skipping a write logs nothing at default verbosity", async () => {
+  const { url, close } = await startMockServer((req, res) => {
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/json");
+    res.end(
+      JSON.stringify({
+        namespace: "memini",
+        namespace_source: "derived",
+        identity: { authenticated: true, admin: false, read_only: true },
+        settings: {},
+        settings_sources: {},
+        read_set: [],
+        server: { version: "test", default_namespace: "default" },
+      }),
+    );
+  });
+  const realError = console.error;
+  const logged = [];
+  console.error = (...a) => logged.push(a.join(" "));
+  const prevUrl = process.env.MEMINI_BASE_URL;
+  const prevDebug = process.env.MEMINI_DEBUG;
+  process.env.MEMINI_BASE_URL = url;
+  delete process.env.MEMINI_DEBUG;
+  try {
+    const mod = await import("./_shared.mjs?cb=ro-quiet-" + Date.now());
+    await mod.getSessionContext({ cwd: process.cwd(), ppid: 1, allowNetwork: "always", noPersist: true });
+    await mod.postRemember("another fact", "memini", {});
+    assert.equal(
+      logged.length,
+      0,
+      `a skipped write must be silent at default verbosity; logged ${JSON.stringify(logged)}`,
+    );
+  } finally {
+    console.error = realError;
+    if (prevUrl === undefined) delete process.env.MEMINI_BASE_URL;
+    else process.env.MEMINI_BASE_URL = prevUrl;
+    if (prevDebug === undefined) delete process.env.MEMINI_DEBUG;
+    else process.env.MEMINI_DEBUG = prevDebug;
+    await close();
+  }
+});
+
+test("read-write credential: writes are sent as normal", async () => {
+  const seen = [];
+  const { url, close } = await startMockServer((req, res) => {
+    seen.push(req.url);
+    res.statusCode = req.url === "/v1/handshake" ? 200 : 201;
+    res.setHeader("Content-Type", "application/json");
+    if (req.url === "/v1/handshake") {
+      res.end(
+        JSON.stringify({
+          namespace: "memini",
+          namespace_source: "derived",
+          identity: { authenticated: true, admin: false, read_only: false },
+          settings: {},
+          settings_sources: {},
+          read_set: [],
+          server: { version: "test", default_namespace: "default" },
+        }),
+      );
+      return;
+    }
+    res.end(JSON.stringify({ id: "m1" }));
+  });
+  const prevUrl = process.env.MEMINI_BASE_URL;
+  process.env.MEMINI_BASE_URL = url;
+  try {
+    const mod = await import("./_shared.mjs?cb=rw-write-" + Date.now());
+    await mod.getSessionContext({ cwd: process.cwd(), ppid: 1, allowNetwork: "always", noPersist: true });
+    await mod.postRemember("a fact", "memini", {});
+    assert.ok(seen.includes("/v1/memories"), `write must be sent; saw ${JSON.stringify(seen)}`);
+  } finally {
+    if (prevUrl === undefined) delete process.env.MEMINI_BASE_URL;
+    else process.env.MEMINI_BASE_URL = prevUrl;
+    await close();
+  }
+});
+
+test("no handshake identity (older server): writes are NOT skipped", async () => {
+  const seen = [];
+  const { url, close } = await startMockServer((req, res) => {
+    seen.push(req.url);
+    res.statusCode = req.url === "/v1/handshake" ? 200 : 201;
+    res.setHeader("Content-Type", "application/json");
+    if (req.url === "/v1/handshake") {
+      res.end(
+        JSON.stringify({
+          namespace: "memini",
+          namespace_source: "derived",
+          identity: { authenticated: true },
+          settings: {},
+          settings_sources: {},
+          read_set: [],
+          server: { version: "test", default_namespace: "default" },
+        }),
+      );
+      return;
+    }
+    res.end(JSON.stringify({ id: "m1" }));
+  });
+  const prevUrl = process.env.MEMINI_BASE_URL;
+  process.env.MEMINI_BASE_URL = url;
+  try {
+    const mod = await import("./_shared.mjs?cb=no-identity-" + Date.now());
+    await mod.getSessionContext({ cwd: process.cwd(), ppid: 1, allowNetwork: "always", noPersist: true });
+    await mod.postRemember("a fact", "memini", {});
+    assert.ok(
+      seen.includes("/v1/memories"),
+      "an absent read_only field must mean 'writable', never 'skip' — a client that " +
+        "guessed otherwise would silently stop saving against an older server",
+    );
+  } finally {
+    if (prevUrl === undefined) delete process.env.MEMINI_BASE_URL;
+    else process.env.MEMINI_BASE_URL = prevUrl;
+    await close();
+  }
+});

--- a/ui/src/api-schema.gen.ts
+++ b/ui/src/api-schema.gen.ts
@@ -414,7 +414,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * List API keys (name/home/default namespace/created/disabled/admin/source — never a secret or hash)
+         * List API keys (name/home/default namespace/created/disabled/admin/read_only/source — never a secret or hash)
          * @description Admin-gated: allowed for the admin env key (MEMINI_API_KEY), a named key with admin=true, or dev/bootstrap mode (auth disabled entirely — no admin key, an empty api_keys table, and no MEMINI_API_KEYS_FILE keys). A request authenticated by a non-admin named table or file key gets 403. Includes keys from both the api_keys table (source=db, mutable via this API) and the declarative MEMINI_API_KEYS_FILE (source=file, read-only here — see updateApiKey/deleteApiKey/rotateApiKey).
          */
         get: operations["listApiKeys"];
@@ -450,7 +450,7 @@ export interface paths {
         options?: never;
         head?: never;
         /**
-         * Update an API key's home namespace, default namespace, disabled state, admin capability, and/or per-key settings
+         * Update an API key's home namespace, default namespace, disabled state, admin capability, read-only capability, and/or per-key settings
          * @description Admin-gated, see listApiKeys. Preserve-unspecified semantics matching `memini key add`'s rotation contract: an omitted field leaves the stored value unchanged; an explicitly passed field — including an explicit empty home/default_namespace, disabled=false, or admin=false — overrides it. A `settings` object replaces the key's per-key behavioral settings override: its present fields replace the corresponding stored values, while fields left unset within it continue to inherit the server's global defaults. 404 if no such key exists; 409 for a MEMINI_API_KEYS_FILE-sourced key (managed declaratively via that file, not this API), or when a named admin key targets ITSELF with admin=false (self-demote) or disabled=true (self-disable) — a break-glass guard, use the admin env key or another admin key instead.
          */
         patch: operations["updateApiKey"];
@@ -1142,6 +1142,8 @@ export interface components {
             disabled: boolean;
             /** @description Whether this key is an admin credential: it may reach the admin-gated surfaces (/v1/keys CRUD and /v1/settings/defaults), exactly like the admin env key (MEMINI_API_KEY). A self-guard still applies — an admin key cannot demote, disable, or delete itself over this API. */
             admin: boolean;
+            /** @description Whether this key is a read-only credential: it may issue reads (GET/HEAD, plus the read-shaped POSTs /v1/search, /v1/answer and /v1/handshake) and every mutating request is refused with 403, across both the REST and MCP surfaces. Independent of admin — an admin key that is also read_only may enumerate keys but not change them. Note this bounds what the key may CHANGE, not what it may SEE: a read-only key can still name any namespace and read it. */
+            read_only: boolean;
             source: components["schemas"]["ApiKeySource"];
             /** @description Per-key behavioral settings override; fields left unset inherit the server's global defaults. */
             settings?: components["schemas"]["ClientSettings"];
@@ -1169,6 +1171,11 @@ export interface components {
              * @default false
              */
             admin: boolean;
+            /**
+             * @description Create the key as a read-only credential (see ApiKey.read_only). Defaults to false — a key that may write.
+             * @default false
+             */
+            read_only: boolean;
         };
         UpdateApiKeyRequest: {
             /** @description Omit to leave the current binding unchanged; an explicit empty string clears it. */
@@ -1179,6 +1186,8 @@ export interface components {
             disabled?: boolean;
             /** @description Omit to leave the current admin capability unchanged; grant it with true, revoke it with false. A named admin key cannot revoke its own admin (admin=false targeting the key that authenticated the request) — that returns 409; use the admin env key or another admin key. */
             admin?: boolean;
+            /** @description Omit to leave the current read-only capability unchanged; impose it with true, lift it with false. A named key cannot impose read_only on itself (read_only=true targeting the key that authenticated the request) — that returns 409, because a read-only credential can no longer reach this endpoint to undo it; use the admin env key, another admin key, or the CLI. */
+            read_only?: boolean;
             /** @description Omit to leave the key's settings override unchanged; present fields replace the corresponding stored value (fields left unset within it continue to inherit the server's global defaults). */
             settings?: components["schemas"]["ClientSettings"];
         };
@@ -1187,6 +1196,8 @@ export interface components {
             authenticated: boolean;
             /** @description Effective admin capability: true for the admin env key, dev mode with no auth configured, and a named key with admin=true. When true the caller may reach the admin-gated surfaces (/v1/keys CRUD and /v1/settings/defaults); when false those return 403. */
             admin: boolean;
+            /** @description Effective read-only capability: true only for a named key with read_only=true. False for the admin env key and dev mode, which authenticate with no named principal and so carry no capability bits. When true, every mutating request is refused with 403 — clients should skip writes rather than attempt and log them. */
+            read_only: boolean;
             /** @description Name of the API key that authenticated the request; absent for the admin key or dev mode (no named principal). */
             key_name?: string;
             /** @description The key's bound home namespace, if any. */

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'preact/hooks'
 import { LocationProvider, Router, Route, useLocation } from 'preact-iso'
-import { apiToken, identity, serverWarning, theme } from './store'
+import { apiToken, identity, readOnlySession, serverWarning, theme } from './store'
 import { verifyToken, ApiError } from './api'
 import { Login } from './views/Login'
 import { NamespaceSelect } from './components/NamespaceSelect'
@@ -167,6 +167,18 @@ function Shell() {
               title="No auth configured on the server — anyone who can reach it has full access. Create an admin API key to lock it down."
             >
               no auth
+            </span>
+          )}
+          {/* The signed-in key cannot write. Persistent for the same reason the
+              dev-mode chip is: it is a standing property of the session, not an
+              event, and it is the one piece of context that explains why every
+              write control on every view is disabled. */}
+          {readOnlySession.value && (
+            <span
+              class="chip limited"
+              title="This API key is read-only — it can read everything it could before, but the server refuses every write. Sign in with a read-write key to make changes."
+            >
+              read-only
             </span>
           )}
           <NamespaceSelect />

--- a/ui/src/components/MemoryDrawer.tsx
+++ b/ui/src/components/MemoryDrawer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'preact/hooks'
 import { createPortal } from 'preact/compat'
 import type { Memory } from '../types'
 import { api } from '../api'
-import { refresh } from '../store'
+import { refresh, readOnlySession, READ_ONLY_HINT } from '../store'
 import { TierBadge } from './TierBadge'
 import { MemoryTypeBadge } from './MemoryTypeBadge'
 import {
@@ -161,8 +161,9 @@ export function MemoryDrawer({ memory: m, onClose, wide, from, fromNs }: Props) 
           <button
             class={`icon-btn ${armed ? 'danger-on' : ''}`}
             aria-label={armed ? 'Confirm delete' : 'Forget memory'}
+            title={readOnlySession.value ? READ_ONLY_HINT : undefined}
             onClick={del}
-            disabled={deleting}
+            disabled={deleting || readOnlySession.value}
           >
             <IconTrash />
           </button>
@@ -286,7 +287,8 @@ export function MemoryDrawer({ memory: m, onClose, wide, from, fromNs }: Props) 
             <button
               class="btn primary"
               onClick={reassign}
-              disabled={reassigning || reassignTo.trim().length === 0}
+              title={readOnlySession.value ? READ_ONLY_HINT : undefined}
+              disabled={reassigning || reassignTo.trim().length === 0 || readOnlySession.value}
             >
               Reassign
             </button>

--- a/ui/src/components/NamespaceDrawer.tsx
+++ b/ui/src/components/NamespaceDrawer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { createPortal } from 'preact/compat'
 import { api } from '../api'
-import { namespace, refresh } from '../store'
+import { namespace, refresh, readOnlySession, READ_ONLY_HINT } from '../store'
 import type { RenamespaceReport } from '../types'
 import { IconClose, IconRefresh } from '../icons'
 
@@ -101,11 +101,21 @@ function MoveSection({ name, onDone, initialTo }: { name: string; onDone: () => 
         style={{ width: '100%', marginBottom: '10px' }}
       />
       <div style={{ display: 'flex', gap: '8px' }}>
-        <button class="btn" onClick={() => run(true)} disabled={!canRun}>
+        <button
+          class="btn"
+          onClick={() => run(true)}
+          title={readOnlySession.value ? READ_ONLY_HINT : undefined}
+          disabled={!canRun || readOnlySession.value}
+        >
           {busy ? <span class="spinner" style={{ width: '14px', height: '14px' }} /> : <IconRefresh />}
           Preview
         </button>
-        <button class="btn primary" onClick={() => run(false)} disabled={!canRun}>
+        <button
+          class="btn primary"
+          onClick={() => run(false)}
+          title={readOnlySession.value ? READ_ONLY_HINT : undefined}
+          disabled={!canRun || readOnlySession.value}
+        >
           Move
         </button>
       </div>
@@ -160,11 +170,21 @@ function SplitSection({ name, onDone }: { name: string; onDone: () => void }) {
         style={{ width: '100%', marginBottom: '10px' }}
       />
       <div style={{ display: 'flex', gap: '8px' }}>
-        <button class="btn" onClick={() => run(true)} disabled={busy}>
+        <button
+          class="btn"
+          onClick={() => run(true)}
+          title={readOnlySession.value ? READ_ONLY_HINT : undefined}
+          disabled={busy || readOnlySession.value}
+        >
           {busy ? <span class="spinner" style={{ width: '14px', height: '14px' }} /> : <IconRefresh />}
           Preview
         </button>
-        <button class="btn primary" onClick={() => run(false)} disabled={busy}>
+        <button
+          class="btn primary"
+          onClick={() => run(false)}
+          title={readOnlySession.value ? READ_ONLY_HINT : undefined}
+          disabled={busy || readOnlySession.value}
+        >
           Split
         </button>
       </div>

--- a/ui/src/icons.tsx
+++ b/ui/src/icons.tsx
@@ -82,6 +82,16 @@ export const IconKey = base([
   <circle cx="8" cy="15" r="4.5" />,
   <path d="m11.5 11.5 8-8M16.5 6.5 19 9M14 9l2 2" />,
 ])
+/** Read-only capability toggle. The pair shows the ACTION, not the state:
+    IconLock offers "make read-only", IconUnlock offers "allow writes". */
+export const IconLock = base([
+  <rect x="3.5" y="11" width="17" height="10.5" rx="2" />,
+  <path d="M7.5 11V7a4.5 4.5 0 0 1 9 0v4" />,
+])
+export const IconUnlock = base([
+  <rect x="3.5" y="11" width="17" height="10.5" rx="2" />,
+  <path d="M7.5 11V7a4.5 4.5 0 0 1 8.9-1" />,
+])
 export const IconMoon = base([<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z" />])
 export const IconSun = base([
   <circle cx="12" cy="12" r="4" />,

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1,4 +1,4 @@
-import { signal, effect } from '@preact/signals'
+import { signal, effect, computed } from '@preact/signals'
 import type { CallerIdentity } from './types'
 
 export type Theme = 'ink' | 'ivory'
@@ -50,6 +50,21 @@ export const theme = signal<Theme>(initial.theme)
 // mid-session 401 in api.ts clears it). authenticated=false is dev mode (no
 // auth configured); admin drives the admin-gated views' locked states.
 export const identity = signal<CallerIdentity | null>(null)
+
+// Whether the signed-in credential is read-only: the server refuses its every
+// mutating request with 403. Write controls read this to disable themselves and
+// say why, rather than letting the operator click through to a failure.
+//
+// This is presentation only — the server is the authority, and it enforces the
+// same rule whatever the UI believes. `=== true` is deliberate: an identity that
+// predates the field (or is still resolving) must read as writable, so an older
+// server never presents a needlessly crippled UI.
+export const readOnlySession = computed(() => identity.value?.read_only === true)
+
+// One sentence, reused as the title on every control readOnlySession disables,
+// so the explanation is identical wherever the operator meets it.
+export const READ_ONLY_HINT =
+  'This API key is read-only — the server refuses every write. Sign in with a read-write key to make changes.'
 
 // Set true when a request 401s WHILE a session was live (api.ts, only when it
 // clears a previously non-null identity) — the key this browser was signed in

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1467,6 +1467,14 @@ pre.json {
   background: color-mix(in oklab, var(--tier-semantic) 12%, transparent);
   color: color-mix(in oklab, var(--tier-semantic) 82%, var(--text));
 }
+/* Reduced-capability marker: the cool end of the tier ramp, distinct from
+   .warn's ember (a problem) and .pending's amber (an advisory). A read-only
+   credential is neither — it is a deliberate, static constraint. */
+.chip.limited {
+  border-color: color-mix(in oklab, var(--tier-working) 55%, transparent);
+  background: color-mix(in oklab, var(--tier-working) 12%, transparent);
+  color: color-mix(in oklab, var(--tier-working) 82%, var(--text));
+}
 .chip.on {
   border-color: var(--line-strong);
   color: var(--text);

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -94,6 +94,7 @@ export interface UpdateApiKeyBody {
   default_namespace?: string
   disabled?: boolean
   admin?: boolean
+  read_only?: boolean
   settings?: Partial<ClientSettings>
 }
 

--- a/ui/src/views/Activity.tsx
+++ b/ui/src/views/Activity.tsx
@@ -158,6 +158,13 @@ function detailChips(ev: ActivityEvent): { label: string; title?: string; warn?:
     if (typeof d.admin === 'boolean') {
       chips.push({ label: d.admin ? 'admin granted' : 'admin revoked', title: 'Admin capability change', warn: true })
     }
+    if (typeof d.read_only === 'boolean') {
+      chips.push({
+        label: d.read_only ? 'read-only imposed' : 'read-only lifted',
+        title: 'Read-only capability change',
+        warn: true,
+      })
+    }
   }
 
   return chips

--- a/ui/src/views/Config.tsx
+++ b/ui/src/views/Config.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'preact/hooks'
 import { api } from '../api'
-import { identity, refreshNonce } from '../store'
+import { identity, refreshNonce, readOnlySession, READ_ONLY_HINT } from '../store'
 import { useAsync } from '../hooks'
 import { SETTINGS_CATALOG } from '../settings-catalog.gen'
 import { SettingsEditor, formatSettingValue } from '../components/SettingsEditor'
@@ -347,7 +347,12 @@ function DefaultsTab() {
         <SettingsEditor values={explicit} placeholders={placeholders} onSet={setField} onReset={resetField} readOnly={readOnly} />
         {!readOnly && (
           <div style={{ display: 'flex', gap: '10px', alignItems: 'center', marginTop: '16px' }}>
-            <button class="btn primary" type="submit" disabled={saving}>
+            <button
+              class="btn primary"
+              type="submit"
+              title={readOnlySession.value ? READ_ONLY_HINT : undefined}
+              disabled={saving || readOnlySession.value}
+            >
               {saving && <span class="spinner" style={{ width: '14px', height: '14px' }} />}
               Save global defaults
             </button>
@@ -475,7 +480,12 @@ function PinRow({
           onInput={(e) => setNote((e.target as HTMLInputElement).value)}
           style={{ flex: '1 1 160px' }}
         />
-        <button class="btn primary" type="submit" disabled={busy || !namespaceVal.trim()}>
+        <button
+          class="btn primary"
+          type="submit"
+          title={readOnlySession.value ? READ_ONLY_HINT : undefined}
+          disabled={busy || !namespaceVal.trim() || readOnlySession.value}
+        >
           Save
         </button>
         <button class="btn ghost" type="button" onClick={() => setEditing(false)} disabled={busy}>
@@ -502,15 +512,21 @@ function PinRow({
       <span class="hint" style={{ flex: '1 1 140px' }}>
         {fmtDate(pin.updated_at)}
       </span>
-      <button class="btn ghost" type="button" onClick={() => setEditing(true)} disabled={busy}>
+      <button
+        class="btn ghost"
+        type="button"
+        onClick={() => setEditing(true)}
+        title={readOnlySession.value ? READ_ONLY_HINT : undefined}
+        disabled={busy || readOnlySession.value}
+      >
         Edit
       </button>
       <button
         class={`icon-btn ${armed ? 'danger-on' : ''}`}
         aria-label={armed ? `Confirm delete pin ${pin.key}` : `Delete pin ${pin.key}`}
-        title={armed ? 'Click again to confirm' : 'Delete'}
+        title={readOnlySession.value ? READ_ONLY_HINT : armed ? 'Click again to confirm' : 'Delete'}
         onClick={del}
-        disabled={busy}
+        disabled={busy || readOnlySession.value}
       >
         <IconTrash />
       </button>
@@ -585,7 +601,8 @@ function AddPinForm({ onAdded, onError }: { onAdded: () => void; onError: (e: st
       <button
         class="btn primary"
         type="submit"
-        disabled={busy || !namespaceVal.trim() || (!remoteUrl.trim() && !toplevelPath.trim())}
+        title={readOnlySession.value ? READ_ONLY_HINT : undefined}
+        disabled={busy || !namespaceVal.trim() || (!remoteUrl.trim() && !toplevelPath.trim()) || readOnlySession.value}
       >
         {busy && <span class="spinner" style={{ width: '14px', height: '14px' }} />}
         Add pin

--- a/ui/src/views/Keys.tsx
+++ b/ui/src/views/Keys.tsx
@@ -395,6 +395,10 @@ function CreateKeyForm({
         default_namespace: defaultNS.trim() || undefined,
         disabled: false,
         admin,
+        // Placeholder until the create form grows a read-only control: the
+        // generated type requires the field because the spec gives it a
+        // default, the same way it requires `admin` and `disabled`.
+        read_only: false,
       })
       setName('')
       setHome('')

--- a/ui/src/views/Keys.tsx
+++ b/ui/src/views/Keys.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'preact/hooks'
 import { api } from '../api'
-import { apiToken, identity } from '../store'
+import { apiToken, identity, readOnlySession, READ_ONLY_HINT } from '../store'
 import { useAsync } from '../hooks'
 import type { ApiKey } from '../types'
 import { Loading, ErrorBanner, Empty } from '../components/States'
 import { SettingsEditor } from '../components/SettingsEditor'
-import { IconKey, IconTrash, IconRefresh, IconCopy, IconCheck, IconChevron } from '../icons'
+import { IconKey, IconTrash, IconRefresh, IconCopy, IconCheck, IconChevron, IconLock, IconUnlock } from '../icons'
 import { fmtDate } from '../util'
 
 // Keys manages the REST API-key surface (K3b): a list of every key — both
@@ -178,6 +178,23 @@ function KeyRow({ k, globalDefaults, onChanged, onError, onSecret }: RowProps) {
     }
   }
 
+  const toggleReadOnly = async () => {
+    setBusy(true)
+    onError(null)
+    try {
+      // Imposing read-only on one's OWN key returns 409 (the server's
+      // self-guard: a read-only credential can no longer reach this endpoint to
+      // undo it). Surfaced through the shared error path like any other
+      // mutation failure.
+      await api.updateKey(k.name, { read_only: !k.read_only })
+      onChanged()
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
   const rotate = async () => {
     setBusy(true)
     onError(null)
@@ -219,6 +236,11 @@ function KeyRow({ k, globalDefaults, onChanged, onError, onSecret }: RowProps) {
             admin
           </span>
         )}
+        {k.read_only && (
+          <span class="chip limited" title="Read-only key — may read everything, but the server refuses its every write, over both REST and MCP">
+            read-only
+          </span>
+        )}
         <button
           class="icon-btn"
           aria-label={expanded ? `Collapse settings for ${k.name}` : `Edit settings for ${k.name}`}
@@ -237,30 +259,52 @@ function KeyRow({ k, globalDefaults, onChanged, onError, onSecret }: RowProps) {
               class="btn ghost"
               type="button"
               aria-label={k.admin ? `Revoke admin from ${k.name}` : `Grant admin to ${k.name}`}
-              title={k.admin ? 'Revoke admin capability' : 'Grant admin capability'}
+              title={readOnlySession.value ? READ_ONLY_HINT : k.admin ? 'Revoke admin capability' : 'Grant admin capability'}
               onClick={toggleAdmin}
-              disabled={busy}
+              disabled={busy || readOnlySession.value}
             >
               {k.admin ? 'Revoke admin' : 'Grant admin'}
             </button>
             <button
               class="icon-btn"
+              type="button"
+              aria-label={k.read_only ? `Allow ${k.name} to write` : `Make ${k.name} read-only`}
+              title={
+                readOnlySession.value
+                  ? READ_ONLY_HINT
+                  : k.read_only
+                    ? 'Lift the read-only restriction'
+                    : 'Refuse every write from this key'
+              }
+              onClick={toggleReadOnly}
+              disabled={busy || readOnlySession.value}
+            >
+              {k.read_only ? <IconUnlock /> : <IconLock />}
+            </button>
+            <button
+              class="icon-btn"
               aria-label={k.disabled ? `Enable ${k.name}` : `Disable ${k.name}`}
-              title={k.disabled ? 'Enable' : 'Disable'}
+              title={readOnlySession.value ? READ_ONLY_HINT : k.disabled ? 'Enable' : 'Disable'}
               onClick={toggleDisabled}
-              disabled={busy}
+              disabled={busy || readOnlySession.value}
             >
               <IconCheck />
             </button>
-            <button class="icon-btn" aria-label={`Rotate secret for ${k.name}`} title="Rotate secret" onClick={rotate} disabled={busy}>
+            <button
+              class="icon-btn"
+              aria-label={`Rotate secret for ${k.name}`}
+              title={readOnlySession.value ? READ_ONLY_HINT : 'Rotate secret'}
+              onClick={rotate}
+              disabled={busy || readOnlySession.value}
+            >
               <IconRefresh />
             </button>
             <button
               class={`icon-btn ${armed ? 'danger-on' : ''}`}
               aria-label={armed ? `Confirm delete ${k.name}` : `Delete ${k.name}`}
-              title={armed ? 'Click again to confirm' : 'Delete'}
+              title={readOnlySession.value ? READ_ONLY_HINT : armed ? 'Click again to confirm' : 'Delete'}
               onClick={del}
-              disabled={busy}
+              disabled={busy || readOnlySession.value}
             >
               <IconTrash />
             </button>
@@ -380,6 +424,7 @@ function CreateKeyForm({
   const [home, setHome] = useState('')
   const [defaultNS, setDefaultNS] = useState('')
   const [admin, setAdmin] = useState(bootstrapping)
+  const [readOnly, setReadOnly] = useState(false)
   const [busy, setBusy] = useState(false)
 
   const submit = async (e: Event) => {
@@ -395,15 +440,13 @@ function CreateKeyForm({
         default_namespace: defaultNS.trim() || undefined,
         disabled: false,
         admin,
-        // Placeholder until the create form grows a read-only control: the
-        // generated type requires the field because the spec gives it a
-        // default, the same way it requires `admin` and `disabled`.
-        read_only: false,
+        read_only: readOnly,
       })
       setName('')
       setHome('')
       setDefaultNS('')
       setAdmin(false)
+      setReadOnly(false)
       onCreated(created.name, created.secret)
     } catch (err) {
       onError(err instanceof Error ? err.message : String(err))
@@ -444,7 +487,24 @@ function CreateKeyForm({
         <input type="checkbox" checked={admin} onChange={(e) => setAdmin((e.target as HTMLInputElement).checked)} />
         admin
       </label>
-      <button class="btn primary" type="submit" disabled={busy || !name.trim()}>
+      <label
+        class="hint"
+        title="Make this key read-only: it may read everything, but the server refuses its every write, over both REST and MCP. Use it for unattended agents (CI) that should recall context but never change it."
+        style={{ display: 'flex', alignItems: 'center', gap: '6px', flex: '0 0 auto', cursor: 'pointer' }}
+      >
+        <input
+          type="checkbox"
+          checked={readOnly}
+          onChange={(e) => setReadOnly((e.target as HTMLInputElement).checked)}
+        />
+        read-only
+      </label>
+      <button
+        class="btn primary"
+        type="submit"
+        title={readOnlySession.value ? READ_ONLY_HINT : undefined}
+        disabled={busy || !name.trim() || readOnlySession.value}
+      >
         {busy && <span class="spinner" style={{ width: '14px', height: '14px' }} />}
         <IconKey />
         Create key

--- a/ui/src/views/Namespaces.tsx
+++ b/ui/src/views/Namespaces.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'preact/hooks'
 import { useLocation } from 'preact-iso'
 import { api } from '../api'
-import { namespace, refreshNonce, refresh } from '../store'
+import { namespace, refreshNonce, refresh, readOnlySession, READ_ONLY_HINT } from '../store'
 import { useAsync } from '../hooks'
 import { TIERS, type Stats } from '../types'
 import { tierColor, relTime, num, nsTree, type NsNode } from '../util'
@@ -424,8 +424,9 @@ function Pod({
           <button
             class={`icon-btn pod-del-btn ${armed ? 'danger-on' : ''}`}
             aria-label={armed ? 'Confirm delete' : `Delete ${name}`}
+            title={readOnlySession.value ? READ_ONLY_HINT : undefined}
             onClick={del}
-            disabled={deleting}
+            disabled={deleting || readOnlySession.value}
           >
             <IconTrash />
           </button>

--- a/ui/src/views/Scopes.tsx
+++ b/ui/src/views/Scopes.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'preact/hooks'
 import { api } from '../api'
-import { namespace, refreshNonce } from '../store'
+import { namespace, refreshNonce, readOnlySession, READ_ONLY_HINT } from '../store'
 import { useAsync } from '../hooks'
 import type { NamespaceLink, ReadSetEntryItem, ReadSetOrigin, Tier } from '../types'
 import { Loading, ErrorBanner, Empty } from '../components/States'
@@ -136,7 +136,13 @@ function LinkRow({ link, onDelete }: { link: NamespaceLink; onDelete: () => void
       </span>
       <span class="hint mono">{link.tiers?.length ? link.tiers.join(', ') : 'semantic, procedural'}</span>
       {link.note && <span class="hint">{link.note}</span>}
-      <button class="icon-btn" aria-label={`Delete link to ${link.dst}`} onClick={onDelete}>
+      <button
+        class="icon-btn"
+        aria-label={`Delete link to ${link.dst}`}
+        title={readOnlySession.value ? READ_ONLY_HINT : undefined}
+        onClick={onDelete}
+        disabled={readOnlySession.value}
+      >
         <IconTrash />
       </button>
     </div>
@@ -196,7 +202,12 @@ function AddLinkForm({ onAdded, onError }: { onAdded: () => void; onError: (e: s
         onInput={(e) => setNote((e.target as HTMLInputElement).value)}
         style={{ flex: 1, minWidth: '140px' }}
       />
-      <button class="btn primary" type="submit" disabled={busy || !dst.trim()}>
+      <button
+        class="btn primary"
+        type="submit"
+        title={readOnlySession.value ? READ_ONLY_HINT : undefined}
+        disabled={busy || !dst.trim() || readOnlySession.value}
+      >
         {busy && <span class="spinner" style={{ width: '14px', height: '14px' }} />}
         Add link
       </button>


### PR DESCRIPTION
Adds `read_only`, a second per-key authorization bit next to `admin`. A read-only credential reads everything it could read before, and the server refuses every mutating request it makes, on both the REST and MCP surfaces.

## The problem

I want to give a CI job's LLM access to memini. It should be able to recall project context, but it must never write, update, or delete a memory. Today there's no way to express that: every key that can authenticate can write, and `admin` only gates key management. A CI agent runs unattended, usually on a branch nobody has reviewed yet, and a bad write from one is invisible until it poisons somebody's recall weeks later.

## How it's enforced, and why this way

Both HTTP surfaces use the same shape: an explicit allowlist of what a read-only key may do, with everything else refused.

On REST that's a single middleware in `Mount`, registered right after `authMiddleware`: safe methods, plus three read-shaped POSTs (`/v1/search`, `/v1/answer`, and `/v1/handshake`, which is documented side-effect-free and is the call every client makes before anything else). On MCP it's a receiving middleware gating `tools/call` against an allowlist of read tools. MCP mounts outside `rest.Mount`'s group, so without that second gate a read-only key could just write over MCP instead.

The obvious alternative was to mirror the existing `requireAdmin` pattern and put a `requireWrite` call at the top of each mutating handler. I didn't, because that's about 20 call sites that fail *open*: add a write endpoint later, forget the line, and read-only keys silently get write access with no test to catch it. With an allowlist the default is refusal, so forgetting over-restricts (a loud 403 on something that should have been readable) instead of quietly granting writes.

Two tests keep the allowlists honest rather than relying on anyone remembering:

- `TestIsReadRequestClassifiesEverySpecEndpoint` parses `api/openapi.yaml` and asserts every `/v1` operation is classified, so adding an endpoint without deciding read-or-write fails CI.
- `TestMCPReadToolAllowlistMatchesAnnotations` cross-checks the tool allowlist against each tool's own `ReadOnlyHint` annotation. Those annotations were already authoritative, since `cmd/gendocs` builds the tool reference labels from them.

`read_only` is deliberately independent of `admin` rather than both collapsing into one `role` enum. `admin` plus `read_only` is a useful combination (an auditor who can list keys and read server defaults but change neither), and a role enum would have been a breaking wire, YAML, and CLI change for no gain.

## Trade-offs I made on purpose

These are choices, not oversights, so please push back on any of them:

- **The self-guard is stricter than admin's.** A named key can't make *itself* read-only; that returns 409. Once the flag is set, the gate refuses `/v1/keys` too, so the key could never lift it again. Clearing `read_only` on itself is allowed, since that direction is a restoration and is only reachable while the key can still write.
- **MCP refuses with an error tool *result*, not a protocol error.** A protocol error reads to an agent as "the call broke", which invites a retry. An error result is ordinary output the model sees and adapts to, and it says "Do not retry" in as many words. That matters for an unattended agent whose hooks would otherwise try a write every turn.
- **Write tools stay listed** for a read-only MCP session instead of being hidden from `tools/list`. Hiding them is a reasonable design too, so there's a test pinning the current behavior; switching would be a conscious change to what the agent sees, not a silent one.
- **Reads still reinforce.** Serving a read still bumps access counters and still appends to the activity log. That's internal relevance bookkeeping, and `read_only` bounds what the caller can change, not whether serving a read leaves a trace. A read-only agent's recalls still improve ranking, which I think is what you want.
- **Dry runs count as writes.** `POST /v1/namespaces/move` and `/split` post to a mutating endpoint even with `dry_run: true`, so a read-only key can't preview a move. The UI disables Preview alongside Apply rather than moving the 403 one click later.
- **Clients skip writes instead of collecting 403s.** `identity.read_only` rides the handshake the client already performs, so the plugin stops attempting captures rather than eating a 403 and logging it every single turn. An older server omits the field, and clients read absent as writable, so this can't make a client silently stop saving against an older server.

## One thing worth being explicit about

`read_only` bounds what a key can change, not what it can see. A read-only key can still send any `X-Memini-Namespace` and read every namespace on the server. I put a warning on that in `docs/api-keys.md` and again in the access-control guide, because someone reading "read-only" and inferring "contained" would be worse off than with no doc at all. Restricting what a credential can read is still a deployment topology decision.

That also meant rewriting the opening section of `docs/api-keys.md`. It used to say "there is exactly one authorization bit a key carries", which this change makes false, and the section was titled "Keys are identity, not authorization". It's now "not isolation", which is the accurate framing: a key does carry authorization, it just doesn't scope namespaces. The two places that echoed the old wording and every anchor pointing at the old heading are updated too.

## What changed

| Surface | Change |
| --- | --- |
| Storage | `store.APIKey.ReadOnly` on both drivers, `read_only` column defaulting to false so every existing key stays read-write |
| Auth | `apiauth.Principal.ReadOnly` from table and file keys. The env key and dev mode still resolve to a nil principal and stay fully privileged |
| REST | Fail-closed middleware, plus `read_only` on `ApiKey`, the create/update requests, and `CallerIdentity` |
| MCP | Call-time refusal via the read-tool allowlist |
| CLI | `memini key add --read-only`, a `READ ONLY` column in `key ls`, preserved across rotation |
| File keys | `read_only: true`, which is how a CI credential actually gets provisioned (a mounted Secret) |
| UI | Persistent topbar chip, per-key chip with a lock/unlock toggle, a create-form checkbox, and 15 write controls disabled with one shared explanation |
| Docs | A "The read-only attribute" reference section, the CI agent walkthrough, an fsck token caveat, and a chart values example |

## Verification

Every CI gate passes locally: `go test -race ./...`, `go build -tags=integration ./...`, golangci-lint with 0 issues, 219 hook tests, 180 client core tests, the UI build, and all five generated-artifact drift gates. Each commit is independently green.

I also checked it against a running server rather than only in tests. With a `--read-only` key, `POST /v1/memories` returns 403, `POST /v1/search` returns 200, `POST /v1/handshake` returns 200, and `DELETE /v1/pins` returns 403. The same holds for a key provisioned through a declarative `MEMINI_API_KEYS_FILE` entry, which is the path CI will really use, while a read-write file key and the break-glass env key on that same server are unaffected and still return 201. `GET /v1/self` reports `{"admin": false, "authenticated": true, "key_name": "ci-agent", "read_only": true}`.

For the UI I signed in with an `admin` plus `read_only` key: the chips render, every write control is disabled with the shared hint, and reads still work. I measured the new chip's contrast in the browser at 5.74:1 on the dark theme and 4.83:1 on the light one, both above the 4.5:1 floor for 11px text.
