### PR TITLE
fix(rerank): accept OpenAI list-envelope responses (data alias for results)

### DIFF
--- a/internal/rerank/crossencoder.go
+++ b/internal/rerank/crossencoder.go
@@ -95,11 +95,19 @@ type rerankRequest struct {
 	Documents []string `json:"documents"`
 }
 
+type rerankResult struct {
+	Index          int     `json:"index"`
+	RelevanceScore float64 `json:"relevance_score"`
+}
+
 type rerankResponse struct {
-	Results []struct {
-		Index          int     `json:"index"`
-		RelevanceScore float64 `json:"relevance_score"`
-	} `json:"results"`
+	Results []rerankResult `json:"results"`
+	// Data is the OpenAI-list-envelope alias for Results. Servers that wrap
+	// rerank output in the OpenAI list convention (Voyage AI, DashScope, and
+	// several aggregator gateways) return {"object":"list","data":[...]} with
+	// the same per-item shape, which would otherwise be misreported as
+	// "empty results".
+	Data []rerankResult `json:"data"`
 	// Error carries a server-reported error delivered with a 200 status. Some
 	// servers (e.g. LM Studio) answer an unimplemented /rerank route with
 	// HTTP 200 and {"error": "..."} rather than a 4xx, which would otherwise be
@@ -260,6 +268,9 @@ func (c *CrossEncoder) scoreBatch(ctx context.Context, query string, candidates 
 	}
 	if rr.Error != "" {
 		return nil, fmt.Errorf("rerank: server returned 200 with error: %s", rr.Error)
+	}
+	if len(rr.Results) == 0 && len(rr.Data) > 0 {
+		rr.Results = rr.Data
 	}
 	if len(rr.Results) == 0 {
 		return nil, fmt.Errorf("rerank: empty results for %d documents", len(docs))

--- a/internal/rerank/crossencoder_test.go
+++ b/internal/rerank/crossencoder_test.go
@@ -366,3 +366,31 @@ func TestCrossEncoderMinScoreSingleCandidateStillScored(t *testing.T) {
 		t.Fatalf("ungated single candidate must not make a network call")
 	}
 }
+
+func TestCrossEncoderAcceptsDataEnvelope(t *testing.T) {
+	// Voyage AI, DashScope, and several aggregator gateways wrap rerank
+	// output in the OpenAI list convention: {"object":"list","data":[...]}
+	// with the same per-item shape as the Cohere-style "results" field.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"object":"list","data":[
+			{"index":0,"relevance_score":0.1},
+			{"index":1,"relevance_score":0.9}
+		],"model":"m","id":"x"}`))
+	}))
+	defer srv.Close()
+
+	ce, err := New(Config{BaseURL: srv.URL, Model: "m"})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	got, err := ce.Rerank(context.Background(), "q", []Candidate{{ID: "a"}, {ID: "b"}})
+	if err != nil {
+		t.Fatalf("rerank: %v", err)
+	}
+	want := []string{"b", "a"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The cross-encoder client expects Cohere-style rerank responses:

```json
{"results": [{"index": 0, "relevance_score": 0.9}]}
```

but a number of servers in the OpenAI ecosystem wrap the same items in the OpenAI list convention instead — **Voyage AI**, **DashScope** (Alibaba), and various aggregator gateways:

```json
{"object": "list", "data": [{"index": 0, "relevance_score": 0.9}], "model": "...", "id": "..."}
```

The per-item shape is identical; only the envelope field name differs.

Against such a server the decoder finds no `results`, `scoreBatch` returns `rerank: empty results for N documents`, and **every recall silently falls back to composite order** — while `healthz` keeps reporting the reranker as configured, so the degradation is easy to miss. I ran a deployment like this for a while without noticing; the only trace was a `WARN recall: rerank failed` line per recall.

## Fix

Accept `data` as an alias when `results` is absent, in the same spirit as the existing `Error` field that tolerates LM Studio answering an unimplemented `/rerank` route with HTTP 200 + `{"error": ...}`. Servers emitting both fields keep the Cohere-style precedence.

- shared `rerankResult` item type, `Data []rerankResult` alias field on the response
- after decode: `if len(rr.Results) == 0 && len(rr.Data) > 0 { rr.Results = rr.Data }`
- test: `TestCrossEncoderAcceptsDataEnvelope` with a full OpenAI-style envelope

`go test ./internal/rerank/` and `go vet` pass.

## Verification against a real gateway

Reproduced with Qwen3-Reranker-0.6B behind a DashScope-proxying gateway: before the change every recall logged `rerank: empty results for N documents`; with the alias the reranker scores and reorders normally (verified via `healthz?verbose=1` reranker `last_success` and recall behavior).