### PR TITLE
fix(openclaw): pass the configured timeout when registering hooks

### DIFF
--- a/integrations/openclaw/plugin/src/index.ts
+++ b/integrations/openclaw/plugin/src/index.ts
@@ -2044,11 +2044,17 @@ const plugin: {
     // before_prompt_build/agent_end (the coarse api.registerHook is for internal
     // events like message:sent). Warn rather than silently drop memory if a build
     // somehow lacks it (eleboucher/memini#26).
-    const addHook = (name: string, handler: any) => {
-      if (typeof api.on === "function") api.on(name, handler);
+    // OpenClaw resolves a hook's timeout as
+    // policy.timeouts[hookName] ?? policy.timeoutMs ?? opts.timeoutMs, falling back to
+    // its own per-hook defaults (before_prompt_build: 15s, agent_end: 30s). Passing the
+    // configured timeout as opts makes timeout_ms the default for both hooks while
+    // leaving host config free to override it (eleboucher/memini#93).
+    const addHook = (name: string, handler: any, opts?: { timeoutMs?: number }) => {
+      if (typeof api.on === "function") api.on(name, handler, opts);
       else api.logger.warn?.(`memini: api.on unavailable; ${name} hook not registered`);
     };
-    addHook("before_prompt_build", recallHandler);
+    const hookTimeoutMs = Number(sessionCtx.cfg.timeout_ms) || undefined;
+    addHook("before_prompt_build", recallHandler, { timeoutMs: hookTimeoutMs });
 
     const captureHandler = async (event: any, hookCtx: any) => {
       const live = await sessionLive(sessionCtx);
@@ -2086,7 +2092,7 @@ const plugin: {
       // Record the captured ID so the next recall can drop it.
       if (writeResult?.id) rememberCaptured(ns, String(writeResult.id));
     };
-    addHook("agent_end", captureHandler);
+    addHook("agent_end", captureHandler, { timeoutMs: hookTimeoutMs });
 
     // Opt-in explicit tools, registered after the memory slot above. Best-effort:
     // a failure (e.g. typebox unavailable) is logged and leaves the slot working.


### PR DESCRIPTION
Fixes #93.

`api.on` forwards a third options argument:

```js
on: (hookName, handler, opts) => registerTypedHook(record, hookName, handler, opts, params.hookPolicy)
```

and OpenClaw resolves the timeout as `policy.timeouts[hookName] ?? policy.timeoutMs ?? opts.timeoutMs`.
The plugin passed no options, so both hooks used OpenClaw`s per-hook defaults —
15s for `before_prompt_build`, 30s for `agent_end` — and `timeout_ms` never applied
to recall at all.

The asymmetry is the damaging part: with a slow backend, recall is killed at 15s
and discarded while capture still writes at one memory per turn, so the store grows
while retrieval degrades. Measured against a CPU cross-encoder reranker, a single
recall over the default 8-document pool took 12.0s with nothing else in flight,
leaving ~3s of margin before the cap.

This passes the already-resolved `sessionCtx.cfg.timeout_ms` as `opts.timeoutMs` for
both hooks. Because `policy` is checked first, a host that sets
`plugins.entries.memini.hooks.timeouts.before_prompt_build` still wins — this only
changes the fallback, from OpenClaw`s built-in default to the plugin`s own
configured timeout.

`Number(...) || undefined` keeps the current behaviour when `timeout_ms` is unset or
zero, so the option is simply omitted and OpenClaw`s default applies as before.

Build, typecheck and the plugin test suite (72 tests) all pass.