### PR TITLE
feat(openclaw): capture_skip_patterns to drop turns matching a marker

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -167,6 +167,13 @@ As an extra backstop, `min_capture_chars` (env `MEMINI_MIN_CAPTURE_CHARS`, defau
 **0** = off) drops a capture whose stripped user turn is shorter than N characters —
 set it (e.g. `30`) if a gateway still emits short residual-noise turns.
 
+`capture_skip_patterns` (a list of substrings, default empty) drops any turn that
+contains one of them, matched case-insensitively across both the user and assistant
+text. Unlike the `[cron:` / `[Subagent Context]` markers above — which must prefix the
+user turn — these match anywhere, so they catch structured markers an integration emits
+mid-reply (e.g. a tool-invocation block like `type: image generation task`) that would
+otherwise be captured verbatim as a durable "fact".
+
 **There is no relevance-score floor knob — by design.** Bounding per-turn volume
 is `recall_limit`'s job, not a score gate, because benchmarking
 (`cmd/bench -vec-gate`) showed neither score can decide "inject nothing when

--- a/integrations/openclaw/plugin/openclaw.plugin.json
+++ b/integrations/openclaw/plugin/openclaw.plugin.json
@@ -26,6 +26,7 @@
       "skip_without_agent": { "type": "boolean" },
       "skip_system_turns": { "type": "boolean" },
       "system_kinds": { "type": "array", "items": { "type": "string" } },
+      "capture_skip_patterns": { "type": "array", "items": { "type": "string" } },
       "fallback_on_error": { "type": "boolean" },
       "timeout_ms": { "type": "number" },
       "expose_tools": { "type": "boolean" },

