### PR TITLE
fix(openclaw): hyphenate memini-status/memini-namespace command names

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -89,7 +89,7 @@ means no home leg; there is no derivation, just this explicit config/env pair.
 
 ```
 1. MEMINI_NAMESPACE       local env override, wins outright
-2. server-side pin        set with memini:namespace, stored on the memini server
+2. server-side pin        set with memini-namespace, stored on the memini server
 3. the `namespace` config sent to the server as the declared namespace
 4. "openclaw"             the default
 ```
@@ -125,8 +125,8 @@ temporary big hammer.
 
 | Command            | What it does                                                         |
 | ------------------ | -------------------------------------------------------------------- |
-| `memini:status`    | Effective settings, resolved namespace **with provenance**, warnings |
-| `memini:namespace` | Show, set, or clear the server-side namespace pin for this install   |
+| `memini-status`    | Effective settings, resolved namespace **with provenance**, warnings |
+| `memini-namespace` | Show, set, or clear the server-side namespace pin for this install   |
 
 Recall shaping (both optional, matching the opencode/Claude Code plugins):
 `recall_limit` (max memories per turn, default **3**) and `recall_max_tokens`

--- a/integrations/openclaw/plugin/src/index.ts
+++ b/integrations/openclaw/plugin/src/index.ts
@@ -1013,7 +1013,7 @@ export async function sessionLive(
   return effectiveConfig(ctx.cfg, hs, env);
 }
 
-// --- pins (/memini:namespace) -------------------------------------------------
+// --- pins (/memini-namespace) -------------------------------------------------
 
 async function pinsRequest(
   boot: Bootstrap,
@@ -1057,7 +1057,7 @@ function offlineMessage(boot: Bootstrap, error: unknown): string {
   );
 }
 
-// --- /memini:status + /memini:namespace --------------------------------------
+// --- /memini-status + /memini-namespace --------------------------------------
 
 // statusGet is the diagnostics-only GET. It bypasses the client's
 // warn-and-return-null degrade path: a failed probe here is data for the report,
@@ -1256,8 +1256,20 @@ export function renderStatus(
   return L.join("\n");
 }
 
