### PR TITLE
feat(llm): configurable completion budget and raw extra-body passthrough

### DIFF
--- a/cmd/gendocs/main.go
+++ b/cmd/gendocs/main.go
@@ -110,7 +110,7 @@ var groups = []group{
 			"handling all work. Configuring one adds background consolidation, `POST /v1/answer`, the `memory_answer` " +
 			"MCP tool, and `MEMINI_RERANK=llm`.\n\nNote that `memory_answer` is only registered as an MCP tool when " +
 			"an LLM is configured. Without one, agents will not see the tool at all.",
-		Vars: []string{"MEMINI_LLM_BASE_URL", "MEMINI_LLM_API_KEY", "MEMINI_LLM_MODEL", "MEMINI_LLM_API"},
+		Vars: []string{"MEMINI_LLM_BASE_URL", "MEMINI_LLM_API_KEY", "MEMINI_LLM_MODEL", "MEMINI_LLM_API", "MEMINI_LLM_MAX_TOKENS", "MEMINI_LLM_EXTRA_BODY"},
 	},
 	{
 		Key:   "rerank",

--- a/cmd/memini/root.go
+++ b/cmd/memini/root.go
@@ -279,8 +279,14 @@ func buildServiceStack(
 	var svcOpts []service.Option
 	var chatClient llm.Client
 	if cfg.LLMEnabled() {
+		extraBody, err := cfg.LLMExtraBodyMap()
+		if err != nil {
+			_ = st.Close()
+			return nil, nil, nil, nil, nil, err
+		}
 		client, err := llm.New(llm.API(cfg.LLMAPI), llm.Config{
 			BaseURL: cfg.LLMBaseURL, APIKey: cfg.LLMAPIKey, Model: cfg.LLMModel,
+			MaxTokens: cfg.LLMMaxTokens, ExtraBody: extraBody,
 		})
 		if err != nil {
 			_ = st.Close()

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -59,6 +59,8 @@ server deployment. Treat the rest as tuning you reach for when you have a reason
 | [`MEMINI_LLM_API_KEY`](#memini_llm_api_key) | none | [LLM (optional)](#llm-optional) |
 | [`MEMINI_LLM_MODEL`](#memini_llm_model) | `gpt-4o-mini` | [LLM (optional)](#llm-optional) |
 | [`MEMINI_LLM_API`](#memini_llm_api) | `openai` | [LLM (optional)](#llm-optional) |
+| [`MEMINI_LLM_MAX_TOKENS`](#memini_llm_max_tokens) | `0` | [LLM (optional)](#llm-optional) |
+| [`MEMINI_LLM_EXTRA_BODY`](#memini_llm_extra_body) | none | [LLM (optional)](#llm-optional) |
 | [`MEMINI_RERANK`](#memini_rerank) | `off` | [Reranking](#reranking) |
 | [`MEMINI_RERANK_MODEL`](#memini_rerank_model) | none | [Reranking](#reranking) |
 | [`MEMINI_RERANK_API_KEY`](#memini_rerank_api_key) | none | [Reranking](#reranking) |
@@ -331,6 +333,18 @@ string, default `gpt-4o-mini`. Set by `Config.LLMModel`.
 string, default `openai`. Set by `Config.LLMAPI`.
 
 `MEMINI_LLM_API` selects the chat backend: "openai" (default) or "anthropic".
+
+### `MEMINI_LLM_MAX_TOKENS`
+
+int, default `0`. Set by `Config.LLMMaxTokens`.
+
+`MEMINI_LLM_MAX_TOKENS` caps the completion length of every chat call. 0 (the default) keeps the client's built-in budget (4096). Reasoning models that spend thousands of hidden thinking tokens inside the budget need more headroom here, or their JSON answers come back truncated (finish_reason "length") and the affected pipeline call is lost.
+
+### `MEMINI_LLM_EXTRA_BODY`
+
+string, default none. Set by `Config.LLMExtraBody`.
+
+`MEMINI_LLM_EXTRA_BODY` is a JSON object merged into every chat request body at the top level, for provider-specific dialect knobs memini deliberately does not model. Typical use: disabling hidden reasoning on DeepSeek-style endpoints ('{"thinking":{"type":"disabled"}}') or Qwen-style ones ('{"enable_thinking":false}'). Fields memini sets itself (model, messages, temperature, max_tokens) always win. Invalid JSON fails config loading.
 
 ## Reranking
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -325,6 +325,20 @@ type Config struct {
 	LLMModel string `env:"MEMINI_LLM_MODEL" envDefault:"gpt-4o-mini"`
 	// LLMAPI selects the chat backend: "openai" (default) or "anthropic".
 	LLMAPI string `env:"MEMINI_LLM_API" envDefault:"openai"`
+	// LLMMaxTokens caps the completion length of every chat call. 0 (the
+	// default) keeps the client's built-in budget (4096). Reasoning models
+	// that spend thousands of hidden thinking tokens inside the budget need
+	// more headroom here, or their JSON answers come back truncated
+	// (finish_reason "length") and the affected pipeline call is lost.
+	LLMMaxTokens int `env:"MEMINI_LLM_MAX_TOKENS" envDefault:"0"`
+	// LLMExtraBody is a JSON object merged into every chat request body at
+	// the top level, for provider-specific dialect knobs memini deliberately
+	// does not model. Typical use: disabling hidden reasoning on
+	// DeepSeek-style endpoints ('{"thinking":{"type":"disabled"}}') or
+	// Qwen-style ones ('{"enable_thinking":false}'). Fields memini sets
+	// itself (model, messages, temperature, max_tokens) always win. Invalid
+	// JSON fails config loading.
+	LLMExtraBody string `env:"MEMINI_LLM_EXTRA_BODY"`
 
 	// Rerank selects recall reranking: "off" (default), "llm" (reorder with the
 	// chat LLM), or a cross-encoder /rerank base URL (e.g. http://host:8002/v1).
@@ -992,6 +1006,12 @@ func (c *Config) validate() error {
 	if c.EmbedDims <= 0 {
 		return fmt.Errorf("MEMINI_EMBED_DIMS must be positive, got %d", c.EmbedDims)
 	}
+	if c.LLMMaxTokens < 0 {
+		return fmt.Errorf("MEMINI_LLM_MAX_TOKENS must be >= 0, got %d", c.LLMMaxTokens)
+	}
+	if _, err := c.LLMExtraBodyMap(); err != nil {
+		return err
+	}
 	if c.RequestTimeout < 0 {
 		return fmt.Errorf("MEMINI_REQUEST_TIMEOUT must be >= 0, got %v", c.RequestTimeout)
 	}
@@ -1093,4 +1113,19 @@ func (c *Config) dedupTiers() []memory.Tier {
 		}
 	}
 	return tiers
+}
+
+// LLMExtraBodyMap parses LLMExtraBody into the raw top-level fields to merge
+// into every chat request, or nil when unset. A non-object or invalid JSON
+// value is a configuration error.
+func (c *Config) LLMExtraBodyMap() (map[string]json.RawMessage, error) {
+	raw := strings.TrimSpace(c.LLMExtraBody)
+	if raw == "" {
+		return nil, nil
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return nil, fmt.Errorf("MEMINI_LLM_EXTRA_BODY: invalid JSON object: %w", err)
+	}
+	return m, nil
 }

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -18,6 +18,7 @@ import (
 // cache-read rate.
 type AnthropicClient struct {
 	client    anthropic.Client
+	extra     []option.RequestOption
 	model     string
 	maxTokens int64
 }
@@ -37,8 +38,13 @@ func NewAnthropic(cfg Config) (*AnthropicClient, error) {
 	if cfg.BaseURL != "" {
 		opts = append(opts, option.WithBaseURL(strings.TrimRight(cfg.BaseURL, "/")))
 	}
+	var extra []option.RequestOption
+	for key, raw := range cfg.ExtraBody {
+		extra = append(extra, option.WithJSONSet(key, raw))
+	}
 	return &AnthropicClient{
 		client:    anthropic.NewClient(opts...),
+		extra:     extra,
 		model:     cfg.Model,
 		maxTokens: maxTokensOr(cfg.MaxTokens),
 	}, nil
@@ -160,7 +166,7 @@ func (c *AnthropicClient) ChatTools(
 		}
 	}
 
-	msg, err := c.client.Messages.New(ctx, params)
+	msg, err := c.client.Messages.New(ctx, params, c.extra...)
 	if err != nil {
 		return ChatResult{}, fmt.Errorf("llm: anthropic chat tools: %w", err)
 	}
@@ -196,7 +202,7 @@ func (c *AnthropicClient) chat(ctx context.Context, system, user string) (string
 		Messages: []anthropic.MessageParam{
 			anthropic.NewUserMessage(anthropic.NewTextBlock(user)),
 		},
-	})
+	}, c.extra...)
 	if err != nil {
 		return "", fmt.Errorf("llm: anthropic: %w", err)
 	}

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -138,7 +138,15 @@ type Config struct {
 	// MaxTokens caps the completion length (defaults to defaultMaxTokens). A
 	// budget is required for reasoning models, which otherwise spend the server
 	// default on hidden reasoning and return empty content.
-	MaxTokens  int
+	MaxTokens int
+	// ExtraBody is a raw JSON object merged into every chat request body at
+	// the top level. It exists for provider-specific dialect knobs this client
+	// deliberately does not model — e.g. disabling hidden reasoning on
+	// DeepSeek-style endpoints ({"thinking":{"type":"disabled"}}) or
+	// Qwen-style ones ({"enable_thinking":false}). Keys set here override
+	// nothing: fields the client sets explicitly (model, messages,
+	// temperature, max_tokens) win.
+	ExtraBody  map[string]json.RawMessage
 	HTTPClient *http.Client
 }
 

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -18,6 +18,7 @@ type OpenAIClient struct {
 	client    openai.Client
 	model     string
 	maxTokens int64
+	extra     []option.RequestOption
 }
 
 // NewOpenAI builds a chat client. BaseURL and Model are required.
@@ -34,10 +35,15 @@ func NewOpenAI(cfg Config) (*OpenAIClient, error) {
 		option.WithMaxRetries(maxRetries),
 		option.WithHTTPClient(httpClientOr(cfg.HTTPClient)),
 	}
+	var extra []option.RequestOption
+	for key, raw := range cfg.ExtraBody {
+		extra = append(extra, option.WithJSONSet(key, raw))
+	}
 	return &OpenAIClient{
 		client:    openai.NewClient(opts...),
 		model:     cfg.Model,
 		maxTokens: maxTokensOr(cfg.MaxTokens),
+		extra:     extra,
 	}, nil
 }
 
@@ -147,7 +153,7 @@ func (c *OpenAIClient) ChatTools(
 		params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{OfAuto: openai.String(string(choice))}
 	}
 
-	resp, err := c.client.Chat.Completions.New(ctx, params)
+	resp, err := c.client.Chat.Completions.New(ctx, params, c.extra...)
 	if err != nil {
 		return ChatResult{}, fmt.Errorf("llm: chat tools: %w", err)
 	}
@@ -185,7 +191,7 @@ func (c *OpenAIClient) chat(ctx context.Context, system, user string, jsonMode b
 			OfJSONObject: &shared.ResponseFormatJSONObjectParam{},
 		}
 	}
-	resp, err := c.client.Chat.Completions.New(ctx, params)
+	resp, err := c.client.Chat.Completions.New(ctx, params, c.extra...)
 	if err != nil {
 		return "", fmt.Errorf("llm: chat: %w", err)
 	}

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -309,3 +309,34 @@ func TestOpenAIChatToolsRejectsEmptyReply(t *testing.T) {
 		t.Errorf("error should mention the empty response, got %v", err)
 	}
 }
+
+func TestOpenAIExtraBodyMergedIntoRequest(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &got)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"{}"}}]}`))
+	}))
+	defer srv.Close()
+
+	c, err := llm.NewOpenAI(llm.Config{
+		BaseURL: srv.URL, Model: "m",
+		ExtraBody: map[string]json.RawMessage{
+			"thinking": json.RawMessage(`{"type":"disabled"}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if _, err := c.Complete(context.Background(), "sys", "user"); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	th, ok := got["thinking"].(map[string]any)
+	if !ok || th["type"] != "disabled" {
+		t.Fatalf("thinking not merged into request body: %v", got["thinking"])
+	}
+	if got["model"] != "m" {
+		t.Fatalf("client-set field lost: model=%v", got["model"])
+	}
+}


### PR DESCRIPTION
## Motivation

The chat clients send `temperature: 0` + `max_tokens: 4096` (the built-in `defaultMaxTokens`). That is exactly right for the recommended non-reasoning models — but on OpenAI-compatible gateways many popular models now reason by default and **spend the completion budget on hidden thinking**.

Measured with `deepseek-v4-flash` on the distill prompt (real episodes, memini-identical request):

| | latency | completion tokens | of which reasoning | finish_reason |
|---|---|---|---|---|
| default request | 32.7s | 4,097 | 3,966 | `length` — JSON truncated, distillation lost |
| same + `{"thinking":{"type":"disabled"}}` | 5.4s | ~500 | 0 | `stop`, identical output quality |

The failure is silent in practice: distill-on-write only warns, so a reasoning model quietly loses most write-time distillations while everything looks healthy.

## What this adds

Two additive env knobs, both defaulting to current behavior:

**`MEMINI_LLM_MAX_TOKENS`** (int, default 0 = keep built-in 4096) — the dialect-free fix: give reasoning models enough headroom that the answer survives the thinking. Validated `>= 0` at config load.

**`MEMINI_LLM_EXTRA_BODY`** (JSON object, default unset) — merged into every chat request at the top level, for provider dialect knobs memini deliberately does **not** model:

```sh
MEMINI_LLM_EXTRA_BODY={"thinking":{"type":"disabled"}}   # DeepSeek-style
MEMINI_LLM_EXTRA_BODY={"enable_thinking":false}            # Qwen-style
MEMINI_LLM_EXTRA_BODY={"reasoning_effort":"low"}          # effort-style gateways
```

The reasoning-toggle dialect landscape is too fragmented to enumerate (DeepSeek `thinking`, Qwen `enable_thinking` / `chat_template_kwargs`, per-vendor `reasoning_effort` level sets…), so this stays a raw passthrough: one setting, one meaning, and the dialect choice remains the operator's. Fields memini sets itself (`model`, `messages`, `temperature`, `max_tokens`) always win — implemented with the SDKs' own `option.WithJSONSet`, applied to both the OpenAI and Anthropic clients. Invalid JSON fails config loading.

## Notes

- `go test ./internal/...` passes; new test `TestOpenAIExtraBodyMergedIntoRequest` asserts the merge reaches the wire and client-set fields survive
- `gen-docs` regenerated (`docs/reference/configuration.md`), group table updated
- No behavior change when neither variable is set