--- a/integrations/openclaw/plugin/src/index.ts
+++ b/integrations/openclaw/plugin/src/index.ts
@@ -116,6 +116,7 @@ const typeboxConfigSchema = Type.Object(
     skip_without_agent: Type.Optional(Type.Boolean()),
     skip_system_turns: Type.Optional(Type.Boolean()),
     system_kinds: Type.Optional(Type.Array(Type.String())),
+    capture_skip_patterns: Type.Optional(Type.Array(Type.String())),
     fallback_on_error: Type.Optional(Type.Boolean()),
     timeout_ms: Type.Optional(Type.Number()),
     expose_tools: Type.Optional(Type.Boolean()),
@@ -147,6 +148,12 @@ const DEFAULT_NAMESPACE_TEMPLATE = "{namespace}-{agent}";
 // skip_without_agent doesn't catch them — skip_system_turns does. Matched
 // case-insensitively; override the set via the system_kinds config.
 const DEFAULT_SYSTEM_KINDS = ["heartbeat", "cron"];
+// Case-insensitive substrings that, if present anywhere in a turn (user or
+// assistant text), skip capture entirely. Empty by default; operators add the
+// markers their integrations emit (e.g. structured tool-invocation blocks) so
+// those turns never enter the memory corpus. Generalises NOISE_PREFIXES, which
+// only matches a prefix of the user text.
+const DEFAULT_CAPTURE_SKIP_PATTERNS: string[] = [];
 
 // harnessCwd is the daemon's working directory: this install's stable pin
 // identity. gatewayFacts resolves it into the toplevel_path fact that rides
@@ -302,6 +309,10 @@ export function resolveConfig(
       Array.isArray(c.system_kinds) && c.system_kinds.length
         ? c.system_kinds.map((k: any) => String(k).toLowerCase())
         : DEFAULT_SYSTEM_KINDS,
+    capture_skip_patterns:
+      Array.isArray(c.capture_skip_patterns) && c.capture_skip_patterns.length
+        ? c.capture_skip_patterns.map((p: any) => String(p)).filter((p: string) => p.length > 0)
+        : DEFAULT_CAPTURE_SKIP_PATTERNS,
     fallback_on_error: c.fallback_on_error !== false,
     timeout_ms: Number(c.timeout_ms || process.env.MEMINI_TIMEOUT_MS || DEFAULT_TIMEOUT_MS),
     // On by default. The memory slot's automatic recall/capture cannot express
@@ -594,6 +605,16 @@ const ROLE_LABEL = /^(?:user|assistant|system)\s*:\s*/i;
 export function startsWithNoisePrefix(text: string) {
   const body = text.replace(ROLE_LABEL, "");
   return NOISE_PREFIXES.some((p) => body.startsWith(p));
+}
+
+// Operator-configured substring backstop. Unlike startsWithNoisePrefix (a prefix
+// of the user text), this matches anywhere in the combined turn, case-insensitively,
+// catching structured markers an integration emits mid-content (e.g. a tool block
+// in the assistant's reply). Empty patterns list => no-op.
+export function matchesSkipPattern(text: string, patterns: string[] | undefined) {
+  if (!patterns || !patterns.length) return false;
+  const hay = text.toLowerCase();
+  return patterns.some((p) => p && hay.includes(p.toLowerCase()));
 }
 
 // Mirrors the opencode plugin's labels toggle. Default is plain bullets (no
@@ -2075,6 +2096,9 @@ const plugin: {
       const captureUser = stripRuntimePreambles(userText);
       if (!captureUser || startsWithNoisePrefix(captureUser)) return;
       if (captureUser.length < live.min_capture_chars) return;
+      // Operator noise markers can appear in either side of the turn (e.g. a
+      // tool-invocation block in the assistant reply), so match the combined text.
+      if (matchesSkipPattern(`${captureUser}\n${assistantText}`, live.capture_skip_patterns)) return;
       const ns = effectiveNamespace(live, hookCtx);
       if (ns == null) return;
       // A capture without a session_id can never be excluded by the pre-turn

--- a/integrations/openclaw/plugin/test/helpers.test.ts
+++ b/integrations/openclaw/plugin/test/helpers.test.ts
@@ -21,6 +21,7 @@ import {
   sessionLive,
   shouldSkipSystemTurn,
   startsWithNoisePrefix,
+  matchesSkipPattern,
   stripRuntimePreambles,
   type ResolvedConfig,
 } from "../src/index.ts";
@@ -238,6 +239,24 @@ test("startsWithNoisePrefix: real production cron turn behind a User: label is n
     "User: [cron:b571428f-243c-4604-919e-effb800d44c0 homelab-peers-commits] " +
     "You are a homelab commit watcher. Check these repos and post to Discord.";
   assert.equal(startsWithNoisePrefix(text), true);
+});
+
+test("matchesSkipPattern: matches a marker mid-content, case-insensitively, on either side of the turn", () => {
+  const patterns = ["type: image generation task"];
+  const turn = "Make me a picture of a cat\nSure — TYPE: Image Generation Task\nnode: ksampler ...";
+  assert.equal(matchesSkipPattern(turn, patterns), true);
+});
+
+test("matchesSkipPattern: empty or undefined patterns is a no-op", () => {
+  assert.equal(matchesSkipPattern("type: image generation task", []), false);
+  assert.equal(matchesSkipPattern("type: image generation task", undefined), false);
+});
+
+test("matchesSkipPattern: a loose topical mention is not skipped without the exact marker", () => {
+  assert.equal(
+    matchesSkipPattern("we talked about image generation yesterday", ["type: image generation task"]),
+    false,
+  );
 });
 
 test("startsWithNoisePrefix: bare and role-labelled markers both match", () => {


### PR DESCRIPTION
The only capture noise filter, `startsWithNoisePrefix`, matches a **prefix of the user text**. Integrations that emit a structured block mid-reply slip past it. Concretely: an image-generation tool invocation puts `type: image generation task` in the assistant output, the turn is captured verbatim, then promoted into a durable semantic "fact" that recall keeps surfacing. On one deployment this class reached ~29 memories, one recalled 87 times.

Adds `capture_skip_patterns`: a list of case-insensitive substrings matched across the **combined user + assistant** turn; any match skips capture. Empty by default, so existing deployments are unaffected. An operator sets e.g. `["type: image generation task"]` and those turns never enter the corpus.

It generalises `NOISE_PREFIXES` (prefix-of-user-text only) to an operator-configurable substring backstop that matches anywhere in the turn, which is where these markers actually land.

Wired at every site a list-config needs, mirroring `system_kinds`: the TypeBox config schema, `resolveConfig` (with an empty-default fallback), the new `matchesSkipPattern` helper, the `agent_end` capture handler, and the manifest `configSchema` allowlist -- a key missing there fails host validation and crashloops the gateway, so it must be declared in both places.

Build, typecheck and the full test suite pass; adds three `matchesSkipPattern` unit tests (mid-content case-insensitive match, empty/undefined no-op, and that a loose topical mention without the exact marker is not skipped).