+// openclaw's command-name validator rejects a colon ("Command name must start
+// with a letter and contain only letters, numbers, hyphens, and underscores"),
+// so the `plugin:command` convention Claude Code uses for these same two
+// commands (plugin/commands/status.md, plugin/commands/namespace.md, resolved
+// via ${CLAUDE_PLUGIN_ROOT}) cannot be reused verbatim here — see
+// https://github.com/eleboucher/memini/issues/82. These names are openclaw-only
+// (Claude Code derives its own from the plugin/command directory layout, not
+// from this file), so the colon is swapped for a hyphen at this boundary only:
+// nothing upstream of registerCommand needs to change.
+const OPENCLAW_STATUS_COMMAND = "memini-status";
+const OPENCLAW_NAMESPACE_COMMAND = "memini-namespace";
+
 /**
- * registerMeminiCommands wires memini:status and memini:namespace.
+ * registerMeminiCommands wires memini-status and memini-namespace.
  *
  * The namespace command no longer writes a local override file: `<namespace>`/
  * `--clear` now PUT/DELETE a server-side pin (POST/DELETE /v1/pins) keyed by
@@ -1277,7 +1289,7 @@ export function registerMeminiCommands(api: any, ctx: SessionContext) {
   };
 
   api.registerCommand({
-    name: "memini:status",
+    name: OPENCLAW_STATUS_COMMAND,
     description: "Show memini's effective settings: namespace + provenance, connection, server read set",
     acceptsArgs: false,
     async handler(cmdCtx: any) {
@@ -1297,7 +1309,7 @@ export function registerMeminiCommands(api: any, ctx: SessionContext) {
   });
 
   api.registerCommand({
-    name: "memini:namespace",
+    name: OPENCLAW_NAMESPACE_COMMAND,
     description: "Show, set, or --clear the server-side memini namespace pin for this gateway install",
     acceptsArgs: true,
     async handler(cmdCtx: any) {
@@ -1319,8 +1331,8 @@ export function registerMeminiCommands(api: any, ctx: SessionContext) {
             out.push(`take effect while it is set.`);
           }
           out.push("");
-          out.push(`Set a pin with:    /memini:namespace <namespace>`);
-          out.push(`Clear it with:     /memini:namespace --clear`);
+          out.push(`Set a pin with:    /${OPENCLAW_NAMESPACE_COMMAND} <namespace>`);
+          out.push(`Clear it with:     /${OPENCLAW_NAMESPACE_COMMAND} --clear`);
           return { text: out.join("\n") };
         }
 
@@ -2086,7 +2098,7 @@ const plugin: {
       }
     }
 
-    // /memini:status and /memini:namespace. Best-effort for the same reason: a
+    // /memini-status and /memini-namespace. Best-effort for the same reason: a
     // host build without registerCommand must not cost the plugin its memory slot.
     if (typeof api.registerCommand === "function") {
       try {

--- a/integrations/openclaw/plugin/test/helpers.test.ts
+++ b/integrations/openclaw/plugin/test/helpers.test.ts
@@ -799,7 +799,7 @@ test("sessionLive: a network failure always degrades regardless of fallback_on_e
   }
 });
 
-// --- registerMeminiCommands: memini:status / memini:namespace -----------------
+// --- registerMeminiCommands: memini-status / memini-namespace -----------------
 
 function fakeApi() {
   const commands: Record<string, (ctx: any) => Promise<{ text: string }>> = {};
@@ -812,22 +812,22 @@ function fakeApi() {
   return { api, commands };
 }
 
-test("registerMeminiCommands: registers memini:status and memini:namespace", () => {
+test("registerMeminiCommands: registers memini-status and memini-namespace", () => {
   const { api, commands } = fakeApi();
   registerMeminiCommands(api, fixedSessionContext({}, undefined));
-  assert.deepEqual(Object.keys(commands).sort(), ["memini:namespace", "memini:status"]);
+  assert.deepEqual(Object.keys(commands).sort(), ["memini-namespace", "memini-status"]);
 });
 
-test("memini:namespace (no args): shows the live namespace + pin details", async () => {
+test("memini-namespace (no args): shows the live namespace + pin details", async () => {
   const { api, commands } = fakeApi();
   const hs = fakeHandshake({ namespace: "acme/widget", namespace_source: "pin", pin: { key: "remote:x", created_by: "kit" } });
   registerMeminiCommands(api, fixedSessionContext({}, hs));
-  const { text } = await commands["memini:namespace"]({});
+  const { text } = await commands["memini-namespace"]({});
   assert.match(text, /namespace: acme\/widget\s+\(source: server:pin\)/);
   assert.match(text, /pin:\s+key remote:x, set by kit/);
 });
 
-test("memini:namespace <ns>: PUTs a pin keyed by the daemon-cwd toplevel_path and invalidates the memo", async () => {
+test("memini-namespace <ns>: PUTs a pin keyed by the daemon-cwd toplevel_path and invalidates the memo", async () => {
   // A plain non-git directory on purpose: the pin identity is the daemon's
   // cwd path, so no git repo is needed to pin a gateway install.
   const cwd = tmpProject(false);
@@ -849,7 +849,7 @@ test("memini:namespace <ns>: PUTs a pin keyed by the daemon-cwd toplevel_path an
 
     const { api, commands } = fakeApi();
     registerMeminiCommands(api, ctx);
-    const { text } = await commands["memini:namespace"]({ args: "acme/api" });
+    const { text } = await commands["memini-namespace"]({ args: "acme/api" });
     assert.match(text, /namespace pinned: acme\/api/);
     const put = calls.find((c) => c.method === "PUT");
     assert.ok(put, "expected a PUT /v1/pins call");
@@ -864,7 +864,7 @@ test("memini:namespace <ns>: PUTs a pin keyed by the daemon-cwd toplevel_path an
   }
 });
 
-test("a pin written via memini:namespace is resolved by this gateway's own next handshake", async () => {
+test("a pin written via memini-namespace is resolved by this gateway's own next handshake", async () => {
   // The end-to-end loop the pin exists for: PUT the pin, memo invalidated,
   // and the very next handshake (same facts, matched by path:<daemon-cwd>)
   // resolves it as server:pin, beating the declared/config namespace.
@@ -899,7 +899,7 @@ test("a pin written via memini:namespace is resolved by this gateway's own next 
 
     const { api, commands } = fakeApi();
     registerMeminiCommands(api, ctx);
-    await commands["memini:namespace"]({ args: "acme/api" });
+    await commands["memini-namespace"]({ args: "acme/api" });
 
     // After the pin: no TTL wait needed (the write invalidated the memo), and
     // the fresh handshake resolves the pin.
@@ -914,7 +914,7 @@ test("a pin written via memini:namespace is resolved by this gateway's own next 
   }
 });
 
-test("memini:namespace <ns>: refuses a header-injecting namespace instead of normalizing it", async () => {
+test("memini-namespace <ns>: refuses a header-injecting namespace instead of normalizing it", async () => {
   const cwd = tmpProject();
   const realFetch = globalThis.fetch;
   let putCalled = false;
@@ -926,7 +926,7 @@ test("memini:namespace <ns>: refuses a header-injecting namespace instead of nor
     const ctx = createSessionContext({}, process.env, cwd);
     const { api, commands } = fakeApi();
     registerMeminiCommands(api, ctx);
-    const { text } = await commands["memini:namespace"]({ args: "evil\r\nX-Evil: 1" });
+    const { text } = await commands["memini-namespace"]({ args: "evil\r\nX-Evil: 1" });
     assert.match(text, /invalid namespace/);
     assert.equal(putCalled, false);
   } finally {
@@ -934,7 +934,7 @@ test("memini:namespace <ns>: refuses a header-injecting namespace instead of nor
   }
 });
 
-test("memini:namespace --clear: 404 reports nothing to clear; success invalidates the memo", async () => {
+test("memini-namespace --clear: 404 reports nothing to clear; success invalidates the memo", async () => {
   const cwd = tmpProject();
   const realFetch = globalThis.fetch;
   globalThis.fetch = (async () => ({ ok: false, status: 404, async json() { return {}; } })) as any;
@@ -942,14 +942,14 @@ test("memini:namespace --clear: 404 reports nothing to clear; success invalidate
     const ctx = createSessionContext({}, process.env, cwd);
     const { api, commands } = fakeApi();
     registerMeminiCommands(api, ctx);
-    const { text } = await commands["memini:namespace"]({ args: "--clear" });
+    const { text } = await commands["memini-namespace"]({ args: "--clear" });
     assert.match(text, /nothing to clear/);
   } finally {
     globalThis.fetch = realFetch;
   }
 });
 
-test("memini:namespace: an unreachable server on a pin write points at the config namespace value", async () => {
+test("memini-namespace: an unreachable server on a pin write points at the config namespace value", async () => {
   const cwd = tmpProject();
   const realFetch = globalThis.fetch;
   globalThis.fetch = (async () => { throw new Error("ECONNREFUSED"); }) as any;
@@ -957,7 +957,7 @@ test("memini:namespace: an unreachable server on a pin write points at the confi
     const ctx = createSessionContext({}, process.env, cwd);
     const { api, commands } = fakeApi();
     registerMeminiCommands(api, ctx);
-    const { text } = await commands["memini:namespace"]({ args: "acme/api" });
+    const { text } = await commands["memini-namespace"]({ args: "acme/api" });
     assert.match(text, /Could not reach the memini server/);
     assert.match(text, /config `namespace`/);
   } finally {
@@ -965,20 +965,20 @@ test("memini:namespace: an unreachable server on a pin write points at the confi
   }
 });
 
-test("memini:status reports an unreachable server rather than throwing into the host", async () => {
+test("memini-status reports an unreachable server rather than throwing into the host", async () => {
   const realFetch = globalThis.fetch;
   globalThis.fetch = (async () => { throw new Error("ECONNREFUSED"); }) as any;
   try {
     const { api, commands } = fakeApi();
     registerMeminiCommands(api, fixedSessionContext({}, undefined));
-    const { text } = await commands["memini:status"]({});
+    const { text } = await commands["memini-status"]({});
     assert.match(text, /reachable\s+NO/);
   } finally {
     globalThis.fetch = realFetch;
   }
 });
 
-test("memini:status reports the read set, redacts the bearer, and reads a 404 /healthz as not-exposed", async () => {
+test("memini-status reports the read set, redacts the bearer, and reads a 404 /healthz as not-exposed", async () => {
   const realFetch = globalThis.fetch;
   const prevKey = process.env.MEMINI_API_KEY;
   const requests: { url: string; headers: any }[] = [];
@@ -1001,7 +1001,7 @@ test("memini:status reports the read set, redacts the bearer, and reads a 404 /h
     process.env.MEMINI_API_KEY = "sk-abcdefghijklmnop4f2a";
     const { api, commands } = fakeApi();
     registerMeminiCommands(api, fixedSessionContext({}, fakeHandshake()));
-    const { text } = await commands["memini:status"]({ agentId: "miso" });
+    const { text } = await commands["memini-status"]({ agentId: "miso" });
 
     assert.match(text, /reachable\s+yes/);
     assert.match(text, /\/healthz not routed/);

--- a/integrations/openclaw/plugin/test/regression.test.mjs
+++ b/integrations/openclaw/plugin/test/regression.test.mjs
@@ -153,10 +153,10 @@ test("the base namespace chain is MEMINI_NAMESPACE > config > openclaw", () => {
   });
 });
 
-// The pin loop, from the shipped bundle: memini:namespace PUTs a pin keyed by
+// The pin loop, from the shipped bundle: memini-namespace PUTs a pin keyed by
 // the same daemon-cwd toplevel_path every handshake sends, the write drops the
 // memo, and the next handshake resolves server:pin over the declared value.
-test("a pin written via memini:namespace is resolved by the gateway's own next handshake", async () => {
+test("a pin written via memini-namespace is resolved by the gateway's own next handshake", async () => {
   const cwd = mkdtempSync(join(tmpdir(), "openclaw-memini-pin-"));
   const realFetch = globalThis.fetch;
   let pinned = false;
@@ -186,7 +186,7 @@ test("a pin written via memini:namespace is resolved by the gateway's own next h
 
     const commands = {};
     registerMeminiCommands({ logger: { warn() {} }, registerCommand(def) { commands[def.name] = def.handler; } }, ctx);
-    const { text } = await commands["memini:namespace"]({ args: "acme/api" });
+    const { text } = await commands["memini-namespace"]({ args: "acme/api" });
     assert.match(text, /namespace pinned: acme\/api/);
 
     // No TTL wait: the write invalidated the memo, so the next resolution
@@ -199,7 +199,7 @@ test("a pin written via memini:namespace is resolved by the gateway's own next h
   }
 });
 
-test("register wires memini:status and memini:namespace when the host supports commands", () => {
+test("register wires memini-status and memini-namespace when the host supports commands", () => {
   const names = [];
   plugin.register({
     pluginConfig: { enabled: true },
@@ -211,7 +211,7 @@ test("register wires memini:status and memini:namespace when the host supports c
       names.push(def.name);
     },
   });
-  assert.deepEqual(names.sort(), ["memini:namespace", "memini:status"]);
+  assert.deepEqual(names.sort(), ["memini-namespace", "memini-status"]);
 });
 
 test("register survives a host with no registerCommand at all", () => {


### PR DESCRIPTION
## Summary
- openclaw's command-name validator rejects a colon, so `memini:status` and `memini:namespace` (registered in `integrations/openclaw/plugin/src/index.ts`) both failed to register on every gateway start; `memory_*` tools were unaffected.
- Fixed at the openclaw registration boundary only: the two literal names are now `memini-status` / `memini-namespace` (via new `OPENCLAW_STATUS_COMMAND`/`OPENCLAW_NAMESPACE_COMMAND` constants), plus the in-command help text that told users what to type.
- Updated the matching test expectations (`test/helpers.test.ts`, `test/regression.test.mjs`) and the openclaw README's command table/namespace-resolution note.

## Why not rename the Claude Code side too
Claude Code's `plugin:command` colon convention is correct there (`plugin/commands/status.md` / `namespace.md`, resolved via `${CLAUDE_PLUGIN_ROOT}`) and is derived from the plugin/command directory layout, not from any string in this file. The two hosts don't actually share one name string — the openclaw plugin's `src/index.ts` hardcodes its own literal `"memini:status"`/`"memini:namespace"` in `registerCommand()` calls, independent of the Claude Code command markdown. So this is a narrow, source-only fix in the openclaw plugin; nothing needed to change on the Claude Code side.

I picked a hyphen (`memini-status`) as the separator since that's the only thing openclaw's validator accepts besides underscore, and it reads closest to the existing colon form. If a different separator convention is preferred, happy to adjust.

## Generated files
Confirmed `integrations/openclaw/plugin/dist/index.js` (referenced in the bug report) is gitignored and build-only (`npm run build`, esbuild) — not hand-edited or committed. No other generated file (per `CONTRIBUTING.md`'s drift-gate table) touches this code path.

## Verification
- `npm run build && npm test` in `integrations/openclaw/plugin/` — 151 tests pass (`test/regression.test.mjs`, `test/bundle.test.mjs`, `test/helpers.test.ts`)
- `npm run typecheck` — clean
- `npx oxfmt --check integrations/openclaw/README.md` — clean
- Inspected built `dist/index.js` to confirm only `memini-status`/`memini-namespace` appear, no leftover colon form

Fixes #82.