### PR TITLE
fix: activity-log inject rows stored bare when beacon hydration races its serve

### DIFF
--- a/internal/service/events.go
+++ b/internal/service/events.go
@@ -89,10 +89,19 @@ func (s *Service) logEvents(ctx context.Context, events []store.Event) {
 // logEventsPrepared is logEvents with a hook that runs against the rows just
 // before they are appended, for a writer that must read the store to complete
 // them (RecordInjected's snapshot hydration). Running inside the same goroutine
-// as the append keeps the read off the caller's latency, and — since the
-// background write is already queued behind the serve that preceded it — gives
-// that serve's own rows a head start on landing, which is exactly what the
-// hydration looks for. prepare must be best-effort: it cannot fail the append.
+// as the append keeps the read off the caller's latency, and the FIFO chain
+// below guarantees the serve that preceded the beacon has COMMITTED before the
+// hydration read runs, which is exactly what it looks for. prepare must be
+// best-effort: it cannot fail the append.
+//
+// The FIFO is load-bearing, not an optimization. An earlier version spawned
+// each append as a free-running goroutine and asserted in a comment that the
+// beacon's write was "already queued behind the serve that preceded it" — no
+// such queue existed (sync.WaitGroup orders nothing), and under store write
+// contention the beacon's hydration read raced the serve's insert and lost,
+// permanently storing the inject rows bare (~3% of injections on a busy
+// sqlite deployment, observed 7-21ms serve→beacon gaps). Chaining each append
+// on its predecessor's completion makes submission order the commit order.
 func (s *Service) logEventsPrepared(ctx context.Context, events []store.Event,
 	prepare func(context.Context, []store.Event),
 ) {
@@ -122,8 +131,22 @@ func (s *Service) logEventsPrepared(ctx context.Context, events []store.Event,
 		return
 	}
 	// Detach from the request lifetime but keep its values; bound the work.
+	// The chain: take the current tail as this append's predecessor and
+	// install a fresh done channel as the new tail, atomically. The goroutine
+	// waits for the predecessor before writing, so appends commit in
+	// submission order; the per-write timeout starts after the wait, so a
+	// slow predecessor consumes its own budget, not its successors'.
 	bg := context.WithoutCancel(ctx)
+	s.eventQMu.Lock()
+	prev := s.eventQTail
+	done := make(chan struct{})
+	s.eventQTail = done
+	s.eventQMu.Unlock()
 	s.bg.Go(func() {
+		defer close(done)
+		if prev != nil {
+			<-prev
+		}
 		ectx, cancel := context.WithTimeout(bg, eventLogTimeout)
 		defer cancel()
 		write(ectx)
@@ -338,7 +361,12 @@ const injectHydrateMaxIDs = 200
 // Best-effort like everything else on this path — an unresolved id keeps its
 // bare row (the "taken on faith" contract), and a store error logs and leaves
 // every row bare.
-func (s *Service) hydrateInjected(ctx context.Context, namespace string, events []store.Event) {
+//
+// since bounds how far back the serve lookup reaches; zero means unbounded.
+// The write path passes now-injectHydrateWindow (the serve just happened);
+// the read-time heal passes zero, because a historical bare row's serve sits
+// near the ROW's own time, not near now.
+func (s *Service) hydrateInjected(ctx context.Context, namespace string, events []store.Event, since time.Time) {
 	els, ok := s.eventLog()
 	if !ok {
 		return
@@ -355,7 +383,7 @@ func (s *Service) hydrateInjected(ctx context.Context, namespace string, events 
 	if len(ids) == 0 {
 		return
 	}
-	snaps, err := els.ServedSnapshots(ctx, namespace, ids, s.now().Add(-injectHydrateWindow))
+	snaps, err := els.ServedSnapshots(ctx, namespace, ids, since)
 	if err != nil {
 		slog.WarnContext(ctx, "activity: inject snapshot hydration failed",
 			"namespace", namespace, "count", len(ids), "err", err)
@@ -366,6 +394,43 @@ func (s *Service) hydrateInjected(ctx context.Context, namespace string, events 
 			events[i].MemoryNS = snap.Namespace
 			events[i].MemoryTier = snap.Tier
 			events[i].MemorySummary = snap.Summary
+		}
+	}
+}
+
+// healBareInjectRows re-runs snapshot hydration, at read time, over inject
+// rows that were stored bare. Before the append FIFO existed (see
+// logEventsPrepared) a beacon's hydration could race its serve's insert and
+// lose, so historical logs carry inject rows with an id but no namespace,
+// tier or summary — the feed rendered them as raw id prefixes and the UI had
+// no namespace to open them with.
+//
+// Display-only and best-effort: the healed snapshot is returned with the
+// page, never written back, so the store keeps its write-time contract and a
+// row that still resolves nothing stays bare. Rows are grouped by their own
+// event namespace — a feed page can span namespaces, and the borrow-from-serve
+// rule (a beacon only learns what its namespace was served) must hold per
+// row, not per request. The lookup is unbounded in time because a historical
+// row's serve sits near that row's own moment, not near now.
+//
+// Known limit: healing happens after the store-side tier/text filters ran, so
+// a still-bare row keeps missing those filters. Only a persisted backfill
+// could fix that, which this deliberately is not.
+func (s *Service) healBareInjectRows(ctx context.Context, rows []store.Event) {
+	byNS := make(map[string][]int)
+	for i, r := range rows {
+		if r.Kind == store.EventInject && r.MemoryID != "" && r.MemoryNS == "" {
+			byNS[r.Namespace] = append(byNS[r.Namespace], i)
+		}
+	}
+	for ns, idxs := range byNS {
+		sub := make([]store.Event, len(idxs))
+		for j, i := range idxs {
+			sub[j] = rows[i]
+		}
+		s.hydrateInjected(ctx, ns, sub, time.Time{})
+		for j, i := range idxs {
+			rows[i] = sub[j]
 		}
 	}
 }
@@ -436,7 +501,7 @@ func (s *Service) RecordInjected(ctx context.Context, namespace string, r Inject
 		events = append(events, e)
 	}
 	s.logEventsPrepared(ctx, events, func(ctx context.Context, evs []store.Event) {
-		s.hydrateInjected(ctx, namespace, evs)
+		s.hydrateInjected(ctx, namespace, evs, s.now().Add(-injectHydrateWindow))
 	})
 }
 
@@ -751,6 +816,8 @@ func (s *Service) Events(ctx context.Context, in EventsInput) (EventsPage, error
 	if len(rows) == 0 {
 		return EventsPage{}, nil
 	}
+
+	s.healBareInjectRows(ctx, rows)
 
 	groups := groupEvents(rows)
 

--- a/internal/service/events_test.go
+++ b/internal/service/events_test.go
@@ -983,3 +983,163 @@ func TestPruneEvents(t *testing.T) {
 		t.Fatalf("no-op prune deleted rows: %d events remain, want 1", len(page.Events))
 	}
 }
+
+// slowServeAppendStore delays the append of recall-kind event rows, forcing
+// the interleaving that produced bare inject rows in production: the serve's
+// insert still in flight when the beacon's hydration read runs.
+type slowServeAppendStore struct {
+	*sqlitevec.Store
+	delay time.Duration
+}
+
+func (s *slowServeAppendStore) AppendEvents(ctx context.Context, evs []store.Event) error {
+	if len(evs) > 0 && evs[0].Kind == store.EventRecall {
+		time.Sleep(s.delay)
+	}
+	return s.Store.AppendEvents(ctx, evs)
+}
+
+// TestAsyncEventLogOrdersServeBeforeBeacon is the regression for the
+// serve-vs-beacon append race. With the event log ASYNC (the production
+// default), a recall's serve rows are appended from a detached goroutine; the
+// injection beacon that follows milliseconds later hydrates its rows by
+// reading those serve rows back. Before appends were chained FIFO, nothing
+// ordered the two goroutines — delaying the serve append made the hydration
+// read run first, find nothing, and store the inject rows permanently bare
+// (observed at ~3% of injections on a contended production store, with
+// 7-21ms serve→beacon gaps). The FIFO makes submission order commit order, so
+// the delayed serve must land before the beacon's read runs.
+func TestAsyncEventLogOrdersServeBeforeBeacon(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlitevec.Open(ctx, filepath.Join(t.TempDir(), "events.db"), dims)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	svc := service.New(&slowServeAppendStore{Store: st, delay: 100 * time.Millisecond},
+		embedtest.New(dims),
+		service.WithSyncReinforce(),
+		service.WithEventLog(true),
+		// Deliberately NOT WithSyncEventLog: the race lives on the async path.
+	)
+
+	m, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "n", Content: "the primary database is postgres", Tier: memory.TierSemantic,
+	})
+	if err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+	if _, err := svc.Recall(ctx, service.RecallInput{
+		Namespace: "n", Query: "database", Limit: 5,
+	}); err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	svc.RecordInjected(ctx, "n", service.InjectedReport{
+		SessionID: "s1", Surface: "prompt", InjectedIDs: []string{m.ID},
+	})
+	svc.WaitBackground()
+
+	// Assert on the RAW stored rows, not through Events(): the read path
+	// heals bare rows for display, which would mask exactly the write-time
+	// race this test exists to catch.
+	raw, err := st.ListEvents(ctx, store.EventFilter{
+		Namespace: "n", Kinds: []store.EventKind{store.EventInject}, Limit: 50,
+	})
+	if err != nil {
+		t.Fatalf("list raw events: %v", err)
+	}
+	if len(raw) != 1 {
+		t.Fatalf("want 1 stored inject row, got %d", len(raw))
+	}
+	if raw[0].MemoryNS != "n" || raw[0].MemorySummary == "" {
+		t.Fatalf("inject row stored bare — beacon hydration ran before the serve append committed: %+v", raw[0])
+	}
+}
+
+// TestEventsHealsBareInjectRows covers the read-time heal for rows the
+// pre-FIFO race already stored bare: an inject row with an id but no
+// snapshot, whose serve row exists in the same namespace. Events must return
+// it hydrated (borrowed from the serve, however old — the lookup is unbounded
+// in time), without writing anything back to the store, and an id that was
+// never served must stay bare.
+func TestEventsHealsBareInjectRows(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlitevec.Open(ctx, filepath.Join(t.TempDir(), "events.db"), dims)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	svc := service.New(st, embedtest.New(dims),
+		service.WithSyncReinforce(),
+		service.WithEventLog(true),
+		service.WithSyncEventLog(),
+	)
+
+	m, err := svc.Remember(ctx, service.RememberInput{
+		Namespace: "n", Content: "the primary database is postgres", Tier: memory.TierSemantic,
+	})
+	if err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+	if _, err := svc.Recall(ctx, service.RecallInput{
+		Namespace: "n", Query: "database", Limit: 5,
+	}); err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+
+	// Simulate the pre-fix outcome: the beacon's rows landed bare.
+	bare := []store.Event{
+		{OpID: "bare-op", Kind: store.EventInject, Namespace: "n",
+			MemoryID: m.ID, Rank: 1,
+			Detail:    map[string]any{"surface": "prompt"},
+			CreatedAt: time.Now().Add(-48 * time.Hour)},
+		{OpID: "bare-op", Kind: store.EventInject, Namespace: "n",
+			MemoryID: "never-served", Rank: 2,
+			Detail:    map[string]any{"surface": "prompt"},
+			CreatedAt: time.Now().Add(-48 * time.Hour)},
+	}
+	if err := st.AppendEvents(ctx, bare); err != nil {
+		t.Fatalf("append bare rows: %v", err)
+	}
+
+	page, err := svc.Events(ctx, service.EventsInput{
+		Namespace: "n", Kinds: []store.EventKind{store.EventInject},
+	})
+	if err != nil {
+		t.Fatalf("events: %v", err)
+	}
+	var healed, unserved *service.ActivityMemory
+	for i := range page.Events {
+		for j := range page.Events[i].Memories {
+			am := &page.Events[i].Memories[j]
+			switch am.ID {
+			case m.ID:
+				healed = am
+			case "never-served":
+				unserved = am
+			}
+		}
+	}
+	if healed == nil || unserved == nil {
+		t.Fatalf("bare inject rows missing from feed: %+v", page.Events)
+	}
+	if healed.Namespace != "n" || healed.Summary == "" {
+		t.Fatalf("bare row not healed at read time: %+v", healed)
+	}
+	if unserved.Namespace != "" || unserved.Summary != "" {
+		t.Fatalf("never-served id must stay bare (borrow-from-serve rule): %+v", unserved)
+	}
+
+	// Heal is display-only: the stored rows must still be bare.
+	raw, err := st.ListEvents(ctx, store.EventFilter{
+		Namespace: "n", Kinds: []store.EventKind{store.EventInject}, Limit: 50,
+	})
+	if err != nil {
+		t.Fatalf("list raw events: %v", err)
+	}
+	for _, r := range raw {
+		if r.OpID == "bare-op" && r.MemoryNS != "" {
+			t.Fatalf("heal must not write back to the store, row %q got ns %q", r.MemoryID, r.MemoryNS)
+		}
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -471,6 +471,16 @@ type Service struct {
 	// bg tracks detached best-effort goroutines (async recall reinforcement) so
 	// WaitBackground can join them before the store is closed.
 	bg sync.WaitGroup
+
+	// eventQMu/eventQTail chain asynchronous activity-log appends into a
+	// strict FIFO: under the mutex each append captures the previous append's
+	// done channel as its predecessor and installs its own as the new tail,
+	// so the goroutines execute in submission order no matter how the
+	// scheduler interleaves them. RecordInjected's snapshot hydration depends
+	// on this ordering — its read must observe the serve rows the preceding
+	// recall/briefing submitted milliseconds earlier (see logEventsPrepared).
+	eventQMu   sync.Mutex
+	eventQTail chan struct{}
 }
 
 // WaitBackground blocks until detached background goroutines (async recall

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1566,6 +1566,22 @@ pre.json {
 .act-mem.floored {
   opacity: 0.5;
 }
+/* A bare inject row: a client reported the id but no serve snapshot could be
+   borrowed, so there is nothing to open. Inert on purpose — a hover/pointer
+   affordance here would promise a click that can only 404. */
+.act-mem.ghost {
+  opacity: 0.55;
+  cursor: default;
+}
+.act-mem.ghost:hover {
+  background: none;
+}
+.chip.ghost-badge {
+  border-style: dashed;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
 .chip.floored-badge {
   border-color: var(--line-strong);
   color: var(--muted);

--- a/ui/src/views/Activity.tsx
+++ b/ui/src/views/Activity.tsx
@@ -405,26 +405,40 @@ export function Activity() {
 
                 {(ev.memories?.length ?? 0) > 0 && (
                   <div class="act-mems">
-                    {ev.memories?.map((m) => (
-                      <button
+                    {ev.memories?.map((m) => {
+                      // A row with neither summary nor namespace is a bare
+                      // snapshot: nothing to show and — crucially — no
+                      // namespace to open the memory with, so a click could
+                      // only fall back to the viewer's active namespace and
+                      // 404. Render it inert instead of as a dead button.
+                      const bare = !m.summary && !m.namespace
+                      const Row = bare ? 'span' : 'button'
+                      return (
+                      <Row
                         key={m.id}
-                        type="button"
-                        class={`act-mem${m.filtered ? ' floored' : ''}`}
-                        onClick={() => openMemory(m.id, m.namespace || undefined)}
+                        {...(bare
+                          ? {
+                              class: 'act-mem ghost',
+                              title:
+                                'A client reported injecting this memory, but no matching serve was recorded — there is no snapshot to show and no namespace to open it in.',
+                            }
+                          : {
+                              type: 'button' as const,
+                              class: `act-mem${m.filtered ? ' floored' : ''}`,
+                              onClick: () => openMemory(m.id, m.namespace || undefined),
+                            })}
                       >
                         {m.rank ? <span class="act-rank mono">#{m.rank}</span> : <span class="act-rank" />}
                         <TierBadge tier={m.tier} />
                         {/* A row whose writer recorded no snapshot has no text
                             to show. Fall back to the id prefix rather than an
-                            empty line — memini resolves short ids, so it is
-                            something you can actually act on. */}
+                            empty line. */}
                         {m.summary ? (
                           <span class="act-summary">{m.summary}</span>
                         ) : (
-                          <span class="act-summary mono muted" title="No snapshot was recorded for this memory">
-                            {m.id.slice(0, 8)}
-                          </span>
+                          <span class="act-summary mono muted">{m.id.slice(0, 8)}</span>
                         )}
+                        {bare && <span class="chip ghost-badge">no snapshot</span>}
                         {m.section && <span class="chip">{m.section}</span>}
                         {/* The score is the "why": how well this memory matched
                             the query it was served for. */}
@@ -454,8 +468,9 @@ export function Activity() {
                         {showNs && m.namespace && m.namespace !== ev.namespace && (
                           <span class="chip mono">{m.namespace}</span>
                         )}
-                      </button>
-                    ))}
+                      </Row>
+                      )
+                    })}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## What this looks like

The Recent Activity feed occasionally shows `inject` events whose memory rows render as a bare id prefix (`#1 c1e80069`) with no summary — and clicking such a row throws a 404, because the UI has no namespace to open the memory with and falls back to the viewer's active one.

## Why it happens: the append "queue" doesn't exist

`RecordInjected` hydrates the beacon's bare ids by *borrowing* the snapshot from the serve (recall/briefing) event that preceded it — `hydrateInjected` reads `ServedSnapshots` for the same namespace. The comment on `logEventsPrepared` asserted this was safe because the beacon's background write is "already queued behind the serve that preceded it".

No such queue exists. `s.bg` is a plain `sync.WaitGroup`; `bg.Go` spawns free-running goroutines that the scheduler may interleave arbitrarily. The failing sequence:

1. A hook calls recall → the serve rows are appended from **goroutine A**; the response returns immediately.
2. The plugin injects and POSTs the beacon within milliseconds.
3. **Goroutine B** (the beacon) runs `hydrateInjected`, which reads for A's rows.
4. Under store write contention, A's insert hasn't committed when B's read runs → hydration finds nothing → the inject rows are stored **permanently bare**.

Observed on a busy sqlite deployment (~1.4 GB db): **~3% of injected rows stored bare** over a 15h window, with serve→beacon gaps of 7–21 ms. The definitive fingerprint: for every bare row, a matching serve event exists in the *same namespace*, timestamped milliseconds *before* the beacon — and byte-identical event sequences with the same ~8 ms gap hydrate fine on other occasions. Same namespace, serve always present, outcome flips on timing. (Two other theories — the 24h `injectHydrateWindow` and a namespace mismatch — were both falsified by this data.)

## The fix, in three layers

**1. Make the documented ordering real (prevention).** Async activity-log appends are now chained FIFO: under a mutex, each append captures the previous append's `done` channel as its predecessor and installs its own as the new tail; the goroutine waits on its predecessor before writing. Submission order is now commit order, so the beacon's hydration read always observes the serve that preceded it.

Design notes:
- The mutex guards only the handoff (capture prev / install self), never the I/O — no serialization cost on the request path, and `logEventsPrepared` still returns immediately.
- The per-write `eventLogTimeout` starts *after* the predecessor wait, so a slow append consumes its own budget rather than cascading deadline exhaustion down the chain.
- No resident worker goroutine, no close/drain lifecycle: `WaitBackground()` already joins the last link via the existing WaitGroup. `WithSyncEventLog` (tests) is unchanged.

**2. Heal historical rows at read time (repair).** Logs written before this fix carry bare rows sprinkled through history. `Events()` now re-runs hydration over still-bare inject rows when assembling a feed page — grouped by each row's own event namespace (a page can span namespaces, and the borrow-from-serve security rule must hold per row), unbounded in time (a historical row's serve sits near the *row's* moment, not near now), and display-only: nothing is written back, so the "ids are taken on faith, never resolved against the memories table" containment is untouched. A row that still resolves nothing stays bare. Known limit (deliberate): still-bare rows continue to miss the store-side tier/text filters; only a persisted backfill could change that.

**3. Render the truly unresolvable inert (UI).** A memory row with neither summary nor namespace can't be opened — a click could only 404. It now renders as a dimmed, non-interactive row with a `no snapshot` badge and an explanatory tooltip, instead of a button that promises a click it cannot honor.

## Tests

- `TestAsyncEventLogOrdersServeBeforeBeacon` — regression for the race. Runs the event log **async** (the production default) against a store wrapper that delays recall-row appends by 100 ms, then asserts on the **raw stored rows**. Verified to fail against the pre-fix code with exactly the production symptom (`MemoryNS:"" MemoryTier:"" MemorySummary:""`) and pass with the FIFO. It bypasses `Events()` on purpose: the read-time heal would otherwise mask a regression in the prevention layer.
- `TestEventsHealsBareInjectRows` — appends a pre-fix-style bare row directly, asserts `Events()` returns it hydrated from a 48h-old serve, that a never-served id stays bare (containment), and that nothing was written back to the store.
- Full `go test ./...`, `golangci-lint` (0 issues), and UI `tsc`/build pass.

## Compatibility

No API, schema, or store-interface changes. `hydrateInjected` gains a `since` parameter (internal); both sqlite and postgres `ServedSnapshots` already accept a zero bound.
